### PR TITLE
ci: Build VM image with Windows 11 for CI on Azure

### DIFF
--- a/.github/workflows/build-windows-ci-image.yaml
+++ b/.github/workflows/build-windows-ci-image.yaml
@@ -1,0 +1,162 @@
+---
+name: 'build-windows-ci-image'
+
+# Steps:
+# 1. If does not exist, create Azure Shared Image Gallery (SIG) for VM images.
+# 2. Build Azure VM image based on Windows 11 and publish to the SIG.
+# 3. If does not exist, create Azure Virtual Network for build test VM and VMs created on PRs.
+# 4. Create Azure VM to test the image.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        default: '0.0.1'
+        description: 'Version of VM image to build. Default version will run `make packer-build-and-overwrite` target.'
+        required: true
+        type: string
+
+env:
+  AZURE_DEFAULTS_LOCATION: "swedencentral"
+  MINIKUBE_AZ_SUBSCRIPTION_ID: ${{ secrets.MINIKUBE_AZ_SUBSCRIPTION_ID }}
+  MINIKUBE_AZ_RESOURCE_GROUP: "SIG-CLUSTER-LIFECYCLE-MINIKUBE"
+  MINIKUBE_AZ_SIG_NAME: "minikube" # see https://learn.microsoft.com/en-us/azure/virtual-machines/shared-image-galleries
+  MINIKUBE_AZ_IMAGE_NAME: "minikube-ci-windows-11" # VM image definition in SIG
+  MINIKUBE_AZ_IMAGE_VERSION: "${{ inputs.version }}" # VM image definition in SIG
+  MINIKUBE_AZ_VM_ADMIN_USERNAME: '${{ secrets.MINIKUBE_AZ_VM_ADMIN_USERNAME }}'
+  MINIKUBE_AZ_VM_ADMIN_PASSWORD: '${{ secrets.MINIKUBE_AZ_VM_ADMIN_PASSWORD }}'
+  MINIKUBE_AZ_VM_ADMIN_SSH_PUBLIC_KEY: ${{ secrets.MINIKUBE_AZ_VM_ADMIN_SSH_PUBLIC_KEY }}
+
+permissions:
+  id-token: write # Require write permission to Fetch an OIDC token.
+
+jobs:
+  check-bicep:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Check Bicep templates
+      run: |
+        make bicep-fmt && make bicep-lint
+
+  create-sig:
+    needs: [ check-bicep ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Azure Login # https://github.com/microsoftgraph/msgraph-bicep-types/tree/main/quickstart-templates/create-fic-for-github-actions
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.MINIKUBE_AZ_CLIENT_ID }}
+        subscription-id: ${{ secrets.MINIKUBE_AZ_SUBSCRIPTION_ID }}
+        tenant-id: ${{ secrets.MINIKUBE_AZ_TENANT_ID }}
+    - name: Deploy Azure Shared Image Gallery # Equivalent of the sig-deploy target in the Makefile
+      uses: azure/bicep-deploy@v2
+      with:
+        type: deploymentStack
+        operation: create
+        name: "gha-minikube-sig"
+        scope: resourceGroup
+        resource-group-name: ${{ env.MINIKUBE_AZ_RESOURCE_GROUP }}
+        subscription-id: ${{ secrets.MINIKUBE_AZ_SUBSCRIPTION_ID }}
+        template-file: ./sig.bicep
+        parameters-file: ./sig.bicepparam
+        action-on-unmanage-resources: delete
+        deny-settings-mode: none
+  
+  build-image:
+    needs: [ create-sig ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Azure Login # https://github.com/microsoftgraph/msgraph-bicep-types/tree/main/quickstart-templates/create-fic-for-github-actions
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.MINIKUBE_AZ_CLIENT_ID }}
+        subscription-id: ${{ secrets.MINIKUBE_AZ_SUBSCRIPTION_ID }}
+        tenant-id: ${{ secrets.MINIKUBE_AZ_TENANT_ID }}
+    - run: make packer-init
+    - run: make packer-validate
+    - if: ${{ inputs.version == '0.0.1' }}
+      run: make packer-build-and-overwrite
+    - if: ${{ inputs.version != '0.0.1' }}
+      run: make packer-build-and-publish
+    - run: make sig-list-images
+  
+  create-vnet:
+    needs: [ check-bicep ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Azure Login # https://github.com/microsoftgraph/msgraph-bicep-types/tree/main/quickstart-templates/create-fic-for-github-actions
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.MINIKUBE_AZ_CLIENT_ID }}
+        subscription-id: ${{ secrets.MINIKUBE_AZ_SUBSCRIPTION_ID }}
+        tenant-id: ${{ secrets.MINIKUBE_AZ_TENANT_ID }}
+    - name: Deploy Azure Virtual Network # Equivalent of the vnet-deploy target in the Makefile
+      uses: azure/bicep-deploy@v2
+      with:
+        type: deploymentStack
+        operation: create
+        name: "gha-minikube-vnet" # this name will be referenced in any workflow creating VM
+        scope: resourceGroup
+        resource-group-name: ${{ env.MINIKUBE_AZ_RESOURCE_GROUP }}
+        subscription-id: ${{ secrets.MINIKUBE_AZ_SUBSCRIPTION_ID }}
+        template-file: ./vnet.bicep
+        parameters-file: ./vnet.bicepparam
+        action-on-unmanage-resources: delete
+        deny-settings-mode: none
+  test-image:
+    needs: [ build-image, create-vnet ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Azure Login # https://github.com/microsoftgraph/msgraph-bicep-types/tree/main/quickstart-templates/create-fic-for-github-actions
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.MINIKUBE_AZ_CLIENT_ID }}
+        subscription-id: ${{ secrets.MINIKUBE_AZ_SUBSCRIPTION_ID }}
+        tenant-id: ${{ secrets.MINIKUBE_AZ_TENANT_ID }}
+    - name: Deploy Azure Virtual Machine # Equivalent of the vm-deploy target in the Makefile
+      id: create_vm
+      uses: azure/bicep-deploy@v2
+      with:
+        type: deploymentStack
+        operation: create
+        name: "gha-minikube-vm-${{ github.run_id }}"
+        scope: resourceGroup
+        resource-group-name: ${{ env.MINIKUBE_AZ_RESOURCE_GROUP }}
+        subscription-id: ${{ secrets.MINIKUBE_AZ_SUBSCRIPTION_ID }}
+        template-file: ./vm.bicep
+        parameters-file: ./vm.bicepparam
+        parameters: '{"vmName": "vm-${{ github.run_id }}"}'
+        action-on-unmanage-resources: delete
+        deny-settings-mode: none
+    - run: make vm-list
+    - name: Deploy admin SSH private key
+      run: |
+        echo "${{ secrets.MINIKUBE_AZ_VM_ADMIN_SSH_PRIVATE_KEY }}" | base64 -d > ./ssh.key
+        chmod 0600 ./ssh.key
+    - name: Wait for SSH
+      continue-on-error: true # ensure is always VM deleted
+      run: |
+        HOST="${{ steps.create_vm.outputs.vmPublicFqdn }}"
+        echo "Waiting for SSH on $HOST..."
+        for i in {1..30}; do
+          if ssh -i ./ssh.key -o StrictHostKeyChecking=no -o ConnectTimeout=5 "minikubeadmin@$HOST" 'echo "SSH connected to machine $([System.Net.Dns]::GetHostName())"'; then
+            echo "SSH is ready!"
+            exit 0
+          fi
+          echo "Waiting for SSH... ($i/30)"
+          sleep 10
+        done
+        echo "SSH failed to become ready."
+        exit 1
+    - name: Test
+      continue-on-error: true # ensure is always VM deleted
+      run: |
+        HOST="${{ steps.create_vm.outputs.vmPublicFqdn }}"
+        ssh -i ./ssh.key -o StrictHostKeyChecking=no -o ConnectTimeout=5 "minikubeadmin@$HOST" 'kubectl version --client'
+    - run: make vm-delete vm="vm-${{ github.run_id }}" # Fast deletion of VM+DISK+NIC+PIP only. Do NOT run azure/bicep-deploy@v2 with delete operation as it takes 10 minutes to delete VM with its child resources.
+    - run: make vm-list # Check deletion was successful

--- a/hack/windows-ci-image/.gitattributes
+++ b/hack/windows-ci-image/.gitattributes
@@ -1,0 +1,11 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+*.sh  text eol=lf
+*.txt text eol=lf
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf

--- a/hack/windows-ci-image/.gitignore
+++ b/hack/windows-ci-image/.gitignore
@@ -1,0 +1,7 @@
+.azure/
+*.auto.*
+*.backup
+*.local.*
+*.rdp
+*secrets*
+vm-connect-ssh.sh

--- a/hack/windows-ci-image/.mise.toml
+++ b/hack/windows-ci-image/.mise.toml
@@ -1,0 +1,8 @@
+[[env]]
+AZURE_CONFIG_DIR = { value = "{{config_root}}/.azure" }
+[[env]]
+'_'.source = { path = "env.sh" }
+
+[tools]
+packer = "1.14"
+# TODO: Add Azure CLI?

--- a/hack/windows-ci-image/Makefile
+++ b/hack/windows-ci-image/Makefile
@@ -1,0 +1,257 @@
+# minikube-windows-image Makefile
+
+MINIKUBE_AZ_SIG_STACK_DEPLOYMENT_NAME ?= "make-minikube-ci-sig" # Azure implementation detail
+MINIKUBE_AZ_VNET_STACK_DEPLOYMENT_NAME ?= "make-minikube-ci-vnet" # Azure implementation detail
+MINIKUBE_AZ_VM_STACK_DEPLOYMENT_NAME ?= "make-minikube-ci-vm" # Azure implementation detail
+
+.DEFAULT_GOAL := help
+
+SHELL = /usr/bin/env bash -o pipefail
+.SHELLFLAGS = -ec
+
+##@ General
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+.PHONY:
+preflight: ## Pre-flight checks for azure-* and packer-* targets
+	$(if $(strip $(MINIKUBE_AZ_SUBSCRIPTION_ID)),,$(error MINIKUBE_AZ_SUBSCRIPTION_ID is not defined. Source env.sh.))
+	$(if $(strip $(MINIKUBE_AZ_RESOURCE_GROUP)),,$(error MINIKUBE_AZ_RESOURCE_GROUP is not defined. Source env.sh.))
+	$(if $(strip $(MINIKUBE_AZ_SIG_NAME)),,$(error MINIKUBE_AZ_SIG_NAME is not defined. Source env.sh.))
+	$(if $(strip $(MINIKUBE_AZ_IMAGE_NAME)),,$(error MINIKUBE_AZ_IMAGE_NAME is not defined. Source env.sh.))
+	$(if $(strip $(MINIKUBE_AZ_IMAGE_VERSION)),,$(error MINIKUBE_AZ_IMAGE_VERSION is not defined. Source env.sh.))
+	$(if $(strip $(MINIKUBE_AZ_VM_ADMIN_USERNAME)),,$(error MINIKUBE_AZ_VM_ADMIN_USERNAME is not defined. Source env.sh.))
+	$(if $(strip $(MINIKUBE_AZ_VM_ADMIN_PASSWORD)),,$(error MINIKUBE_AZ_VM_ADMIN_PASSWORD is not defined. Add to env.local.sh.))
+	$(if $(strip $(MINIKUBE_AZ_VM_ADMIN_SSH_PUBLIC_KEY)),,$(error MINIKUBE_AZ_VM_ADMIN_SSH_PUBLIC_KEY is not defined. Add to env.local.sh.))
+	@$(MAKE) printenv
+
+.PHONY:
+printenv: ## Dump project-specific environment variables
+	@echo
+	@printf "\033[0;32m%(%F %T)T Azure Minikube CI environment variables:\033[0m\n"
+	@env | grep AZ | sort | sed "s|$(MINIKUBE_AZ_VM_ADMIN_PASSWORD)|*****|g"
+
+##@ Azure resources inspection
+
+.PHONY:
+_az-header:
+	@echo
+	@printf "\033[0;32m%(%F %T)T Executing Azure CLI command:\033[0m\n"
+
+.PHONY:
+az-list-resources: | preflight _az-header ## List everything in resourcs group
+	az resource list --resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" --output table
+
+.PHONY:
+az-list-deployments: | preflight _az-header ## List deployment stacks on Azure
+	az deployment group list --verbose --resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" --output table
+	@echo
+	az stack group list --verbose --resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" --output table
+
+##@ Azure Shared Image Gallery lifecycle
+
+.PHONY:
+sig-plan: | preflight _az-header ## Generate what-if plan of SIG stack deployment for inspection
+	az deployment group what-if --verbose \
+		--resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" \
+		--subscription "$(MINIKUBE_AZ_SUBSCRIPTION_ID)" \
+		--template-file sig.bicep \
+		--parameters sig.bicepparam
+
+.PHONY:
+sig-deploy: | preflight _az-header ## Deploy SIG stack from Bicep templates to Azure
+	az stack group create --verbose \
+		--name "$(MINIKUBE_AZ_SIG_STACK_DEPLOYMENT_NAME)" \
+		--resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" \
+		--subscription "$(MINIKUBE_AZ_SUBSCRIPTION_ID)" \
+		--template-file sig.bicep \
+		--parameters sig.bicepparam \
+		--action-on-unmanage deleteResources --deny-settings-mode None
+
+.PHONY:
+sig-validate: | preflight _az-header ## Validate SIG stack deployment
+	az stack group validate --verbose \
+		--name "$(MINIKUBE_AZ_SIG_STACK_DEPLOYMENT_NAME)" \
+		--resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" \
+		--subscription "$(MINIKUBE_AZ_SUBSCRIPTION_ID)" \
+		--template-file sig.bicep \
+		--parameters sig.bicepparam \
+		--action-on-unmanage detachAll --deny-settings-mode none
+
+.PHONY:
+sig-undeploy: | preflight _az-header ## Delete SIG stack and its resources from Azure (prompts for confirmation)
+	az stack group delete --verbose \
+		--name "$(MINIKUBE_AZ_SIG_STACK_DEPLOYMENT_NAME)" \
+		--resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" \
+		--subscription "$(MINIKUBE_AZ_SUBSCRIPTION_ID)" \
+		--action-on-unmanage deleteResources
+
+.PHONY:
+sig-list-images: | preflight _az-header ## Lists image versions available in SIG
+	az sig image-version list --verbose \
+		--resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" \
+		--gallery-name "$(MINIKUBE_AZ_SIG_NAME)" \
+		--gallery-image-name "$(MINIKUBE_AZ_IMAGE_NAME)" \
+		--query '[].{Version:name,PublishedDate:publishingProfile.publishedDate,Location:location,group:resourceGroup,state:provisioningState}' \
+		--output table
+
+##@ Azure Virtual Network + Network Security Group lifecycle (required by VM)
+
+.PHONY:
+vnet-plan: | preflight _az-header ## Generate what-if plan of Network stack deployment for inspection
+	az deployment group what-if --verbose \
+		--resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" \
+		--subscription "$(MINIKUBE_AZ_SUBSCRIPTION_ID)" \
+		--template-file vnet.bicep \
+		--parameters vnet.bicepparam
+
+.PHONY:
+vnet-deploy: | preflight _az-header ## Deploy Network stack from Bicep templates to Azure
+	az stack group create --verbose \
+		--name "$(MINIKUBE_AZ_VNET_STACK_DEPLOYMENT_NAME)" \
+		--resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" \
+		--subscription "$(MINIKUBE_AZ_SUBSCRIPTION_ID)" \
+		--template-file vnet.bicep \
+		--parameters vnet.bicepparam \
+		--action-on-unmanage deleteResources --deny-settings-mode None
+
+.PHONY:
+vnet-validate: | preflight _az-header ## Validate Network stack deployment
+	az stack group validate --verbose \
+		--name "$(MINIKUBE_AZ_VNET_STACK_DEPLOYMENT_NAME)" \
+		--resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" \
+		--subscription "$(MINIKUBE_AZ_SUBSCRIPTION_ID)" \
+		--template-file vnet.bicep \
+		--parameters vnet.bicepparam \
+		--action-on-unmanage detachAll --deny-settings-mode none
+
+
+.PHONY:
+vnet-undeploy: | preflight _az-header ## Delete Network stack and its resources from Azure (prompts for confirmation)
+	az stack group delete --verbose \
+		--name "$(MINIKUBE_AZ_VNET_STACK_DEPLOYMENT_NAME)" \
+		--resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" \
+		--subscription "$(MINIKUBE_AZ_SUBSCRIPTION_ID)" \
+		--action-on-unmanage deleteResources
+
+##@ Azure Virtual Machine lifecycle
+
+.PHONY:
+vm-plan: | preflight _az-header ## Generate what-if plan of VM stack deployment for inspection
+	az deployment group what-if --verbose \
+		--resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" \
+		--subscription "$(MINIKUBE_AZ_SUBSCRIPTION_ID)" \
+		--template-file vm.bicep \
+		--parameters vm.bicepparam
+
+.PHONY:
+vm-deploy: | preflight _az-header ## Deploy VM stack from Bicep templates to Azure
+	az stack group create --verbose \
+		--name "$(MINIKUBE_AZ_VM_STACK_DEPLOYMENT_NAME)" \
+		--resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" \
+		--subscription "$(MINIKUBE_AZ_SUBSCRIPTION_ID)" \
+		--template-file vm.bicep \
+		--parameters vm.bicepparam \
+		--action-on-unmanage deleteResources --deny-settings-mode None
+
+.PHONY:
+vm-validate: | preflight _az-header ## Validate VM stack deployment
+	az stack group validate --verbose \
+		--name "$(MINIKUBE_AZ_VM_STACK_DEPLOYMENT_NAME)" \
+		--resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" \
+		--subscription "$(MINIKUBE_AZ_SUBSCRIPTION_ID)" \
+		--template-file vm.bicep \
+		--parameters vm.bicepparam \
+		--action-on-unmanage detachAll --deny-settings-mode none
+
+.PHONY:
+vm-undeploy: | preflight _az-header ## Undeploy VM stack and its resources from Azure (sloow, prompts for confirmation)
+	az stack group delete --verbose \
+		--name "$(MINIKUBE_AZ_VM_STACK_DEPLOYMENT_NAME)" \
+		--resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" \
+		--subscription "$(MINIKUBE_AZ_SUBSCRIPTION_ID)" \
+		--action-on-unmanage deleteResources
+
+.PHONY:
+vm-delete: | preflight _az-header ## Delete VM with fast direct delete operations (args: vm=<name> and optional rg=<name>; 10x faster than undeploy)
+	./scripts/az-vm-delete.sh $(vm) $(rg)
+
+.PHONY:
+vm-fqdn: | preflight _az-header ## Lists FQDN of all VMs deployed on Azure
+	az network public-ip list \
+		--resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" \
+		--query '[].{IP:ipAddress, Hostname:dnsSettings.fqdn}' \
+		--output table
+
+.PHONY:
+vm-list: | preflight _az-header ## List VMs deployed on Azure
+	az vm list --verbose \
+		--resource-group "$(MINIKUBE_AZ_RESOURCE_GROUP)" \
+		--show-details \
+		--output table
+
+##@ Packer pipeline building VM image
+
+.PHONY:
+_packer-header:
+	@echo
+	@printf "\033[0;32m%(%F %T)T Executing Packer command:\033[0m\n"
+
+.PHONY:
+_packer-generate-vars: | preflight
+	@echo
+	@printf "\033[0;32m%(%F %T)T Generating packer/azure.auto.pkrvars.hcl:\033[0m\n"
+	@echo "# Azure Shared Image Gallery where Packer will  publish the VM image." > packer/azure.auto.pkrvars.hcl
+	@echo "minikube_subscription_id=\"$(MINIKUBE_AZ_SUBSCRIPTION_ID)\"" >> packer/azure.auto.pkrvars.hcl
+	@echo "minikube_resource_group=\"$(MINIKUBE_AZ_RESOURCE_GROUP)\"" >> packer/azure.auto.pkrvars.hcl
+	@echo "minikube_shared_image_gallery=\"$(MINIKUBE_AZ_SIG_NAME)\"" >> packer/azure.auto.pkrvars.hcl
+	@echo "vm_image_name=\"$(MINIKUBE_AZ_IMAGE_NAME)\"" >> packer/azure.auto.pkrvars.hcl
+	@echo "vm_image_version=\"$(MINIKUBE_AZ_IMAGE_VERSION)\"" >> packer/azure.auto.pkrvars.hcl
+	@echo "vm_admin_password=\"$(MINIKUBE_AZ_VM_ADMIN_PASSWORD)\"" >> packer/azure.auto.pkrvars.hcl
+	@echo "vm_admin_username=\"$(MINIKUBE_AZ_VM_ADMIN_USERNAME)\"" >> packer/azure.auto.pkrvars.hcl
+	@echo "vm_admin_ssh_public_key=\"$(MINIKUBE_AZ_VM_ADMIN_SSH_PUBLIC_KEY)\"" >> packer/azure.auto.pkrvars.hcl
+
+.PHONY:
+packer-fmt: _packer-header ## Run packer fmt
+	packer fmt ./packer
+
+.PHONY:
+packer-init: _packer-generate-vars ## Run packer init preparing for VM image build 
+	packer init ./packer
+
+.PHONY:
+packer-validate: packer-init ## Run packer validate
+	cd ./packer && packer validate .
+
+.PHONY:
+packer-build-and-publish: packer-init ## Run packer build (checks shared image gallery exists, disallows image overwrite)
+	cd ./packer && packer build -timestamp-ui -warn-on-undeclared-var .
+
+.PHONY:
+packer-build-and-overwrite: packer-init ## Run packer build (checks shared image gallery exists, overwrites existing image)
+	cd ./packer && packer build -force -timestamp-ui -warn-on-undeclared-var .
+
+##@ Bicep templates development
+
+templates := $(shell find . -type f \( -name '*.bicep' -o -name '*.bicepparam' \) )
+
+.PHONY:
+_bicep-header:
+	@echo
+	@printf "\033[0;32m%(%F %T)T Executing Bicep command:\033[0m\n"
+
+_bicep-fmt: _bicep-header $(templates:.bicep=.bicep.fmt) $(parameters:.bicepparam=.biceparam.fmt)
+bicep-fmt: ## Format Bicep templates
+	@$(MAKE) _bicep-fmt
+
+_bicep-lint: _bicep-header $(templates:.bicep=.bicep.lint) $(parameters:.bicepparam=.biceparam.lint)
+bicep-lint: ## Verify Bicep templates
+	@$(MAKE) _bicep-lint
+
+%.bicep.fmt %.bicepparam.fmt:
+	AZURE_BICEP_CHECK_VERSION=False az bicep format --file $(basename $@) --verbose 2>&1
+
+%.bicep.lint %.bicepparam.lint:
+	AZURE_BICEP_CHECK_VERSION=False az bicep lint --file $(basename $@) --verbose 2>&1

--- a/hack/windows-ci-image/README.md
+++ b/hack/windows-ci-image/README.md
@@ -1,0 +1,134 @@
+# Build VM image with Windows 11 for CI on Azure
+
+> [!CAUTION]
+> Minikube was granted access to Azure resource group `SIG-CLUSTER-LIFECYCLE-MINIKUBE` managed by SIG-Cluster-Lifecycle/SIG-Windows.
+> We must **NOT** attempt to delete this resource group!
+>
+> Unfortunately, locking the resource group would not help, becuase it also locks any contained resources:
+>
+>    ```bash
+>    az group lock create --lock-type CanNotDelete \
+>       --name "CanNotDelete-${MINIKUBE_AZ_RESOURCE_GROUP}" \
+>       --resource-group "${MINIKUBE_AZ_RESOURCE_GROUP}" \
+>       --notes "Group managed by SIG-Windows"
+>    ```
+>
+
+## Features
+
+The goal of the project is to build Windows-based golden image for Minikube in order
+to create create short-lived ephemeral Azure Virtual Machines used for testing.
+
+The project provides:
+
+1. Bicep templates to create Shared Image Gallery on Azure in given resource group.
+2. Packer templates to build single Virtual Machine image:
+    - based on Windows 11 with Windows settings optimized and bloatware removed
+    - [specialized, not generalized](https://learn.microsoft.com/en-us/azure/virtual-machines/shared-image-galleries#generalized-and-specialized-images), and [shallowly replicated](https://learn.microsoft.com/en-us/azure/virtual-machines/shared-image-galleries#shallow-replication)
+    - provisioned with local administrator (user-provided username (default: `minikubeadmin`) and password)
+    - provisioned with user-provided public SSH key for streamlined authentication
+    - provisioned with [tools required to run Minikube tests](packer/provisioners/))
+
+3. Packer configuration to publish it to the Azure Shared Image Gallery.
+4. Bicep templates to create Azure Virtual Machine from the published image to verify the output of the image build.
+
+## Usage
+
+Help: `make help`
+
+### Configure
+
+1. Set up Azure CLI:
+
+    ```bash
+    az login
+    ```
+
+    or keep the Azure CLI profile in project-specific location (recommended? safety?):
+
+    ```bash
+    export AZURE_CONFIG_DIR=$HOME/minikube/.azure
+    az login
+    ```
+
+2. Set up environment variables
+
+    Run `make preflight` to check list of all required `MINIKUBE_AZ_*` environment variables.
+
+    Review the reasonable defaults in [env.sh](env.sh).
+
+    Create your user-specific `env.local.sh` setting:
+
+    - `MINIKUBE_AZ_VM_ADMIN_PASSWORD` with password of your choice (see )
+    - `MINIKUBE_AZ_VM_ADMIN_SSH_PUBLIC_KEY=$(cat ~/.ssh/minikubeadmin.id_ecdsa.pub | base64 -w 0)` or equivalent
+    - optionally, any of the others you wish to override their default values
+
+    Load the environment variables:
+
+    ```bash
+    source ./env.sh
+    ```
+
+    Alternatively, install [mise](https://mise.jdx.dev) and let it load [.mise.toml](.mise.toml).
+
+### Build
+
+Run `make help` to learn about available commands.
+
+```bash
+source ./env.sh
+make preflight                  # verify your environment
+make sig-deploy                 # create Shared Image Gallery on Azure
+make packer-build-and-publish   # build VM image and push it to the gallery
+```
+
+### Test
+
+Find IP and FQDN of VM:
+
+```bash
+make vm-deploy          # create VM from the image
+make vm-fqdn            # print public IP and FQDN
+```
+
+Connect to PowerShell on VM:
+```bash
+make vm-generate-ssh    # generate script with ssh command
+./vm-generate-ssh.sh    # uses the insecure SSH key
+```
+
+Connect to PowerShell on VM using the insecure SSH key:
+
+```bash
+ssh -i ~/.ssh/minikube-ci.id_ecdsa  -o StrictHostKeyChecking=no minikubeadmin@vm-minikube-ci.${AZURE_DEFAULTS_LOCATION}.cloudapp.azure.com
+```
+
+Connect to PowerShell on VM using password:
+
+```bash
+export SSHPASS="${MINIKUBE_AZ_VM_ADMIN_PASSWORD}"
+sshpass -e ssh -o StrictHostKeyChecking=no minikubeadmin@vm-minikube-ci.${AZURE_DEFAULTS_LOCATION}.cloudapp.azure.com
+```
+
+On VM, test if Docker is functioning properly:
+
+```powershell
+docker images ls
+docker run hello-world
+```
+
+## Run Minikube
+
+Connect to PowerShell on VM via SSH and run the following commands according to the [docs](https://minikube.sigs.k8s.io/docs/start/?arch=%2Fwindows%2Fx86-64%2Fstable%2F.exe+download):
+
+```powershell
+$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -OutFile 'c:\minikube\minikube.exe' -Uri 'https://github.com/kubernetes/minikube/releases/latest/download/minikube-windows-amd64.exe' -UseBasicParsing
+```
+
+```powershell
+$env:PATH += ';C:\Minikube
+```
+
+```powershell
+minikube start --container-runtime=docker --vm=true
+```

--- a/hack/windows-ci-image/env.sh
+++ b/hack/windows-ci-image/env.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# shellcheck disable=SC1091,SC2034
+
+# Configures environment for Bicep and Packer templates with required inputs
+# for pipelines to create SIG, build VM image, create VM.
+#
+# Create env.local.sh with user-specific overrides of the defaults.
+
+set -o allexport
+
+### Azure environment defaults
+# https://learn.microsoft.com/en-us/cli/azure/azure-cli-configuration#cli-configuration-values-and-environment-variables
+[ -z "$AZURE_CORE_ONLY_SHOW_ERRORS" ] && AZURE_CORE_ONLY_SHOW_ERRORS=true # Disable warnings about preview features
+[ -z "$AZURE_CORE_OUTPUT" ] && AZURE_CORE_OUTPUT=jsonc
+# Not necessary as we expect pre-existing resource group, then its location is referenced as default.
+[ -z "$AZURE_DEFAULTS_LOCATION" ] && AZURE_DEFAULTS_LOCATION="$(az config get defaults.location --only-show-errors --query value -o tsv)"
+[ -z "$AZURE_DEFAULTS_LOCATION" ] && AZURE_DEFAULTS_LOCATION=southcentralus
+# AZURE_DEFAULTS_GROUP not used to avoid implicit target group. Makefile commands are given explicit --resource-group name.
+
+### Minikube environment defaults
+[ -z "$MINIKUBE_AZ_SUBSCRIPTION_ID" ] && MINIKUBE_AZ_SUBSCRIPTION_ID="$(az account show --query 'id' --output tsv)"
+[ -z "$MINIKUBE_AZ_RESOURCE_GROUP" ] && MINIKUBE_AZ_RESOURCE_GROUP="SIG-CLUSTER-LIFECYCLE-MINIKUBE"
+[ -z "$MINIKUBE_AZ_SIG_NAME" ] && MINIKUBE_AZ_SIG_NAME="minikube"
+[ -z "$MINIKUBE_AZ_IMAGE_NAME" ] && MINIKUBE_AZ_IMAGE_NAME="minikube-ci-windows-11"
+[ -z "$MINIKUBE_AZ_IMAGE_VERSION" ] && MINIKUBE_AZ_IMAGE_VERSION="1.0.0"
+[ -z "$MINIKUBE_AZ_VM_ADMIN_USERNAME" ] && MINIKUBE_AZ_VM_ADMIN_USERNAME="minikubeadmin"
+[ -z "$MINIKUBE_AZ_VM_ADMIN_PASSWORD" ] && MINIKUBE_AZ_VM_ADMIN_PASSWORD="" # Must be overriden via env.local.sh or export
+[ -z "$MINIKUBE_AZ_VM_ADMIN_SSH_PUBLIC_KEY" ] && MINIKUBE_AZ_VM_ADMIN_SSH_PUBLIC_KEY="" # Must be overriden via env.local.sh or export
+
+### Load user-specific environment overrides, if present
+[ -f ./env.local.sh ] && source ./env.local.sh
+
+set +o allexport

--- a/hack/windows-ci-image/packer/build.pkr.hcl
+++ b/hack/windows-ci-image/packer/build.pkr.hcl
@@ -1,0 +1,57 @@
+build {
+  sources = [
+    "source.azure-arm.minikube-ci-windows-11"
+  ]
+
+  # Deploy SSH public key for local administrator.
+  # Required by install-openssh.ps1 to generate C:\ProgramData\ssh\administrators_authorized_keys
+  provisioner "powershell" {
+    inline = [
+      "Write-Host '>>> Copying SSH public key to be deployed for local administrator'",
+      "New-Item -Path C:/ProgramData/ssh -ItemType Directory -Force | Out-Null",
+      "Add-Content -Path C:/ProgramData/ssh/admin.pub.txt -Value '${var.vm_admin_ssh_public_key}' -Force"
+    ]
+  }
+
+  ###### <Provisioners with elevated privileges>
+  # These provisioners are required for DISM (e.g. install OpenSSH) and other actions,
+  # and are implemented in terms scheduled tasks which require AutoLogon to complete.
+  provisioner "powershell" {
+    script = "provisioners/enable-autologon.ps1"
+    environment_vars = [
+      "AUTOLOGON_USER_PASSWORD=${var.vm_admin_password}"
+    ]
+  }
+
+  provisioner "windows-restart" {}
+
+  provisioner "powershell" {
+    elevated_user     = var.vm_admin_username
+    elevated_password = var.vm_admin_password
+    scripts = [
+      "provisioners/set-windows.ps1",
+      "provisioners/set-privacy.ps1",
+      "provisioners/remove-bloatware.ps1",
+      "provisioners/remove-services.ps1",
+      "provisioners/add-choco.ps1",
+      "provisioners/add-openssh.ps1",
+      "provisioners/add-hyperv.ps1"
+    ]
+  }
+
+  provisioner "windows-restart" {}
+
+  provisioner "powershell" {
+    elevated_user     = var.vm_admin_username
+    elevated_password = var.vm_admin_password
+    scripts = [
+      "provisioners/add-docker.ps1",
+      "provisioners/add-tools.ps1"
+    ]
+  }
+
+  provisioner "powershell" {
+    script = "provisioners/disable-autologon.ps1"
+  }
+  ###### </Provisioners with elevated privileges>
+}

--- a/hack/windows-ci-image/packer/plugins.pkr.hcl
+++ b/hack/windows-ci-image/packer/plugins.pkr.hcl
@@ -1,0 +1,8 @@
+packer {
+  required_plugins {
+    azure = {
+      source  = "github.com/hashicorp/azure"
+      version = ">= 2"
+    }
+  }
+}

--- a/hack/windows-ci-image/packer/provisioners/add-choco.ps1
+++ b/hack/windows-ci-image/packer/provisioners/add-choco.ps1
@@ -1,0 +1,47 @@
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+# NOTE: Prefer Chocolatey from GitHub, instead of the official location which often keeps being unavailable
+# iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+Write-Host '>>> Installing Chocolatey...'
+
+Set-ExecutionPolicy Bypass -Scope Process -Force;
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
+
+$chocoVersion = '2.6.0'
+$url = "https://github.com/chocolatey/choco/releases/download/${chocoVersion}/chocolatey.${chocoVersion}.nupkg"
+$tempDir = Join-Path $env:TEMP "chocolatey_install"
+$nupkgPath = Join-Path $tempDir "chocolatey.zip"
+
+New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
+
+Write-Host ">>>> Downloading Chocolatey v$chocoVersion from $url..."
+(New-Object System.Net.WebClient).DownloadFile($url, $nupkgPath)
+
+Write-Host ">>>> Extracting..."
+Expand-Archive -Path $nupkgPath -DestinationPath $tempDir -Force
+
+Write-Host ">>>> Running installation script..."
+$installScript = Join-Path $tempDir "tools\chocolateyInstall.ps1"
+& $installScript
+
+# Cleanup
+try {
+    Remove-Item -Recurse -Force $tempDir -ErrorAction Stop
+} catch {
+    Write-Warning ">>>> Failed to cleanup temp dir (likely file in use): $_"
+}
+
+# Bypass confirmation prompts
+choco feature enable --name=allowGlobalConfirmation
+
+# Avoid exit code 3010 (ERROR_SUCCESS_REBOOT_REQUIRED) which fails Packer pipeline
+# https://github.com/chocolatey/choco/issues/3087#issuecomment-1552742454
+# FIXME(mloskot): This leads to false success on "Failed to fetch...docker-engine not installed. The package was not found with the source(s) listed."
+#choco feature disable --name=usePackageExitCodes
+
+# Ignore any detected reboots
+choco feature disable --name=exitOnRebootDetected
+
+Write-Host '>>> Installing Chocolatey done'

--- a/hack/windows-ci-image/packer/provisioners/add-docker.ps1
+++ b/hack/windows-ci-image/packer/provisioners/add-docker.ps1
@@ -1,0 +1,34 @@
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+# https://minikube.sigs.k8s.io/docs/tutorials/docker_desktop_replacement/#Windows
+$packageName = 'docker-engine'
+$maxRetries = 5 # TODO(mloskot): Do exponential backoff, instead of linear?
+
+Write-Host ">>> Installing $packageName..."
+
+if (-not (Get-Service -Name vmic*)) {
+    Write-Error ">>>> add-docker.ps1 must run after add-hyperv.ps1" -ErrorAction Stop
+}
+
+for ($retries = 0; ; $retries++) {
+    if ($retries -gt $maxRetries) {
+        Write-Error ">>>> Could not install package $packageName" -ErrorAction Stop
+    }
+
+    choco install $packageName --yes --no-prompt --no-progress --ignore-detected-reboot
+    Write-Host ">>>> choco install exit code $LASTEXITCODE"
+
+    # Ignore exit code 3010 (ERROR_SUCCESS_REBOOT_REQUIRED)
+    if ($LASTEXITCODE -eq 0 -or $LASTEXITCODE -eq 3010) {
+        $global:LASTEXITCODE = 0 # Packer will fail on exit code 3010
+        Write-Host ">>>> Package $packageName successfully installed"
+        break
+    }
+    else {
+        Write-Host ">>>> Error installing $packageName, retrying in $maxRetries seconds..."
+        Start-Sleep -Seconds $maxRetries
+    }
+}
+
+Write-Host ">>> Installing $packageName done"

--- a/hack/windows-ci-image/packer/provisioners/add-hyperv.ps1
+++ b/hack/windows-ci-image/packer/provisioners/add-hyperv.ps1
@@ -1,0 +1,32 @@
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+# https://minikube.sigs.k8s.io/docs/tutorials/docker_desktop_replacement/#Windows
+$packages = ('Containers', 'Microsoft-Hyper-V')
+$maxRetries = 5 # TODO(mloskot): Do exponential backoff, instead of linear?
+
+foreach ($packageName in $packages) {
+    Write-Host ">>> Installing $packageName..."
+
+    for ($retries = 0; ; $retries++) {
+        if ($retries -gt $maxRetries) {
+            Write-Error ">>>> Could not install package $packageName" -ErrorAction Stop
+        }
+
+        choco install $packageName --source windowsfeatures --yes --no-prompt --no-progress --ignore-detected-reboot
+        Write-Host ">>>> choco install exit code $LASTEXITCODE"
+
+        # Ignore exit code 3010 (ERROR_SUCCESS_REBOOT_REQUIRED)
+        if ($LASTEXITCODE -eq 0 -or $LASTEXITCODE -eq 3010) {
+            $global:LASTEXITCODE = 0 # Packer will fail on exit code 3010
+            Write-Host ">>>> Package $packageName successfully installed"
+            break
+        }
+        else {
+            Write-Host ">>>> Error installing $packageName, retrying in $maxRetries seconds..."
+            Start-Sleep -Seconds $maxRetries
+        }
+    }
+
+    Write-Host ">>> Installing $packageName done"
+}

--- a/hack/windows-ci-image/packer/provisioners/add-openssh.ps1
+++ b/hack/windows-ci-image/packer/provisioners/add-openssh.ps1
@@ -1,0 +1,61 @@
+$ErrorActionPreference = 'Stop'
+
+Write-Host '>>> Installing SSH public key...'
+
+# https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_keymanagement
+if (-not (Test-Path -Path C:\ProgramData\ssh\admin.pub.txt)) {
+    Write-Error -Message "Public key C:\ProgramData\ssh\admin.pub.txt not found" -ErrorAction Stop
+}
+
+$publicKey = Get-Content -Path C:\ProgramData\ssh\admin.pub.txt
+try {
+    $publicKey = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($publicKey))
+} catch {
+    $publicKey = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($publicKey))
+}
+Add-Content -Path C:\ProgramData\ssh\administrators_authorized_keys -Value "$publicKey" -Force
+
+icacls.exe "$env:ProgramData\ssh\administrators_authorized_keys" /inheritance:r /grant "Administrators:F" /grant "SYSTEM:F"
+
+Write-Host '>>> Installing SSH public key done'
+
+# WARNING: This is super slow, may take even 15 minutes
+# Write-Host '>>> Installing OpenSSH Server (Windows Capability)...'
+# Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+# Write-Host '>>> Installing OpenSSH Server (Windows Capability) completed'
+
+# NOTE: This is quick, but Chocolatey may timeout frequently
+# Write-Host '>>> Installing OpenSSH Server (choco)...'
+# Set-ExecutionPolicy Bypass -Scope Process -Force;
+# choco install openssh --yes --no-prompt --no-progress --ignore-detected-reboot
+# & 'C:\Program Files\OpenSSH-Win64\install-sshd.ps1'
+# Write-Host '>>> Installing OpenSSH Server (choco) done'
+
+# NOTE: This is even quicker and reliable too
+Write-Host '>>> Installing OpenSSH Server (zip)...'
+Set-ExecutionPolicy Bypass -Scope Process -Force;
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-WebRequest -Uri 'https://github.com/PowerShell/Win32-OpenSSH/releases/download/10.0.0.0p2-Preview/OpenSSH-Win64.zip' -OutFile C:\openssh.zip
+Expand-Archive -Path C:\openssh.zip -DestinationPath 'C:\Program Files\'
+Remove-Item -Path C:\openssh.zip -Force
+& 'C:\Program Files\OpenSSH-Win64\install-sshd.ps1'
+Write-Host '>>> Installing OpenSSH Server (zip) done'
+
+Write-Host '>>> Starting OpenSSH Server...'
+Start-Service -Name sshd
+Set-Service -Name sshd -StartupType 'Automatic'
+Write-Host '>>> Starting OpenSSH Server completed'
+
+Write-Host '>>> Setting Windows Firewall for SSH...'
+if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) {
+    New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH SSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+}
+Set-NetFirewallRule -DisplayName 'OpenSSH SSH Server (sshd)' -Profile Any -Enabled True
+Write-Host '>>> Setting Windows Firewall for SSH completed'
+
+Write-Host '>>> Setting PowerShell 5.1 as SSH default shell...'
+New-ItemProperty -Path 'HKLM:\SOFTWARE\OpenSSH' -Name DefaultShell -Value 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -PropertyType String -Force
+New-ItemProperty -Path 'HKLM:\SOFTWARE\OpenSSH' -Name DefaultShellCommandOption -Value '/c' -PropertyType String -Force
+Write-Host '>>> Setting PowerShell 5.1 as SSH default shell completed'
+
+Restart-Service -Name sshd

--- a/hack/windows-ci-image/packer/provisioners/add-tools.ps1
+++ b/hack/windows-ci-image/packer/provisioners/add-tools.ps1
@@ -1,0 +1,31 @@
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$packages = ('kubernetes-cli')
+$maxRetries = 5 # TODO(mloskot): Do exponential backoff, instead of linear?
+
+foreach ($packageName in $packages) {
+    Write-Host ">>> Installing $packageName..."
+
+    for ($retries = 0; ; $retries++) {
+        if ($retries -gt $maxRetries) {
+            Write-Error ">>>> Could not install package $packageName" -ErrorAction Stop
+        }
+
+        choco install $packageName --yes --no-prompt --no-progress --ignore-detected-reboot
+        Write-Host ">>>> choco install exit code $LASTEXITCODE"
+
+        # Ignore exit code 3010 (ERROR_SUCCESS_REBOOT_REQUIRED)
+        if ($LASTEXITCODE -eq 0 -or $LASTEXITCODE -eq 3010) {
+            $global:LASTEXITCODE = 0 # Packer will fail on exit code 3010
+            Write-Host ">>>> Package $packageName successfully installed"
+            break
+        } 
+        else {
+            Write-Host ">>>> Error installing $packageName, retrying in $maxRetries seconds..."
+            Start-Sleep -Seconds $maxRetries
+        }
+    }
+
+    Write-Host ">>> Installing $packageName done"
+}

--- a/hack/windows-ci-image/packer/provisioners/disable-autologon.ps1
+++ b/hack/windows-ci-image/packer/provisioners/disable-autologon.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = 'Stop'
+
+Write-Output '>>> Disabling AutoAdminLogon...'
+
+Remove-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name AutoAdminLogon
+Remove-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name DefaultUsername
+Remove-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name DefaultPassword
+
+Write-Output '>>> Disabling AutoAdminLogon completed'

--- a/hack/windows-ci-image/packer/provisioners/enable-autologon.ps1
+++ b/hack/windows-ci-image/packer/provisioners/enable-autologon.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = 'Stop'
+
+# Our testing has shown that Windows 10 does not allow packer to run a Windows scheduled task until the admin user (packer) has logged into the system.
+# So we enable AutoAdminLogon and use packer's windows-restart provisioner to get the system into a good state to allow scheduled tasks to run.
+Write-Output '>>> Enabling AutoLogon...'
+
+if ([string]::IsNullOrEmpty($Env:AUTOLOGON_USER_PASSWORD)) { throw 'env:AUTOLOGON_USER_PASSWORD must be set' }
+
+Write-Output ">>> Enabling AutoAdminLogon to allow scheduled task created by elevated_user=$env:UserName to run..."
+Set-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name AutoAdminLogon -Value 1
+Set-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name DefaultUsername -Value "$env:UserName"
+Set-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name DefaultPassword -Value "$env:AUTOLOGON_USER_PASSWORD"
+
+Write-Output '>>> Enabling AutoLogon completed'
+Write-Output '>>> IMPORTANT: Run Packer provisioner windows-restart as next step'

--- a/hack/windows-ci-image/packer/provisioners/remove-bloatware.ps1
+++ b/hack/windows-ci-image/packer/provisioners/remove-bloatware.ps1
@@ -1,0 +1,59 @@
+Write-Host '>>> Uninstalling applications...'
+
+$bloatware = @(
+    "*bing*",
+    "*feedback*",
+    "*getstarted*",
+    "*msteams*"
+    "*news*",
+    "*onenote*",
+    "*outlook*",
+    "*people*",
+    "*quickassist*",
+    "*skype*"
+    "*solitaire*",
+    "*stickynotes*",
+    "*tips*",
+    "*weather*",
+    "*windowscommunicationsapps*", # Mail & Calendar
+    "*xbox*",
+    "*yourphone*",
+    "*zune*",
+    "Clipchamp.Clipchamp*",
+    "Microsoft.BingWeather*"
+    "Microsoft.GamingApp*",
+    "Microsoft.GetHelp*",
+    "Microsoft.MicrosoftOfficeHub*",
+    "Microsoft.OneDriveSync*",
+    "Microsoft.Paint*",
+    "Microsoft.PowerAutomateDesktop*",
+    "Microsoft.ScreenSketch*",
+    "Microsoft.Teams*",
+    "Microsoft.Todos*",
+    "Microsoft.Windows.DevHome*",
+    "Microsoft.Windows.Photos*",
+    "Microsoft.WindowsCalculator*",
+    "Microsoft.WindowsCamera*",
+    "Microsoft.WindowsSoundRecorder*"
+)
+
+if (Get-Command Get-AppxPackage -ErrorAction SilentlyContinue) {
+    foreach ($app in $bloatware) {
+        Write-Host "Removing $app..."
+        Get-AppxPackage -AllUsers -Name $app -ErrorAction SilentlyContinue | Where-Object { $_.Name -notlike "*XboxGameCallableUI*" -and $_.Name -notlike "*PeopleExperienceHost*" } | Remove-AppxPackage -AllUsers -ErrorAction SilentlyContinue
+        Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -Like $app -and $_.DisplayName -notlike "*XboxGameCallableUI*" -and $_.DisplayName -notlike "*PeopleExperienceHost*" } | Remove-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue
+    }
+} else {
+    Write-Host "Appx removal tools not found. Skipping (Expected on Server Core)."
+}
+
+Write-Host "Removing OneDrive..."
+Stop-Process -Name "OneDrive" -ErrorAction SilentlyContinue
+$onedrive32 = "C:\Windows\SysWOW64\OneDriveSetup.exe"
+$onedrive64 = "C:\Windows\System32\OneDriveSetup.exe"
+if (Test-Path $onedrive32) { Start-Process $onedrive32 -ArgumentList "/uninstall" -Wait -NoNewWindow -ErrorAction SilentlyContinue }
+if (Test-Path $onedrive64) { Start-Process $onedrive64 -ArgumentList "/uninstall" -Wait -NoNewWindow -ErrorAction SilentlyContinue }
+Remove-Item -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Run\OneDrive" -ErrorAction SilentlyContinue
+Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Run" -Name "OneDrive" -ErrorAction SilentlyContinue
+
+Write-Host '>>> Uninstalling applications done'

--- a/hack/windows-ci-image/packer/provisioners/remove-services.ps1
+++ b/hack/windows-ci-image/packer/provisioners/remove-services.ps1
@@ -1,0 +1,84 @@
+Write-Output '>>> Disabling unused services...'
+
+# --- 1. The "Safe for Everyone" List ---
+# Disables Telemetry, Maps, Fax, Insider Service, etc.
+$safeServices = @(
+    "DiagTrack",           # Connected User Experiences and Telemetry
+    "MapsBroker",          # Downloaded Maps Manager
+    "Fax",                 # Fax
+    "RemoteRegistry",      # Remote Registry
+    "wisvc",               # Windows Insider Service
+    "TabletInputService",  # Touch Keyboard (Safe for non-touchscreens)
+    "Themes",              # Visual themes (Unnecessary for headless)
+    "UxSms",               # Desktop Window Manager Session Manager (Unnecessary for headless)
+    "FontCache",           # Font Cache
+    "PcaSvc",              # Program Compatibility Assistant
+    "WerSvc",              # Windows Error Reporting Service
+    "WbioSrvc"             # Windows Biometric Service
+)
+
+# --- 2. The "Gamer/Xbox" List ---
+# Only run this if you DO NOT use the Xbox App or Game Pass
+$xboxServices = @(
+    "XboxGipSvc",          # Xbox Game Input Protocol
+    "XblAuthManager",      # Xbox Live Auth Manager
+    "XblGameSave",         # Xbox Live Game Save
+    "XboxNetApiSvc"        # Xbox Live Networking Service
+)
+
+# --- 3. The "Search" List ---
+# Stops file indexing. Search will break.
+$searchServices = @(
+    "WSearch",             # Windows Search Service
+    "SysMain"              # Superfetch (Pre-loading apps, high disk usage)
+)
+
+# --- 4. The "Headless/Dev" List ---
+# Disables Audio, Bluetooth, and Printing
+$headlessServices = @(
+    "Audiosrv",                 # Windows Audio
+    "AudioEndpointBuilder",     # Windows Audio Endpoint Builder
+    "BthAvctpSvc",              # Bluetooth Audio Gateway Service
+    "BthServ",                  # Bluetooth Support Service
+    "Spooler",                  # Print Spooler (DISABLES PRINTING)
+    "upnphost",                 # UPnP Device Host (Network plug-and-play)
+    "SSDPSRV",                  # SSDP Discovery (Network device discovery)
+    "DeviceAssociationService", # Device Association Service (Pairing devices)
+    "ScDeviceEnum",             # Smart Card Device Enumeration (Rarely used)
+    "SCardSvr",                 # Smart Card (Rarely used)
+    "DoSvc",                    # Delivery Optimization (Peer-to-peer updates)
+    "lfsvc",                    # Geolocation Service
+    "RmSvc",                    # Radio Management (Airplane mode etc)
+    "WpnService",               # Windows Push Notifications System Service
+    "CDPSvc",                   # Connected Devices Platform Service
+    "TrkWks",                   # Distributed Link Tracking Client
+    "InventorySvc"              # Inventory and Compatibility Appraiser (Telemetry)
+)
+
+# --- THE EXECUTION LOOP ---
+# This combines the lists and disables them one by one.
+
+$servicesToDisable = $safeServices + $xboxServices + $searchServices + $headlessServices
+
+foreach ($service in $servicesToDisable) {
+    try {
+        # Check if service exists first
+        if (Get-Service -Name $service -ErrorAction SilentlyContinue) {
+            Write-Host "Disabling: $service" -ForegroundColor Cyan
+            Stop-Service -Name $service -Force -ErrorAction Stop
+            Set-Service -Name $service -StartupType Disabled -ErrorAction Stop
+        } else {
+            Write-Host "Service not found (already removed?): $service" -ForegroundColor Yellow
+        }
+    } catch {
+        Write-Host "Error modifying $service. $_" -ForegroundColor Red
+    }
+}
+
+Write-Output '>>> Disabling unused services completed'
+
+# Check running serives 
+# Get-Service | Where-Object {$_.Status -eq 'Running'}
+
+# TODO:
+# install also & ([scriptblock]::Create((irm "https://debloat.raphi.re/"))) -RunDefaults -Silent

--- a/hack/windows-ci-image/packer/provisioners/set-privacy.ps1
+++ b/hack/windows-ci-image/packer/provisioners/set-privacy.ps1
@@ -1,0 +1,22 @@
+Write-Output '>>> Disabling privacy experience...'
+
+$registryPaths = @{
+    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE" = @{
+        "DisablePrivacyExperience" = 1
+        "DisableVoice"             = 1
+        "PrivacyConsentStatus"     = 1
+        "Protectyourpc"            = 3
+        "HideEULAPage"             = 1
+    }
+    "HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System" = @{
+        "EnableFirstLogonAnimation" = 1
+    }
+}
+ 
+foreach ($path in $registryPaths.Keys) {
+    foreach ($name in $registryPaths[$path].Keys) {
+        New-ItemProperty -Path $path -Name $name -Value $registryPaths[$path][$name] -PropertyType DWord -Force | Out-Null
+    }
+}
+
+Write-Output '>>> Disabling privacy experience completed'

--- a/hack/windows-ci-image/packer/provisioners/set-windows.ps1
+++ b/hack/windows-ci-image/packer/provisioners/set-windows.ps1
@@ -1,0 +1,156 @@
+Write-Host '>>> Applying Windows optimization...'
+
+# ==========================================
+# 1. Basics
+# ==========================================
+Set-TimeZone -Id "Pacific Standard Time"; Stop-Service -Name tzautoupdate -Force; Set-Service -Name tzautoupdate -StartupType Disabled
+
+# ==========================================
+# 2. Service Management
+# ==========================================
+# Early service disabling block removed (Consolidated into main list below)
+
+# Disable Server Manager at Logon (Server specific)
+Get-ScheduledTask -TaskName ServerManager -ErrorAction SilentlyContinue | Disable-ScheduledTask -ErrorAction SilentlyContinue
+
+# Helper function for Reg ADD
+function Add-Reg {
+    param($path, $key, $type, $val)
+    reg add $path /v $key /t $type /d $val /f | Out-Null
+}
+
+# Disable Windows Error Reporting UI
+Add-Reg "HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting" "DontShowUI" "REG_DWORD" "1"
+Add-Reg "HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting" "Disabled" "REG_DWORD" "1"
+
+# ==========================================
+# 3. Registry & UI Tweaks
+# ==========================================
+Write-Host "Applying Registry Tweaks..."
+
+## 3.1 Visual Effects & Performance
+$explorerVisuals = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects"
+if (!(Test-Path $explorerVisuals)) { New-Item -Path $explorerVisuals -Force | Out-Null }
+New-ItemProperty -Path $explorerVisuals -Name "VisualFXSetting" -Value 2 -PropertyType DWORD -Force | Out-Null
+
+$visualEffectsList = "AnimateMinMax","ComboBoxAnimation","CursorShadow","DropShadow",
+    "FadeToGrey","ListviewAlphaSelect","ListviewShadow","MenuAnimation",
+    "SelectionFade","TaskbarAnimations","TooltipAnimation","UIEffects"
+foreach ($e in $visualEffectsList) {
+    Set-ItemProperty "HKCU:\Control Panel\Desktop" -Name $e -Value 0 -ErrorAction SilentlyContinue
+}
+
+## 3.2 Desktop & Colors
+Set-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name "Wallpaper" -Value ""
+Set-ItemProperty -Path "HKCU:\Control Panel\Colors" -Name "Background" -Value "0 0 0"
+
+# Force Solid Color Background
+$wallpapersReg = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Wallpapers"
+if (!(Test-Path $wallpapersReg)) { New-Item -Path $wallpapersReg -Force | Out-Null }
+New-ItemProperty -Path $wallpapersReg -Name "BackgroundType" -Value 1 -PropertyType DWORD -Force | Out-Null
+
+# Disable Window Dragging Contents
+Set-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name "DragFullWindows" -Value "0" -ErrorAction SilentlyContinue
+
+# Disable Lock Screen
+Add-Reg "HKLM\SOFTWARE\Policies\Microsoft\Windows\Personalization" "NoLockScreen" "REG_DWORD" "1"
+
+## 3.3 Transparency
+$themesReg = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize"
+if (!(Test-Path $themesReg)) { New-Item -Path $themesReg -Force | Out-Null }
+New-ItemProperty -Path $themesReg -Name "EnableTransparency" -Value 0 -PropertyType DWORD -Force | Out-Null
+
+## 3.4 Search / Cortana / Edge / Ads
+# Disable Edge Startup Boost
+$edgeReg = "HKLM:\SOFTWARE\Policies\Microsoft\Edge"
+if (!(Test-Path $edgeReg)) { New-Item -Path $edgeReg -Force | Out-Null }
+New-ItemProperty -Path $edgeReg -Name "StartupBoostEnabled" -Value 0 -PropertyType DWORD -Force | Out-Null
+New-ItemProperty -Path $edgeReg -Name "SmartScreenEnabled" -Value 0 -PropertyType DWORD -Force | Out-Null
+
+# Disable Cortana & Search Indexing
+Add-Reg "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Search" "AllowCortana" "REG_DWORD" "0"
+Add-Reg "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Search" "DisableIndexing" "REG_DWORD" "1"
+
+# Disable News and Interests
+Add-Reg "HKLM\SOFTWARE\Policies\Microsoft\Dsh" "AllowNewsAndInterests" "REG_DWORD" "0"
+
+# Disable Lock Screen Ads & Spotlight
+Add-Reg "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SubscribedContent-338388Enabled" "REG_DWORD" "0"
+Add-Reg "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\SpotlightState" "Roaming" "REG_DWORD" "0"
+
+# Disable Preview Desktop & Taskbar Animations
+Add-Reg "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "TaskbarMn" "REG_DWORD" "0"
+Add-Reg "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "DisablePreviewDesktop" "REG_DWORD" "1"
+Add-Reg "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "IconsOnly" "REG_DWORD" "1"
+
+# Performance: Font Smoothing & Color Depth
+Add-Reg "HKCU\Control Panel\Desktop" "LogPixels" "REG_DWORD" "96"
+Add-Reg "HKCU\Control Panel\Desktop" "FontSmoothing" "REG_SZ" "0"
+Add-Reg "HKCU\Control Panel\Desktop" "UserPreferencesMask" "REG_BINARY" "9012038010000000"
+
+# ==========================================
+# 3.5 Apply to Default User (For Sysprep Persistence)
+# ==========================================
+Write-Host "Applying settings to Default User Profile (for Sysprep persistence)..."
+
+# Load Default User Hive
+reg load "HKLM\TempDefault" "C:\Users\Default\NTUSER.DAT" | Out-Null
+
+if (Test-Path "HKLM:\TempDefault") {
+    # 1. Visual Effects
+    $defExplorerVisuals = "HKLM:\TempDefault\Software\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects"
+    if (!(Test-Path $defExplorerVisuals)) { New-Item -Path $defExplorerVisuals -Force | Out-Null }
+    New-ItemProperty -Path $defExplorerVisuals -Name "VisualFXSetting" -Value 2 -PropertyType DWORD -Force | Out-Null
+
+    $visualEffectsList = "AnimateMinMax","ComboBoxAnimation","CursorShadow","DropShadow",
+        "FadeToGrey","ListviewAlphaSelect","ListviewShadow","MenuAnimation",
+        "SelectionFade","TaskbarAnimations","TooltipAnimation","UIEffects"
+    foreach ($e in $visualEffectsList) {
+        Set-ItemProperty "HKLM:\TempDefault\Control Panel\Desktop" -Name $e -Value 0 -ErrorAction SilentlyContinue
+    }
+
+    # 2. Desktop & Colors
+    Set-ItemProperty -Path "HKLM:\TempDefault\Control Panel\Desktop" -Name "Wallpaper" -Value ""
+    Set-ItemProperty -Path "HKLM:\TempDefault\Control Panel\Colors" -Name "Background" -Value "0 0 0"
+
+    $defWallpapersReg = "HKLM:\TempDefault\Software\Microsoft\Windows\CurrentVersion\Explorer\Wallpapers"
+    if (!(Test-Path $defWallpapersReg)) { New-Item -Path $defWallpapersReg -Force | Out-Null }
+    New-ItemProperty -Path $defWallpapersReg -Name "BackgroundType" -Value 1 -PropertyType DWORD -Force | Out-Null
+    
+    # 3. Disable Transparency
+    $defThemesReg = "HKLM:\TempDefault\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize"
+    if (!(Test-Path $defThemesReg)) { New-Item -Path $defThemesReg -Force | Out-Null }
+    New-ItemProperty -Path $defThemesReg -Name "EnableTransparency" -Value 0 -PropertyType DWORD -Force | Out-Null
+
+    # 4. Lock Screen & Ads (CurrentUser specific keys in Default hive)
+    Add-Reg "HKLM\TempDefault\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SubscribedContent-338388Enabled" "REG_DWORD" "0"
+    Add-Reg "HKLM\TempDefault\Software\Microsoft\Windows\CurrentVersion\SpotlightState" "Roaming" "REG_DWORD" "0"
+    Add-Reg "HKLM\TempDefault\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "TaskbarMn" "REG_DWORD" "0"
+    Add-Reg "HKLM\TempDefault\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "DisablePreviewDesktop" "REG_DWORD" "1"
+    Add-Reg "HKLM\TempDefault\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "IconsOnly" "REG_DWORD" "1"
+
+    # Unload Hive
+    [gc]::Collect() # Force garbage collection to release handles
+    reg unload "HKLM\TempDefault" | Out-Null
+    Write-Host "Default User settings updated."
+} else {
+    Write-Error "Failed to load Default User hive."
+}
+
+# ==========================================
+# 4. Power Settings
+# ==========================================
+Write-Host "Configuring Power Settings..."
+powercfg /change monitor-timeout-ac 0
+powercfg /change disk-timeout-ac 0
+powercfg /change standby-timeout-ac 0
+powercfg /change hibernate-timeout-ac 0
+powercfg -X -monitor-timeout-ac 0
+powercfg -X -standby-timeout-ac 0
+powercfg -X -hibernate-timeout-ac 0
+powercfg -H OFF
+
+Write-Host "Restarting Explorer to apply changes..."
+Get-Process explorer -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+
+Write-Host '>>> Applying Windows optimization completed'

--- a/hack/windows-ci-image/packer/source.pkr.hcl
+++ b/hack/windows-ci-image/packer/source.pkr.hcl
@@ -1,0 +1,30 @@
+source "azure-arm" "minikube-ci-windows-11" {
+  subscription_id    = var.minikube_subscription_id
+  use_azure_cli_auth = true
+
+  # TODO: Does SIG-Windows grant us permission to allow Packer create/delete temporary resource group for build?
+  build_resource_group_name = var.minikube_resource_group
+
+  image_publisher = "MicrosoftWindowsDesktop"
+  image_offer     = "Windows-11"
+  image_sku       = "win11-25h2-pro"
+
+  vm_size        = "Standard_D2s_v3"
+  os_type        = "Windows"
+  communicator   = "winrm"
+  winrm_use_ssl  = true
+  winrm_insecure = true
+  winrm_timeout  = "5m"
+  winrm_username = var.vm_admin_username
+  winrm_password = var.vm_admin_password
+
+  shared_image_gallery_destination {
+    subscription            = var.minikube_subscription_id
+    resource_group          = var.minikube_resource_group
+    gallery_name            = var.minikube_shared_image_gallery
+    image_name              = var.vm_image_name
+    image_version           = var.vm_image_version
+    use_shallow_replication = true # https://learn.microsoft.com/en-us/azure/virtual-machines/shared-image-galleries#shallow-replication
+    specialized             = true # https://learn.microsoft.com/en-us/azure/virtual-machines/shared-image-galleries#generalized-and-specialized-images
+  }
+}

--- a/hack/windows-ci-image/packer/variables.pkr.hcl
+++ b/hack/windows-ci-image/packer/variables.pkr.hcl
@@ -1,0 +1,37 @@
+variable "minikube_subscription_id" {
+  description = "Identifier (GUID) of Azure subscription containing the resource group."
+  type        = string
+}
+
+variable "minikube_resource_group" {
+  description = "Name of Azure resource group where Packer will run Azure Image Builder and where is the Shared Image Gallery (SIG)."
+  type        = string
+}
+
+variable "minikube_shared_image_gallery" {
+  description = "Name of Azure Shared Image Gallery (SIG) to publish the VM image."
+  type        = string
+}
+
+variable "vm_image_name" {
+  description = "Name of the image build to be publish in the Shared Image Gallery (SIG) and referenced to create VM from it."
+  type        = string
+}
+
+variable "vm_image_version" {
+  description = "Version of the image build to be publish in the Shared Image Gallery (SIG) and referenced to create VM from it."
+  type        = string
+}
+
+variable "vm_admin_username" {
+  type = string
+}
+
+variable "vm_admin_password" {
+  type = string
+}
+
+variable "vm_admin_ssh_public_key" {
+  description = "Content of SSH public key to be deployed to VM image for admin authentication (base64-encoded PEM)."
+  type        = string
+}

--- a/hack/windows-ci-image/scripts/az-vm-delete.sh
+++ b/hack/windows-ci-image/scripts/az-vm-delete.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+VM_ID_OR_NAME="$1"
+[ -z "${VM_ID_OR_NAME}" ] && { echo "VM id or name is empty"; exit 1; }
+
+if [ "${VM_ID_OR_NAME:0:13}" = /subscription ]; then
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Deleting VM ${VM_ID_OR_NAME}"
+  VM_ID="${VM_ID_OR_NAME}"
+elif [ "${VM_ID_OR_NAME:0:13}" != /subscription ]; then
+  VM_RG="$2"
+  [ -z "${VM_RG}" ] && VM_RG="${MINIKUBE_AZ_RESOURCE_GROUP}"
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Deleting VM ${VM_ID_OR_NAME} in ${VM_RG}"
+  VM_ID="$(az vm show --resource-group "${VM_RG}" --name "${VM_ID_OR_NAME}" --query "id" --output tsv)"
+else
+  echo "Usage: $(basename "${0}") <VM id>"
+  echo "Usage: $(basename "${0}") <VM name> <VM resource group name>"
+  exit 1
+fi
+
+VM_OSDISK_ON_PARENT_DELETE=$(az vm show --ids "${VM_ID}" --query 'storageProfile.osDisk.deleteOption' --output tsv)
+if [ "${VM_OSDISK_ON_PARENT_DELETE}" != "Delete" ]; then
+    VM_OSDISK=$(az vm show --ids "${VM_ID}" --query 'storageProfile.osDisk.name' --output tsv)
+fi
+VM_NIC_ON_PARENT_DELETE=$(az vm show --ids "${VM_ID}" --query 'networkProfile.networkInterfaces[].deleteOption' --output tsv)
+VM_PIP_ON_PARENT_DELETE=${VM_NIC_ON_PARENT_DELETE}
+if [ "${VM_NIC_ON_PARENT_DELETE}" != "Delete" ]; then
+  VM_NIC=$(az vm show --ids "${VM_ID}" --query 'networkProfile.networkInterfaces[].id' --output tsv)
+  VM_PIP_ON_PARENT_DELETE=$(az network nic show --ids "${VM_NIC}" --query 'ipConfigurations[].publicIPAddress.deleteOption' --output tsv)
+  if [ "${VM_PIP_ON_PARENT_DELETE}" != "Delete" ]; then
+    VM_PIP=$(az network nic show --ids "${VM_NIC}" --query 'ipConfigurations[].publicIPAddress.id' --output tsv)
+  fi
+fi
+
+set | grep -E "^VM_*" | sort
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] Deleting VM: ${VM_ID}"
+az vm delete --ids "${VM_ID}" --yes
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] Deleting VM done"
+
+if [ -n "${VM_OSDISK}" ]; then
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Deleting OSDisk: ${VM_OSDISK}"
+  az disk delete --ids "${VM_OSDISK}" --yes
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Deleting OSDisk done"
+fi
+
+if [ -n "${VM_NIC}" ]; then
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Deleting NIC: ${VM_NIC}"
+  az network nic delete --ids "${VM_NIC}" # --yes not available
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Deleting done"
+fi
+
+if [ -n "${VM_PIP}" ]; then
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Deleting PIP: ${VM_PIP}"
+  az network public-ip delete --ids "${VM_PIP}" # --yes not available
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Deleting PIP done"
+fi

--- a/hack/windows-ci-image/sig.bicep
+++ b/hack/windows-ci-image/sig.bicep
@@ -1,0 +1,43 @@
+targetScope = 'resourceGroup'
+
+// sig.bicepparam
+@sys.description('Name of the new VM image definition to create in the newly created Shared Image Gallery.')
+param sigImageDefinitionName string
+@sys.description('Name of the new Shared Image Gallery to create')
+param sigName string
+
+var location string = resourceGroup().location
+var imageOffer string = 'minikube-ci'
+var imagePublisher string = 'kubernetes'
+
+resource sig 'Microsoft.Compute/galleries@2024-03-03' = {
+  name: sigName
+  location: location
+  tags: { owner: 'minikube' }
+  properties: {
+    description: 'Gallery for Minikube VM images'
+    identifier: {}
+  }
+}
+
+resource image 'Microsoft.Compute/galleries/images@2024-03-03' = {
+  location: location
+  name: sigImageDefinitionName
+  parent: sig
+  tags: { owner: 'minikube' }
+  properties: {
+    description: 'Minimal Windows 11 image for Minikube CI'
+    identifier: {
+      publisher: imagePublisher
+      offer: imageOffer
+      sku: 'windows-11'
+    }
+    architecture: 'x64'
+    hyperVGeneration: 'V2'
+    osState: 'Specialized'
+    osType: 'Windows'
+  }
+}
+
+output sigId string = sig.id
+output sigImageDefinitionId string = image.id

--- a/hack/windows-ci-image/sig.bicepparam
+++ b/hack/windows-ci-image/sig.bicepparam
@@ -1,0 +1,4 @@
+using './sig.bicep'
+
+param sigImageDefinitionName = readEnvironmentVariable('MINIKUBE_AZ_IMAGE_NAME')
+param sigName = readEnvironmentVariable('MINIKUBE_AZ_SIG_NAME')

--- a/hack/windows-ci-image/vm.bicepparam
+++ b/hack/windows-ci-image/vm.bicepparam
@@ -1,10 +1,14 @@
 using './vm.bicep'
 
-// Azure Shared Image Gallery
+// Pre-existing Azure Shared Image Gallery (see sig.bicepparam)
 param sigName = readEnvironmentVariable('MINIKUBE_AZ_SIG_NAME')
 param sigImageDefinitionName = readEnvironmentVariable('MINIKUBE_AZ_IMAGE_NAME') // same as image name by convention
 param sigImageVersion = readEnvironmentVariable('MINIKUBE_AZ_IMAGE_VERSION') // or 'latest'
 
+// Pre-existing Azure Virtual Network (see vnet.bicepparam)
+param networkNsgName = 'nsg-minikube-ci'
+param networkVnetName = 'vnet-minikube-ci'
+
 // Azure Virtual Machine
 param vmName = 'vm-minikube-ci'
-param vmSize = 'Standard_D16s_v3'
+param vmSize = 'Standard_D2s_v3'

--- a/hack/windows-ci-image/vnet.bicep
+++ b/hack/windows-ci-image/vnet.bicep
@@ -1,0 +1,75 @@
+targetScope = 'resourceGroup'
+
+// vnet.bicepparam
+@sys.description('Name of new Network Security Group to create and where the new VMs will be associated.')
+param networkNsgName string
+@sys.description('Name of new Virtual Network to create and where the new VMs will be attached.')
+param networkVnetName string
+
+var location string = resourceGroup().location
+var subnetName string = '${networkVnetName}-snet'
+
+resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
+  name: networkNsgName
+  location: location
+  tags: { owner: 'minikube' }
+  properties: {
+    securityRules: [
+      {
+        name: 'AllowRDP'
+        properties: {
+          access: 'Allow'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '3389'
+          direction: 'Inbound'
+          priority: 1000
+          protocol: 'Tcp'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+        }
+      }
+      {
+        name: 'AllowSSH'
+        properties: {
+          access: 'Allow'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '22'
+          direction: 'Inbound'
+          priority: 1001
+          protocol: 'Tcp'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+        }
+      }
+    ]
+  }
+}
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
+  name: networkVnetName
+  location: location
+  tags: { owner: 'minikube' }
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+    subnets: [
+      {
+        name: subnetName
+        properties: {
+          addressPrefix: '10.0.1.0/24'
+          networkSecurityGroup: {
+            id: networkSecurityGroup.id
+          }
+        }
+      }
+    ]
+  }
+}
+
+output vmVirtualNetworkId string = virtualNetwork.id
+output vmVirtualNetworkName string = virtualNetwork.name
+output vmSubnetId string = '${virtualNetwork.id}/subnets/${subnetName}'
+output vmSubnetName string = subnetName

--- a/hack/windows-ci-image/vnet.bicepparam
+++ b/hack/windows-ci-image/vnet.bicepparam
@@ -1,0 +1,5 @@
+using './vnet.bicep'
+
+// TODO(mloskot): Move to https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/patterns-shared-variable-file
+param networkNsgName = 'nsg-minikube-ci'
+param networkVnetName = 'vnet-minikube-ci'


### PR DESCRIPTION
An ongoing work in progress from https://github.com/mloskot/minikube-windows-image with my part of collaboration with @medyagh related these items
- #22483 
- #22534

## Idea

The `README.md` explains more, but the grand idea is to build golden image based on Windows 11 as a common Windows flavour used by Minikube users. The golden image allows to create VM with reproducible environment fast, in 15-20 seconds on Azure. 

## Solution

This solution is dedicated to Azure infrastructure, because it targets Azure space provided by SIG-Cluster-Lifecycle/SIG-Windows, so this PR includes Bicep templates for the four GHA workflows:
1. Deploy Azure Shared Image Gallery (ASIG)
2. Build VM image on Azure Image Builder (AIB) using Packer, and publish it to Azure Shared Image Gallery
3. Deploy Azure Virtual Network required to run VMs
4. Deploy a test Azure Virtual Machine as a test of the whole setup

The idea is to configure GHA for at least the workflows 1-3 and run them on schedule.

The VM image is provisioned with the following
- [x] Hyper-V
- [x] Chocolatey
- [x] Docker Engine (fully non-interactive installation and use of Docker Desktop seems impossible)
- [x] Kubernetes CLI
- [ ] ...

TODO: Complete content of the VM image with Minikube-specific tools that are missing

## Future

- Build common **base golden image** with Windows 11 optimizations applied and bloatware removed
- Based on the base golden image, build two flavours of the VM image: `*-hyperv` and `*-wsl`
- Export the VM image outside Azure, as VHD or Vagrant box, to make it usable with other hypervisors.
- ...

------

# Showcasing this work

This work can be seen in action in my personal:

- https://github.com/mloskot/minikube-windows-image
- https://github.com/mloskot/minikube-windows-image/actions