### PR TITLE
Allow nerdctld on any driver

### DIFF
--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -675,10 +675,6 @@ func dockerEnvSupported(containerRuntime, driverName string) error {
 	if containerRuntime != constants.Docker && containerRuntime != constants.Containerd {
 		return fmt.Errorf("the docker-env command only supports the docker and containerd runtimes")
 	}
-	// we only support containerd-env on the Docker driver
-	if containerRuntime == constants.Containerd && driverName != driver.Docker {
-		return fmt.Errorf("the docker-env command only supports the containerd runtime with the docker driver")
-	}
 	return nil
 }
 


### PR DESCRIPTION
It is already in the kicbase, and on the way for iso as well.

* https://github.com/kubernetes/minikube/pull/22547

* https://github.com/kubernetes/minikube/pull/22548
 
No need for artificial restrictions, it will fail if missing.

* https://github.com/kubernetes/minikube/issues/22509


