### PR TITLE
ISO: add nerdctld

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ KIC_VERSION ?= $(shell grep -E "Version =" pkg/drivers/kic/types.go | cut -d \" 
 HUGO_VERSION ?= $(shell grep -E "HUGO_VERSION = \"" netlify.toml | cut -d \" -f2)
 
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
-ISO_VERSION ?= v1.37.0-1768831230-22464
+ISO_VERSION ?= v1.37.0-1769464293-22548
 
 # Dashes are valid in semver, but not Linux packaging. Use ~ to delimit alpha/beta
 DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))

--- a/deploy/iso/minikube-iso/arch/aarch64/package/Config.in
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/Config.in
@@ -7,4 +7,5 @@ menu "System tools aarch64"
     source "$BR2_EXTERNAL_MINIKUBE_PATH/arch/aarch64/package/docker-bin-aarch64/Config.in"
     source "$BR2_EXTERNAL_MINIKUBE_PATH/arch/aarch64/package/docker-buildx-aarch64/Config.in"
     source "$BR2_EXTERNAL_MINIKUBE_PATH/arch/aarch64/package/nerdctl-bin-aarch64/Config.in"
+    source "$BR2_EXTERNAL_MINIKUBE_PATH/arch/aarch64/package/nerdctld-bin-aarch64/Config.in"
 endmenu

--- a/deploy/iso/minikube-iso/arch/aarch64/package/nerdctld-bin-aarch64/Config.in
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/nerdctld-bin-aarch64/Config.in
@@ -1,0 +1,4 @@
+config BR2_PACKAGE_NERDCTLD_BIN_AARCH64
+        bool "nerdctld-bin"
+        default y
+        depends on BR2_aarch64

--- a/deploy/iso/minikube-iso/arch/aarch64/package/nerdctld-bin-aarch64/nerdctl.service
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/nerdctld-bin-aarch64/nerdctl.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=nerdctl
+Requires=nerdctl.socket containerd.service
+After=nerdctl.socket containerd.service
+Documentation=https://github.com/containerd/nerdctl
+
+[Service]
+Type=notify
+Environment=CONTAINERD_NAMESPACE=default
+ExecStart=nerdctld --addr fd://
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/iso/minikube-iso/arch/aarch64/package/nerdctld-bin-aarch64/nerdctl.socket
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/nerdctld-bin-aarch64/nerdctl.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=nerdctl
+Documentation=https://github.com/containerd/nerdctl
+
+[Socket]
+ListenStream=%t/nerdctl.sock
+SocketMode=0660
+
+[Install]
+WantedBy=sockets.target

--- a/deploy/iso/minikube-iso/arch/aarch64/package/nerdctld-bin-aarch64/nerdctld-bin.hash
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/nerdctld-bin-aarch64/nerdctld-bin.hash
@@ -1,0 +1,1 @@
+sha256 e1aff93f3296a36059e2f00baa8cadfc755fcfa640ccd67f25d1a34090e59d1f  nerdctld-0.7.0-linux-arm64.tar.gz

--- a/deploy/iso/minikube-iso/arch/aarch64/package/nerdctld-bin-aarch64/nerdctld-bin.mk
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/nerdctld-bin-aarch64/nerdctld-bin.mk
@@ -1,0 +1,39 @@
+################################################################################
+#
+# nerdctld-bin
+#
+################################################################################
+
+NERDCTLD_BIN_AARCH64_VERSION = 0.7.0
+NERDCTLD_BIN_AARCH64_SITE = https://github.com/afbjorklund/nerdctld/releases/download/v$(NERDCTLD_BIN_AARCH64_VERSION)
+NERDCTLD_BIN_AARCH64_SOURCE = nerdctld-$(NERDCTLD_BIN_AARCH64_VERSION)-linux-arm64.tar.gz
+NERDCTLD_BIN_AARCH64_STRIP_COMPONENTS = 0
+
+define NERDCTLD_BIN_AARCH64_USERS
+	- -1 nerdctl -1 - - - - -
+endef
+
+define NERDCTLD_BIN_AARCH64_INSTALL_TARGET_CMDS
+        $(INSTALL) -D -m 0755 \
+                $(@D)/nerdctld \
+                $(TARGET_DIR)/usr/bin/nerdctld
+endef
+
+define NERDCTLD_BIN_AARCH64_INSTALL_INIT_SYSTEMD
+	$(INSTALL) -D -m 644 \
+			$(NERDCTLD_BIN_AARCH64_PKGDIR)/nerdctl.service \
+			$(TARGET_DIR)/usr/lib/systemd/system/nerdctl.service
+	$(INSTALL) -D -m 644 \
+			$(NERDCTLD_BIN_AARCH64_PKGDIR)/nerdctl.socket\
+			$(TARGET_DIR)/usr/lib/systemd/system/nerdctl.socket
+
+	# Allow running docker as a user in the group "nerdctl"
+	mkdir -p $(TARGET_DIR)/usr/lib/systemd/system/nerdctl.socket.d
+	printf "[Socket]\nSocketMode=0660\nSocketGroup=nerdctl\n" \
+	       > $(TARGET_DIR)/usr/lib/systemd/system/nerdctl.socket.d/override.conf
+	mkdir -p $(TARGET_DIR)/usr/lib/systemd/system/nerdctl.service.d
+	printf "[Service]\nEnvironment=CONTAINERD_NAMESPACE=k8s.io\n" \
+	       > $(TARGET_DIR)/usr/lib/systemd/system/nerdctl.service.d/override.conf
+endef
+
+$(eval $(generic-package))

--- a/deploy/iso/minikube-iso/arch/x86_64/package/Config.in
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/Config.in
@@ -8,5 +8,6 @@ menu "System tools x86_64"
     source "$BR2_EXTERNAL_MINIKUBE_PATH/arch/x86_64/package/docker-buildx/Config.in"
     source "$BR2_EXTERNAL_MINIKUBE_PATH/arch/x86_64/package/hyperv-daemons/Config.in"
     source "$BR2_EXTERNAL_MINIKUBE_PATH/arch/x86_64/package/nerdctl-bin/Config.in"
+    source "$BR2_EXTERNAL_MINIKUBE_PATH/arch/x86_64/package/nerdctld-bin/Config.in"
     source "$BR2_EXTERNAL_MINIKUBE_PATH/arch/x86_64/package/vbox-mount-service/Config.in"
 endmenu

--- a/deploy/iso/minikube-iso/arch/x86_64/package/nerdctld-bin/Config.in
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/nerdctld-bin/Config.in
@@ -1,0 +1,4 @@
+config BR2_PACKAGE_NERDCTLD_BIN
+        bool "nerdctld-bin"
+        default y
+        depends on BR2_x86_64

--- a/deploy/iso/minikube-iso/arch/x86_64/package/nerdctld-bin/nerdctl.service
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/nerdctld-bin/nerdctl.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=nerdctl
+Requires=nerdctl.socket containerd.service
+After=nerdctl.socket containerd.service
+Documentation=https://github.com/containerd/nerdctl
+
+[Service]
+Type=notify
+Environment=CONTAINERD_NAMESPACE=default
+ExecStart=nerdctld --addr fd://
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/iso/minikube-iso/arch/x86_64/package/nerdctld-bin/nerdctl.socket
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/nerdctld-bin/nerdctl.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=nerdctl
+Documentation=https://github.com/containerd/nerdctl
+
+[Socket]
+ListenStream=%t/nerdctl.sock
+SocketMode=0660
+
+[Install]
+WantedBy=sockets.target

--- a/deploy/iso/minikube-iso/arch/x86_64/package/nerdctld-bin/nerdctld-bin.hash
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/nerdctld-bin/nerdctld-bin.hash
@@ -1,0 +1,1 @@
+sha256 f826f84ed8ce67b9cbe2fbcb58e9edbfba05d65d025cf0e6cdc68db2ab8a58ec  nerdctld-0.7.0-linux-amd64.tar.gz

--- a/deploy/iso/minikube-iso/arch/x86_64/package/nerdctld-bin/nerdctld-bin.mk
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/nerdctld-bin/nerdctld-bin.mk
@@ -1,0 +1,39 @@
+################################################################################
+#
+# nerdctld-bin
+#
+################################################################################
+
+NERDCTLD_BIN_VERSION = 0.7.0
+NERDCTLD_BIN_SITE = https://github.com/afbjorklund/nerdctld/releases/download/v$(NERDCTLD_BIN_VERSION)
+NERDCTLD_BIN_SOURCE = nerdctld-$(NERDCTLD_BIN_VERSION)-linux-amd64.tar.gz
+NERDCTLD_BIN_STRIP_COMPONENTS = 0
+
+define NERDCTLD_BIN_USERS
+	- -1 nerdctl -1 - - - - -
+endef
+
+define NERDCTLD_BIN_INSTALL_TARGET_CMDS
+        $(INSTALL) -D -m 0755 \
+                $(@D)/nerdctld \
+                $(TARGET_DIR)/usr/bin/nerdctld
+endef
+
+define NERDCTLD_BIN_INSTALL_INIT_SYSTEMD
+	$(INSTALL) -D -m 644 \
+			$(NERDCTLD_BIN_PKGDIR)/nerdctl.service \
+			$(TARGET_DIR)/usr/lib/systemd/system/nerdctl.service
+	$(INSTALL) -D -m 644 \
+			$(NERDCTLD_BIN_PKGDIR)/nerdctl.socket\
+			$(TARGET_DIR)/usr/lib/systemd/system/nerdctl.socket
+
+	# Allow running docker as a user in the group "nerdctl"
+	mkdir -p $(TARGET_DIR)/usr/lib/systemd/system/nerdctl.socket.d
+	printf "[Socket]\nSocketMode=0660\nSocketGroup=nerdctl\n" \
+	       > $(TARGET_DIR)/usr/lib/systemd/system/nerdctl.socket.d/override.conf
+	mkdir -p $(TARGET_DIR)/usr/lib/systemd/system/nerdctl.service.d
+	printf "[Service]\nEnvironment=CONTAINERD_NAMESPACE=k8s.io\n" \
+	       > $(TARGET_DIR)/usr/lib/systemd/system/nerdctl.service.d/override.conf
+endef
+
+$(eval $(generic-package))

--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -41,7 +41,7 @@ const fileScheme = "file"
 // DefaultISOURLs returns a list of ISO URL's to consult by default, in priority order
 func DefaultISOURLs() []string {
 	v := version.GetISOVersion()
-	isoBucket := "minikube-builds/iso/22464"
+	isoBucket := "minikube-builds/iso/22548"
 
 	return []string{
 		fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s-%s.iso", isoBucket, v, runtime.GOARCH),


### PR DESCRIPTION
Matching the kicbase installation, and the "podman" package.

The systemd units are from upstream git, but not in tarball.

----

Using the same duplicated install as nerdctl, to be fixed later:

* https://github.com/kubernetes/minikube/issues/22135