### PR TITLE
test: add fallback to copy and delete for cross-device `os.Rename` fa…

### DIFF
--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -297,6 +297,8 @@ func TestBinaryMirror(t *testing.T) {
 	}
 
 	newBinaryPath := filepath.Join(newBinaryDir, binaryName)
+	// Usage of os.Rename might result in "invalid cross-device link" error if the files are not on the same partition.
+	// In that case, we fall back to copying the file.
 	if err := os.Rename(binaryPath, newBinaryPath); err != nil {
 		t.Logf("os.Rename failed, falling back to copy (likely cross-device): %v", err)
 		if err := mcnutils.CopyFile(binaryPath, newBinaryPath); err != nil {


### PR DESCRIPTION
this test fails in prow

```
{Failed  === RUN   TestBinaryMirror
I0125 21:40:45.171858   36259 binary.go:79] Not caching binary, using https://dl.k8s.io/release/v1.35.0/bin/linux/amd64/kubectl?checksum=file:https://dl.k8s.io/release/v1.35.0/bin/linux/amd64/kubectl.sha256
    aaa_download_only_test.go:300: Failed to move binary file: rename /home/prow/go/src/k8s.io/minikube/1d3ad5e96184e32ca7e8a36d6e45273d07c47fc1-31380/.minikube/cache/linux/amd64/v1.35.0/kubectl /tmp/TestBinaryMirror2935667422/001/v1.35.0/bin/linux/amd64/kubectl: invalid cross-device link
    aaa_download_only_test.go:309: (dbg) Run:  out/minikube-linux-amd64 start --download-only -p binary-mirror-849738 --alsologtostderr --binary-mirror http://127.0.0.1:43221 --driver=docker  --container-runtime=containerd
    helpers_test.go:185: Cleaning up "binary-mirror-849738" profile ...
    helpers_test.go:188: (dbg) Run:  out/minikube-linux-amd64 delete -p binary-mirror-849738
--- FAIL: TestBinaryMirror (0.16s
```

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/minikube/22551/integration-docker-containerd-linux-x86/2015539493632741376