### PR TITLE
test: Fix TestNewExternalClient unit test windows

### DIFF
--- a/pkg/libmachine/ssh/client_test.go
+++ b/pkg/libmachine/ssh/client_test.go
@@ -75,21 +75,21 @@ func TestNewExternalClient(t *testing.T) {
 	defer os.Remove(keyFilename)
 
 	cases := []struct {
-		sshBinaryPath string
-		user          string
-		host          string
-		port          int
-		auth          *Auth
-		perm          os.FileMode
-		expectedError string
+		sshBinaryPath    string
+		user             string
+		host             string
+		port             int
+		auth             *Auth
+		perm             os.FileMode
+		expectedError    string
 		expectedNotExist bool
-		skipOS        string
+		skipOS           string
 	}{
 		{
-			auth:          &Auth{Keys: []string{"/tmp/private-key-not-exist"}},
-			expectedError: "stat /tmp/private-key-not-exist: no such file or directory",
+			auth:             &Auth{Keys: []string{"/tmp/private-key-not-exist"}},
+			expectedError:    "stat /tmp/private-key-not-exist: no such file or directory",
 			expectedNotExist: true,
-			skipOS:        "none",
+			skipOS:           "none",
 		},
 		{
 			auth:   &Auth{Keys: []string{keyFilename}},


### PR DESCRIPTION
**Cause**
- **Platform Error Strings:** The test asserted an exact `os.Stat `error text `("stat /tmp/...: no such file or directory"`), but Windows `os.Stat` returns a different platform-specific message (`"GetFileAttributesEx ...: The system cannot find the path specified."`), causing the assertion to fail.

**Fix**
- **Test change:** Update test so the missing-file case uses os.IsNotExist(err) instead of comparing the error string. 
- Before: assert exact error string for missing key path.
- After: accept any error where `os.IsNotExist(err)` returns true (cross-platform).

`Why`
- **Cross-platform stability**: `os.IsNotExist `normalizes the intent of the error (file does not exist) across OS-specific error messages, avoiding brittle string comparisons.


**Test Failures before the fix**
<img width="977" height="224" alt="before" src="https://github.com/user-attachments/assets/8823fe9c-ed30-497a-9bfc-916a16adcd1d" />



**Test Run with the fix**
<img width="974" height="104" alt="after" src="https://github.com/user-attachments/assets/780cf2a7-8e28-440d-bdea-25ed2da3c677" />
