### PR TITLE
hyperkit driver: Fix file descriptor leaks in status

### DIFF
--- a/pkg/drivers/hyperkit/driver.go
+++ b/pkg/drivers/hyperkit/driver.go
@@ -535,6 +535,8 @@ func (d *Driver) getPid() int {
 		log.Warnf("Error reading pid file: %v", err)
 		return 0
 	}
+	defer f.Close()
+
 	dec := json.NewDecoder(f)
 
 	var config struct {

--- a/pkg/minikube/cluster/status.go
+++ b/pkg/minikube/cluster/status.go
@@ -484,6 +484,8 @@ func readEventLog(name string) ([]cloudevents.Event, time.Time, error) {
 	if err != nil {
 		return nil, st.ModTime(), fmt.Errorf("open: %w", err)
 	}
+	defer f.Close()
+
 	var events []cloudevents.Event
 
 	scanner := bufio.NewScanner(f)


### PR DESCRIPTION
## Summary

This PR fixes file descriptor leaks in two functions that open files without closing them:

### Bug 1: `readEventLog()` in `pkg/minikube/cluster/status.go`
- **Location**: Line 483
- **Issue**: File opened with `os.Open()` was never closed
- **Impact**: Each call to `readEventLog()` would leak a file descriptor. This function is called during status checks, so repeated `minikube status` commands could exhaust file descriptors over time.

### Bug 2: `getPid()` in `pkg/drivers/hyperkit/driver.go`  
- **Location**: Line 533
- **Issue**: File opened with `os.Open()` was never closed
- **Impact**: Called during hyperkit state checks, start, stop operations. File descriptors would leak on each invocation.

## Fix

Added `defer f.Close()` immediately after the successful `os.Open()` call in both functions. This ensures the file descriptor is properly released regardless of which return path is taken.

## Testing

- [x] `go build` compiles successfully
- [x] `go vet` passes with no warnings
- [x] `go test ./pkg/minikube/cluster/...` passes