### PR TITLE
Test(shell): accept bash/sh/wsl as valid grandparent on Windows

### DIFF
--- a/pkg/libmachine/shell/shell_windows_test.go
+++ b/pkg/libmachine/shell/shell_windows_test.go
@@ -79,7 +79,7 @@ func isKnownWindowsShell(raw string) bool {
 	// between the terminal (cmd/powershell) and the process tree we inspect.
 	// Include it because some environments (Windows Terminal, legacy consoles)
 	// will report conhost.exe as the immediate ancestor rather than the shell.
-	case "powershell.exe", "pwsh.exe", "cmd.exe", "conhost.exe", "go.exe":
+	case "powershell.exe", "pwsh.exe", "cmd.exe", "conhost.exe", "go.exe", "bash.exe", "sh.exe", "wsl.exe":
 		return true
 	default:
 		return false


### PR DESCRIPTION
Include bash/sh/wsl because CI environments may use Git Bash or WSL on Windows agents.
