### PR TITLE
Deprecate podman-env, use docker-env instead

### DIFF
--- a/cmd/minikube/cmd/podman-env.go
+++ b/cmd/minikube/cmd/podman-env.go
@@ -174,6 +174,8 @@ var podmanEnvCmd = &cobra.Command{
 				out.V{"runtime": co.Config.KubernetesConfig.ContainerRuntime})
 		}
 
+		out.WarningT("Using the podman-env command is deprecated, use docker-env for all container runtimes")
+
 		r := co.CP.Runner
 		if ok := isPodmanAvailable(r); !ok {
 			exit.Message(reason.EnvPodmanUnavailable, `The podman service within '{{.cluster}}' is not active`, out.V{"cluster": cname})


### PR DESCRIPTION
The libpod socket is not used much, use compat socket instead.

* https://github.com/kubernetes/minikube/issues/15461

Avoids trying to synch the podman-remote with the cri-o cluster.

* https://github.com/kubernetes/minikube/pull/22547

----

There is also all kinds of "varlink" code and other things, to remove:

https://podman.io/blogs/2020/08/01/deprecate-and-remove-varlink-notice

And eventually remove the "podman" group, and the overrides for it

* https://github.com/kubernetes/minikube/issues/22360