### PR TITLE
Support docker-env with cri-o runtime

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -2100,3 +2100,20 @@ func startNerdctld(options *run.CommandOptions) {
 		exit.Error(reason.StartNerdctld, fmt.Sprintf("Failed to set up DOCKER_HOST: %s", rest.Output()), err)
 	}
 }
+
+func startPodmand(options *run.CommandOptions) {
+	co := mustload.Running(ClusterFlagValue(), options)
+	runner := co.CP.Runner
+
+	// sudo systemctl start podman.socket
+	if rest, err := runner.RunCmd(exec.Command("sudo", "systemctl", "start", "podman.socket")); err != nil {
+		exit.Error(reason.StartPodmand, fmt.Sprintf("Failed to enable podman.socket: %s", rest.Output()), err)
+	}
+
+	// set up environment variable on remote machine. docker client uses 'non-login & non-interactive shell' therefore the only way is to modify .bashrc file of user 'docker'
+	// insert this at 4th line
+	envSetupCommand := exec.Command("/bin/bash", "-c", "sed -i '4i export DOCKER_HOST=unix:///run/podman/podman.sock' .bashrc")
+	if rest, err := runner.RunCmd(envSetupCommand); err != nil {
+		exit.Error(reason.StartPodmand, fmt.Sprintf("Failed to set up DOCKER_HOST: %s", rest.Output()), err)
+	}
+}

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -102,6 +102,8 @@ var (
 	InternalCommandRunner = Kind{ID: "MK_COMMAND_RUNNER", ExitCode: ExProgramError}
 	// minikube failed to start nerdctld
 	StartNerdctld = Kind{ID: "MK_START_NERDCTLD", ExitCode: ExProgramError}
+	// minikube failed to start podmand
+	StartPodmand = Kind{ID: "MK_START_PODMAND", ExitCode: ExProgramError}
 	// minikube failed to generate shell command completion for a supported shell
 	InternalCompletion = Kind{ID: "MK_COMPLETION", ExitCode: ExProgramError}
 	// minikube failed to set an internal config value


### PR DESCRIPTION
It is very similar to containerd, but with podman for cri-o instead of nerdctl for containerd. Both using ssh sockets.

* https://github.com/kubernetes/minikube/issues/15461

There are plenty of refactoring opportunities (this is just copy/paste), for merging the nerdctl and podman support.

* https://github.com/kubernetes/minikube/issues/22509

----

This will use BuildKit in a podman container, by default:

```
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
...
 => => pulling image moby/buildkit:buildx-stable-1
 => => creating container buildx_buildkit_default   
```

To switch to the legacy buildah, use DOCKER_BUILDKIT=0:

```
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
            environment-variable.
....
```