### PR TITLE
test: Fix TestAssetsFromDir unit test windows

### DIFF
--- a/pkg/minikube/machine/filesync_test.go
+++ b/pkg/minikube/machine/filesync_test.go
@@ -137,6 +137,12 @@ func TestAssetsFromDir(t *testing.T) {
 			for _, actualFile := range actualFiles {
 				got[actualFile.GetSourcePath()] = actualFile.GetTargetDir()
 			}
+			// close any open file handles returned by assetsFromDir so Windows can clean up the temp dir
+			for _, actualFile := range actualFiles {
+				if c, ok := actualFile.(interface{ Close() error }); ok {
+					_ = c.Close()
+				}
+			}
 			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("files differ: (-want +got)\n%s", diff)
 			}


### PR DESCRIPTION

**Cause**: `assetsFromDir `returns asset objects that keep file handles open. Tests create temporary directories and call `RemoveAll `on them; on Windows a file cannot be deleted while a handle is open, causing intermittent `TestAssetsFromDir `failures during cleanup.

**Fix**: In `TestAssetsFromDir`, close any returned asset that implements `interface{ Close() error }` before doing comparisons and allowing `TempDir` cleanup. Explicitly closing file handles allows `RemoveAll` to succeed on Windows and makes the test deterministic and cross-platform.


**Test Failures before the fix**
<img width="1201" height="458" alt="before" src="https://github.com/user-attachments/assets/d76447c2-fa6b-424b-aa3b-57d70bd51b2c" />

**Test Run with the fix**
<img width="1245" height="439" alt="after" src="https://github.com/user-attachments/assets/7e034d36-35fe-42a8-93ba-5b6b3793ac6a" />

