### PR TITLE
Test: skip TestAddHostAliasInner on Windows 

### DIFF
--- a/pkg/minikube/machine/start_test.go
+++ b/pkg/minikube/machine/start_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"runtime"
 	"testing"
 
 	"k8s.io/minikube/pkg/minikube/command"
@@ -47,6 +48,9 @@ fe00::0 ip6-localnet
 `
 
 func TestAddHostAliasInner(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping TestAddHostAliasInner on Windows: /bin/bash not available")
+	}
 	// Arrange
 	tempFilePath, err := writeContentToTempFile(initialEtcHostsContent)
 	if err != nil {


### PR DESCRIPTION
`TestAddHostAliasInner `executes a shell command using an absolute` /bin/bash`
path (via `addHostAliasCommand`). On Windows  /bin/bash is typically not present,
causing exec errors and intermittent test failures.