### PR TITLE
vmnet: Run as unprivileged user on macOS 26+

### DIFF
--- a/pkg/drivers/common/vmnet/vmnet.go
+++ b/pkg/drivers/common/vmnet/vmnet.go
@@ -28,7 +28,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
+
+	"github.com/blang/semver/v4"
+	"golang.org/x/sys/unix"
+	"gopkg.in/yaml.v2"
 
 	"k8s.io/minikube/pkg/libmachine/log"
 	"k8s.io/minikube/pkg/libmachine/state"
@@ -40,10 +45,14 @@ import (
 )
 
 const (
-	pidfileName    = "vmnet-helper.pid"
-	logfileName    = "vmnet-helper.log"
-	sockfileName   = "vmnet-helper.sock"
-	executablePath = "/opt/vmnet-helper/bin/vmnet-helper"
+	pidfileName  = "vmnet-helper.pid"
+	logfileName  = "vmnet-helper.log"
+	sockfileName = "vmnet-helper.sock"
+
+	// Installed from GitHub releases.
+	installPath = "/opt/vmnet-helper/bin/vmnet-helper"
+	// Installed via Homebrew (macOS 26+ only).
+	brewInstallPath = "/opt/homebrew/opt/vmnet-helper/libexec/vmnet-helper"
 )
 
 // Helper manages the vmnet-helper process.
@@ -55,22 +64,72 @@ type Helper struct {
 	// will obtain the same MAC address from vmnet.
 	InterfaceID string
 
-	// Offloading is required for krunkit, doss not work with vfkit.
-	// We must use this until libkrun add support for disabling offloading:
-	// https://github.com/containers/libkrun/issues/264
+	// Offloading is required for krunkit, does not work with vfkit.
 	Offloading bool
 
 	// Set when vmnet interface is started.
 	macAddress string
+
+	// NeedsSudo indicates whether sudo was used when starting the helper. Set
+	// by Start(), used by Stop(), Kill(), and GetState(). Required for managing
+	// the helper child process using the pid file.
+	NeedsSudo bool
+}
+
+// helperVersion is the version of vmnet-helper.
+type helperVersion struct {
+	Version string `yaml:"version"`
+	Commit  string `yaml:"commit"`
+}
+
+// helperInfo contains cached information about vmnet-helper.
+type helperInfo struct {
+	Path      string
+	Version   helperVersion
+	NeedsSudo bool
+	Err       error
+}
+
+var (
+	cached helperInfo
+	once   sync.Once
+)
+
+// getHelperInfo returns cached information about vmnet-helper, initializing it
+// on the first call.
+func getHelperInfo() (helperInfo, error) {
+	once.Do(func() {
+		cached.Path, cached.Err = findHelper()
+		if cached.Err != nil {
+			return
+		}
+		cached.Version, cached.Err = getHelperVersion(cached.Path)
+		if cached.Err != nil {
+			return
+		}
+		var macosVersion string
+		macosVersion, cached.Err = macOSVersion()
+		if cached.Err != nil {
+			return
+		}
+		cached.NeedsSudo, cached.Err = helperNeedsSudo(cached.Version, macosVersion)
+	})
+	return cached, cached.Err
 }
 
 type interfaceInfo struct {
 	MACAddress string `json:"vmnet_mac_address"`
 }
 
-// ValidateHelper checks if vmnet-helper is installed and we can run it as root.
-// The returned error.Kind can be used to provide a suggestion for resolving the
-// issue.
+// ValidateHelper validates that vmnet-helper is installed and configured
+// correctly.
+//
+// If the helper needs sudo, we validate that we can run vmnet-helper without a
+// password, or fallback to interactive sudo and update the user's cached sudo
+// credentials.
+//
+// If we fail with an expected error the returned error.Kind can be used to
+// provide a suggestion for resolving the issue.
 func ValidateHelper(options *run.CommandOptions) error {
 	// Ideally minikube will not try to validate in download-only mode, but this
 	// is called from different places in different drivers, so the easier way
@@ -80,47 +139,20 @@ func ValidateHelper(options *run.CommandOptions) error {
 		return nil
 	}
 
-	// Is it installed?
-	if _, err := os.Stat(executablePath); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return &Error{Kind: reason.NotFoundVmnetHelper, Err: err}
-		}
-		return &Error{Kind: reason.HostPathStat, Err: err}
-	}
-
-	// Can we run it as root without a password?
-	cmd := exec.Command("sudo", "--non-interactive", executablePath, "--version")
-	stdout, err := cmd.Output()
+	helper, err := getHelperInfo()
 	if err != nil {
-		// Can we interact with the user?
-		if options.NonInteractive {
-			if exitErr, ok := err.(*exec.ExitError); ok {
-				stderr := strings.TrimSpace(string(exitErr.Stderr))
-				err = fmt.Errorf("%w: %s", err, stderr)
-			}
-			return &Error{Kind: reason.NotConfiguredVmnetHelper, Err: err}
-		}
+		return err
+	}
 
-		// We can fall back to intereactive sudo this time, but the user should
-		// configure a sudoers rule.
-		out.ErrT(style.Tip, "Unable to run vmnet-helper without a password")
-		out.ErrT(style.Indent, "To configure vment-helper to run without a password, please check the documentation:")
-		out.ErrT(style.Indent, "https://github.com/nirs/vmnet-helper/#granting-permission-to-run-vmnet-helper")
-
-		// Authenticate the user, updating the user's cached credentials.
-		cmd = exec.Command("sudo", executablePath, "--version")
-		stdout, err = cmd.Output()
-		if err != nil {
-			if exitErr, ok := err.(*exec.ExitError); ok {
-				stderr := strings.TrimSpace(string(exitErr.Stderr))
-				err = fmt.Errorf("%w: %s", err, stderr)
-			}
-			return &Error{Kind: reason.NotConfiguredVmnetHelper, Err: err}
+	if helper.NeedsSudo {
+		if err := validateRunningWithSudo(helper.Path, options); err != nil {
+			return err
 		}
 	}
 
-	version := strings.TrimSpace(string(stdout))
-	log.Debugf("Validated vmnet-helper version %q", version)
+	log.Debugf("Validated vmnet-helper (path=%q, version=%q, commit=%q, needsSudo=%v)",
+		helper.Path, helper.Version.Version, helper.Version.Commit, helper.NeedsSudo)
+
 	return nil
 }
 
@@ -128,18 +160,31 @@ func ValidateHelper(options *run.CommandOptions) error {
 // machine. The helper will create a unix datagram socket at the specified path.
 // The client (e.g. vfkit) will connect to this socket.
 func (h *Helper) Start(socketPath string) error {
-	args := []string{
-		"--non-interactive",
-		executablePath,
-		"--socket", socketPath,
-		"--interface-id", h.InterfaceID,
+	helper, err := getHelperInfo()
+	if err != nil {
+		return err
 	}
+
+	// Persist for Stop(), Kill(), and GetState().
+	h.NeedsSudo = helper.NeedsSudo
+
+	var executable string
+	var args []string
+
+	if helper.NeedsSudo {
+		executable = "sudo"
+		args = append(args, "--non-interactive", helper.Path)
+	} else {
+		executable = helper.Path
+	}
+
+	args = append(args, "--socket", socketPath, "--interface-id", h.InterfaceID)
 
 	if h.Offloading {
 		args = append(args, "--enable-tso", "--enable-checksum-offload")
 	}
 
-	cmd := exec.Command("sudo", args...)
+	cmd := exec.Command(executable, args...)
 
 	// Create vmnet-helper in a new process group so it is not harmed when
 	// terminating the minikube process group.
@@ -179,12 +224,13 @@ func (h *Helper) Start(socketPath string) error {
 	return nil
 }
 
-// GetMACAddress reutuns the mac address assigned by vmnet framework.
+// GetMACAddress returns the mac address assigned by vmnet framework.
 func (h *Helper) GetMACAddress() string {
 	return h.macAddress
 }
 
-// Stop terminates sudo, which will terminate vmnet-helper.
+// Stop terminates the executable. If running with sudo, sudo will terminate the
+// helper.
 func (h *Helper) Stop() error {
 	log.Info("Stop vmnet-helper")
 	pidfile := h.pidfilePath()
@@ -196,8 +242,9 @@ func (h *Helper) Stop() error {
 		// No pidfile.
 		return nil
 	}
-	log.Debugf("Terminate sudo (pid=%v)", pid)
-	if err := process.Terminate(pid, "sudo"); err != nil {
+	name := h.executableName()
+	log.Debugf("Terminate %s (pid=%v)", name, pid)
+	if err := process.Terminate(pid, name); err != nil {
 		if err != os.ErrProcessDone {
 			return err
 		}
@@ -209,7 +256,8 @@ func (h *Helper) Stop() error {
 	return nil
 }
 
-// Kill both sudo and vmnet-helper by killing the process group.
+// Kill the entire process group. If running with sudo, both sudo and
+// vmnet-helper will be killed.
 func (h *Helper) Kill() error {
 	log.Info("Kill vmnet-helper")
 	pidfile := h.pidfilePath()
@@ -221,7 +269,8 @@ func (h *Helper) Kill() error {
 		// No pidfile.
 		return nil
 	}
-	exists, err := process.Exists(pid, "sudo")
+	name := h.executableName()
+	exists, err := process.Exists(pid, name)
 	if err != nil {
 		return err
 	}
@@ -245,7 +294,7 @@ func (h *Helper) Kill() error {
 	return nil
 }
 
-// GetState returns the sudo child process state.
+// GetState returns the child process state.
 func (h *Helper) GetState() (state.State, error) {
 	pidfile := h.pidfilePath()
 	pid, err := process.ReadPidfile(pidfile)
@@ -256,7 +305,8 @@ func (h *Helper) GetState() (state.State, error) {
 		// No pidfile.
 		return state.Stopped, nil
 	}
-	exists, err := process.Exists(pid, "sudo")
+	name := h.executableName()
+	exists, err := process.Exists(pid, name)
 	if err != nil {
 		return state.Error, err
 	}
@@ -283,6 +333,16 @@ func (h *Helper) pidfilePath() string {
 	return filepath.Join(h.MachineDir, pidfileName)
 }
 
+// executableName returns the name of the executable used by the last Start()
+// call.  Required for checking process state and terminating it. Returns "sudo"
+// if vmnet-helper was started with sudo, otherwise "vmnet-helper".
+func (h *Helper) executableName() string {
+	if h.NeedsSudo {
+		return "sudo"
+	}
+	return "vmnet-helper"
+}
+
 // Apple recommends sizing the receive buffer at 4 times the size of the send
 // buffer, and other projects typically use a 1 MiB send buffer and a 4 MiB
 // receive buffer. However the send buffer size is not used to allocate a buffer
@@ -293,8 +353,8 @@ const sendBufferSize = 65 * 1024
 
 // The receive buffer size determines how many packets can be queued by the
 // peer. Testing shows good performance with a 2 MiB receive buffer. We use a 4
-// MiB buffer to make ENOBUFS errors less likely for the peer and allowing to
-// queue more packets when using the vmnet_enable_tso option.
+// MiB buffer to make ENOBUFS errors less likely for the peer and allows queueing
+// more packets when using the vmnet_enable_tso option.
 const recvBufferSize = 4 * 1024 * 1024
 
 // Socketpair returns a pair of connected unix datagram sockets that can be used
@@ -311,4 +371,128 @@ func Socketpair() (*os.File, *os.File, error) {
 		_ = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF, recvBufferSize)
 	}
 	return os.NewFile(uintptr(fds[0]), "sock1"), os.NewFile(uintptr(fds[1]), "sock2"), nil
+}
+
+// validateRunningWithSudo validates that we can run vmnet-helper with sudo
+// without a password. If running with sudo fails, and we run in interactive
+// mode, we fall back to interactive sudo and update the user's cached sudo
+// credentials. This ensures that the next attempt to run vmnet-helper with sudo
+// will succeed in the next 5 minutes (default sudo timeout).
+func validateRunningWithSudo(helperPath string, options *run.CommandOptions) error {
+	cmd := exec.Command("sudo", "--non-interactive", helperPath, "--version")
+	if _, err := cmd.Output(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			stderr := strings.TrimSpace(string(exitErr.Stderr))
+			err = fmt.Errorf("%w: %s", err, stderr)
+		}
+		// If we are not interactive, we can't authenticate the user, so we fail.
+		if options.NonInteractive {
+			return &Error{Kind: reason.NotConfiguredVmnetHelper, Err: err}
+		}
+
+		log.Debugf("Unable to run vmnet-helper without a password: %v", err)
+
+		// We can fall back to interactive sudo this time, but the user should
+		// configure a sudoers rule.
+		out.ErrT(style.Tip, "Unable to run vmnet-helper without a password")
+		out.ErrT(style.Indent, "To configure vmnet-helper to run without a password, please check the documentation:")
+		out.ErrT(style.Indent, "https://github.com/nirs/vmnet-helper/#granting-permission-to-run-vmnet-helper")
+
+		// Authenticate the user, updating the user's cached credentials.
+		cmd = exec.Command("sudo", "--validate")
+		if _, err := cmd.Output(); err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				stderr := strings.TrimSpace(string(exitErr.Stderr))
+				err = fmt.Errorf("%w: %s", err, stderr)
+			}
+			// If we fail to authenticate the user, we can't run vmnet-helper
+			// with sudo so we must fail.
+			return &Error{Kind: reason.NotConfiguredVmnetHelper, Err: err}
+		}
+
+		log.Debugf("Authenticated user with sudo")
+		return nil
+	}
+
+	log.Debug("Validated running vmnet-helper without a password")
+	return nil
+}
+
+// findHelper finds the path to the vmnet-helper executable.
+func findHelper() (string, error) {
+	paths := []string{brewInstallPath, installPath}
+	for _, path := range paths {
+		if _, err := os.Stat(path); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return "", &Error{Kind: reason.HostPathStat, Err: err}
+			}
+			continue
+		}
+		return path, nil
+	}
+	err := fmt.Errorf("failed to find vmnet-helper at %q", paths)
+	return "", &Error{Kind: reason.NotFoundVmnetHelper, Err: err}
+}
+
+// helperNeedsSudo returns true if vmnet-helper needs sudo to run based on the
+// helper version and macOS version.
+func helperNeedsSudo(version helperVersion, macosVersion string) (bool, error) {
+	// ParseTolerant handles "26.2" by normalizing it to "26.2.0".
+	macVer, err := semver.ParseTolerant(macosVersion)
+	if err != nil {
+		return false, fmt.Errorf("invalid macOS version %q: %w", macosVersion, err)
+	}
+	if macVer.LT(semver.MustParse("26.0.0")) {
+		return true, nil
+	}
+
+	// semver.Parse does not support "v" prefix.
+	helperVer, err := semver.Parse(strings.TrimPrefix(version.Version, "v"))
+	if err != nil {
+		return false, fmt.Errorf("invalid helper version %q: %w", version.Version, err)
+	}
+
+	// Since v0.9.0, vmnet-helper is signed with the
+	// 'com.apple.security.virtualization' entitlement and does not need root.
+	return helperVer.LT(semver.MustParse("0.9.0")), nil
+}
+
+// macOSVersion returns the macOS product version string. The format is
+// "major.minor[.patch]"
+func macOSVersion() (string, error) {
+	version, err := unix.Sysctl("kern.osproductversion")
+	if err != nil {
+		return "", fmt.Errorf("failed to get macOS version: %w", err)
+	}
+	return version, nil
+}
+
+// getHelperVersion returns the version of vmnet-helper.
+func getHelperVersion(executablePath string) (helperVersion, error) {
+	cmd := exec.Command(executablePath, "--version")
+	stdout, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			err = fmt.Errorf("%w: %s", err, exitErr.Stderr)
+		}
+		return helperVersion{}, fmt.Errorf("failed to get vmnet-helper version: %w", err)
+	}
+	return parseHelperVersion(stdout)
+}
+
+// parseHelperVersion parses vmnet-helper version output.
+func parseHelperVersion(stdout []byte) (helperVersion, error) {
+	var version helperVersion
+
+	// Unmarshal current format (>= v0.7.0): "version: v0.7.0\ncommit: 7ee60de20...\n"
+	if err := yaml.Unmarshal(stdout, &version); err != nil {
+		// Fallback for older helper (< v0.7.0): "v0.6.0\n"
+		version.Version = strings.TrimSpace(string(stdout))
+	}
+
+	if version.Version == "" {
+		return version, fmt.Errorf("failed to parse vmnet-helper version: %q", stdout)
+	}
+
+	return version, nil
 }

--- a/pkg/drivers/common/vmnet/vmnet_test.go
+++ b/pkg/drivers/common/vmnet/vmnet_test.go
@@ -1,0 +1,170 @@
+//go:build darwin
+
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmnet
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestMacOSVersion(t *testing.T) {
+	version, err := macOSVersion()
+	if err != nil {
+		t.Fatalf("macOSVersion() failed: %v", err)
+	}
+
+	// Verify against sw_vers output.
+	out, err := exec.Command("sw_vers", "-productVersion").Output()
+	if err != nil {
+		t.Fatalf("sw_vers failed: %v", err)
+	}
+	expected := strings.TrimSpace(string(out))
+
+	if version != expected {
+		t.Errorf("macOSVersion() = %s, sw_vers reports %s", version, expected)
+	}
+}
+
+func TestHelperNeedsSudo(t *testing.T) {
+	tests := []struct {
+		name          string
+		helperVersion helperVersion
+		macOSVersion  string
+		want          bool
+	}{
+		{
+			name:          "old macOS new helper",
+			helperVersion: helperVersion{Version: "v0.9.0"},
+			macOSVersion:  "15.0",
+			want:          true,
+		},
+		{
+			name:          "macOS 26 old helper",
+			helperVersion: helperVersion{Version: "v0.8.0"},
+			macOSVersion:  "26.0",
+			want:          true,
+		},
+		{
+			name:          "macOS 26 new helper",
+			helperVersion: helperVersion{Version: "v0.9.0"},
+			macOSVersion:  "26.0",
+			want:          false,
+		},
+		{
+			name:          "macOS 26 newer helper",
+			helperVersion: helperVersion{Version: "v1.0.0"},
+			macOSVersion:  "26.0",
+			want:          false,
+		},
+		{
+			name:          "macOS 27 new helper",
+			helperVersion: helperVersion{Version: "v0.9.0"},
+			macOSVersion:  "27.0",
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := helperNeedsSudo(tt.helperVersion, tt.macOSVersion)
+			if err != nil {
+				t.Fatalf("helperNeedsSudo() failed: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("helperNeedsSudo(%v, %s) = %v, want %v",
+					tt.helperVersion.Version, tt.macOSVersion, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHelperVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		stdout string
+		want   helperVersion
+	}{
+		{
+			name:   "current version",
+			stdout: "version: v0.9.0\ncommit: b76a29eb542d3ce4df18c4ebef6b1498174a02e5\n",
+			want:   helperVersion{Version: "v0.9.0", Commit: "b76a29eb542d3ce4df18c4ebef6b1498174a02e5"},
+		},
+		{
+			name:   "legacy version",
+			stdout: "v0.6.0\n",
+			want:   helperVersion{Version: "v0.6.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseHelperVersion([]byte(tt.stdout))
+			if err != nil {
+				t.Fatalf("parseHelperVersion() failed: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("parseHelperVersion() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("error", func(t *testing.T) {
+		stdout := []byte("")
+		_, err := parseHelperVersion(stdout)
+		if err == nil {
+			t.Fatalf("parseHelperVersion(%q) expected error, got nil", stdout)
+		}
+		// Error should include the quoted input for debugging.
+		quoted := fmt.Sprintf("%q", stdout)
+		if !strings.Contains(err.Error(), quoted) {
+			t.Errorf("error %q should contain quoted input %s", err, quoted)
+		}
+	})
+}
+
+func TestExecutableName(t *testing.T) {
+	tests := []struct {
+		name      string
+		needsSudo bool
+		want      string
+	}{
+		{
+			name:      "needs sudo",
+			needsSudo: true,
+			want:      "sudo",
+		},
+		{
+			name:      "no sudo",
+			needsSudo: false,
+			want:      "vmnet-helper",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Helper{NeedsSudo: tt.needsSudo}
+			got := h.executableName()
+			if got != tt.want {
+				t.Errorf("executableName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Since v0.9.0, vmnet-helper is signed with the
'com.apple.security.virtualization' entitlement and does not need root
on macOS 26 or later. Since v0.9.0, it's also available via Homebrew for
macOS 26 or later.

This change updates the vfkit and krunkit drivers to support unprivileged
mode and both installation locations.

## vmnet-helper unprivileged support

| macOS version | Helper version | Unprivileged | Install locations                |
|---------------|----------------|--------------|----------------------------------|
| < 26          | any            | ❌           | /opt/vmnet-helper                |
| >= 26         | < v0.9.0       | ❌           | /opt/vmnet-helper                |
| **>= 26**     | **>= v0.9.0**  | ✅           | /opt/vmnet-helper, /opt/homebrew |

Notes:
- Homebrew installation requires macOS 26+ and vmnet-helper v0.9.0+
- Homebrew path (/opt/homebrew) is preferred when both are installed

## Changes in how we run vment-helper

- helper location: We find the helper install path, preferring the brew
  installation, since this is the recommended way since version v0.9.0.
- helper version: We parse the helper version, supporting both current
  YAML format and legacy string format, and log both the version and
  commit hash.
- needs sudo: We check if helper needs sudo based on macOS version and
  helper version.
- validate sudo: We validate that the helper can run with sudo only if
  the helper needs sudo.
- When starting the helper, we run it with sudo only if it needs sudo.
- When checking the helper state or terminating it, we use "sudo" if the
  helper needs sudo, or "vmnet-helper".

## Implementation notes

The helper info (path, version, needsSudo) is looked up once on first
use and cached to avoid repeated filesystem and process operations.

For managing helper state (Stop, Kill, GetState), we must use the
process name from when the cluster was started. For example, if the
helper was started with sudo, we need to look for "sudo" process, not
"vmnet-helper". This is solved by persisting NeedsSudo in the Helper
struct during Start().

For starting or validating (Start, ValidateHelper), we always use the
current system state from the cached helper info. This ensures that
after upgrading vmnet-helper, the new version is used when starting
a new cluster.

## New logs

New debug logs explain better ValidateHelper events.

### CI (macOS 15.7.3, vmnet-helper v0.9.0)

```
I0121 00:28:19.824887   39103 main.go:144] libmachine: Validated running vmnet-helper without a password
I0121 00:28:19.824952   39103 main.go:144] libmachine: Validated vmnet-helper (path="/opt/vmnet-helper/bin/vmnet-helper", version="v0.9.0", commit="b76a29eb542d3ce4df18c4ebef6b1498174a02e5", needsSudo=true)
```

### Local (macOS 26.2, vment-helper v0.9.0)

```
I0121 02:42:03.501181   34670 main.go:144] libmachine: Validated vmnet-helper (path="/opt/homebrew/opt/vmnet-helper/libexec/vmnet-helper", version="v0.9.0", commit="b76a29eb542d3ce4df18c4ebef6b1498174a02e5", needsSudo=false)
```

## vmnet-helper logs

When running in unprivileged mode we see that helper is started as regular user.

```
% cat ~/.minikube/machines/minikube/vmnet-helper.log 
INFO  [main] running /opt/homebrew/opt/vmnet-helper/libexec/vmnet-helper v0.9.0 on macOS 26.2.0
INFO  [main] running as uid: 501 gid: 20
```

## Persistance

```console
% jq .Driver.VmnetHelper ~/.minikube/machines/minikube/config.json
{
  "MachineDir": "/Users/nir/.minikube/machines/minikube",
  "InterfaceID": "ba491a95-9629-4d8f-8e15-314a87b2bc6b",
  "Offloading": false,
  "NeedsSudo": false
}
```