### PR TITLE
docker-env: change --ssh-host login as root

### DIFF
--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -384,6 +384,11 @@ docker-cli install instructions: https://minikube.sigs.k8s.io/docs/tutorials/doc
 			sshAgentPID: co.Config.SSHAgentPID,
 		}
 
+		if sshHost == true {
+			ec.username = "root"
+			sshAdd = true
+		}
+
 		dockerPath, err := exec.LookPath("docker")
 		if err != nil {
 			klog.Warningf("Unable to find docker in path - skipping connectivity check: %v", err)
@@ -425,10 +430,8 @@ docker-cli install instructions: https://minikube.sigs.k8s.io/docs/tutorials/doc
 			}
 
 			// TODO: refactor to work with docker, temp fix to resolve regression
-			if cr == constants.Containerd {
-				// eventually, run something similar to ssh --append-known
-				appendKnownHelper(nodeName, true)
-			}
+			// eventually, run something similar to ssh --append-known
+			appendKnownHelper(nodeName, true)
 		}
 	},
 }

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -231,6 +231,7 @@ func (d *Driver) prepareSSH() error {
 	if err != nil {
 		return fmt.Errorf("create pubkey assetfile : %w", err)
 	}
+
 	defer func() {
 		if err := f.Close(); err != nil {
 			klog.Warningf("error closing the file %s: %v", f.GetSourcePath(), err)
@@ -238,7 +239,7 @@ func (d *Driver) prepareSSH() error {
 	}()
 
 	if err := cmder.Copy(f); err != nil {
-		return fmt.Errorf("copying pub key: %w", err)
+		return fmt.Errorf("copying pub key in /home/docker/.ssh/: %w", err)
 	}
 
 	// Double-check that the container has not crashed so that we may give a better error message

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -231,7 +231,6 @@ func (d *Driver) prepareSSH() error {
 	if err != nil {
 		return fmt.Errorf("create pubkey assetfile : %w", err)
 	}
-
 	defer func() {
 		if err := f.Close(); err != nil {
 			klog.Warningf("error closing the file %s: %v", f.GetSourcePath(), err)
@@ -239,7 +238,7 @@ func (d *Driver) prepareSSH() error {
 	}()
 
 	if err := cmder.Copy(f); err != nil {
-		return fmt.Errorf("copying pub key in /home/docker/.ssh/: %w", err)
+		return fmt.Errorf("copying pub key: %w", err)
 	}
 
 	// Double-check that the container has not crashed so that we may give a better error message

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -135,7 +135,11 @@ func configureAuth(p miniProvisioner) error {
 		return fmt.Errorf("error generating server cert: %v", err)
 	}
 
-	return copyRemoteCerts(authOptions, driver)
+	if err := copyRemoteCerts(authOptions, driver); err != nil {
+		return err
+	}
+
+	return configureRootSSH(p)
 }
 
 func copyHostCerts(authOptions auth.Options) error {
@@ -209,6 +213,14 @@ func copyRemoteCerts(authOptions auth.Options, driver drivers.Driver) error {
 		}
 	}
 
+	return nil
+}
+
+func configureRootSSH(p miniProvisioner) error {
+	cmd := "sudo mkdir -p /root/.ssh && sudo cp /home/docker/.ssh/authorized_keys /root/.ssh/authorized_keys && sudo chown -R root:root /root/.ssh"
+	if _, err := p.SSHCommand(cmd); err != nil {
+		return fmt.Errorf("configure root SSH: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
Before for KIC driver for docker-runtime:
```
bhavya@bhavyaBeliever:~/btech/project/minikube$ minikube docker-env --ssh-host
export DOCKER_HOST="ssh://docker@127.0.0.1:32783"
export MINIKUBE_ACTIVE_DOCKERD="minikube"

# To point your shell to minikube's docker-daemon, run:
# eval $(minikube -p minikube docker-env --ssh-host)
```
After:
```
bhavya@bhavyaBeliever:~/btech/project/minikube$ ./out/minikube docker-env --ssh-host
export DOCKER_HOST="ssh://root@127.0.0.1:32783"
export MINIKUBE_ACTIVE_DOCKERD="minikube"

# To point your shell to minikube's docker-daemon, run:
# eval $(minikube -p minikube docker-env --ssh-host)

bhavya@bhavyaBeliever:~/btech/project/minikube$ eval $(./out/minikube docker-env --ssh-host)

bhavya@bhavyaBeliever:~/btech/project/minikube$ docker ps
CONTAINER ID   IMAGE                          COMMAND                  CREATED       STATUS       PORTS     NAMES
58f8adee15b7   6e38f40d628d                   "/storage-provisioner"   2 hours ago   Up 2 hours             k8s_storage-provisioner_storage-provisioner_kube-system_74e03f84-e660-493b-9c77-3996c63ec53f_1
6eb150a830d7   registry.k8s.io/pause:3.10.1   "/pause"                 2 hours ago   Up 2 hours             k8s_POD_storage-provisioner_kube-system_74e03f84-e660-493b-9c77-3996c63ec53f_0
76533e04dfa1   aa5e3ebc0dfe                   "/coredns -conf /etc…"   2 hours ago   Up 2 hours             k8s_coredns_coredns-7d764666f9-gx8gm_kube-system_cce9e4c3-4d1e-455b-ac09-4f1553567b85_0
...
```

Before For VM (kvm2) driver for docker-runtime: 
```bhavya@bhavyaBeliever:~/btech/project/minikube$ minikube profile list
┌──────────┬────────┬─────────┬────────────────┬─────────┬────────┬───────┬────────────────┬────────────────────┐
│ PROFILE  │ DRIVER │ RUNTIME │       IP       │ VERSION │ STATUS │ NODES │ ACTIVE PROFILE │ ACTIVE KUBECONTEXT │
├──────────┼────────┼─────────┼────────────────┼─────────┼────────┼───────┼────────────────┼────────────────────┤
│ minikube │ kvm2   │ docker  │ 192.168.39.165 │ v1.34.0 │ OK     │ 1     │ *              │ *                  │
└──────────┴────────┴─────────┴────────────────┴─────────┴────────┴───────┴────────────────┴────────────────────┘
bhavya@bhavyaBeliever:~/btech/project/minikube$ eval $(minikube docker-env --ssh-host)

bhavya@bhavyaBeliever:~/btech/project/minikube$ docker ps
error during connect: Get "http://docker.example.com/v1.53/containers/json": command [ssh -l docker -p 22 -o ConnectTimeout=30 -T -- 192.168.39.165 docker system dial-stdio] has exited with exit status 255, make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or directory
Host key verification failed.
```
After:
```
bhavya@bhavyaBeliever:~/btech/project/minikube$ ./out/minikube docker-env --ssh-host
export DOCKER_HOST="ssh://root@192.168.39.61:22"
export MINIKUBE_ACTIVE_DOCKERD="minikube"

# To point your shell to minikube's docker-daemon, run:
# eval $(minikube -p minikube docker-env --ssh-host)
Identity added: /home/bhavya/.minikube/machines/minikube/id_rsa (/home/bhavya/.minikube/machines/minikube/id_rsa)
Host added: /home/bhavya/.ssh/known_hosts (192.168.39.61)
bhavya@bhavyaBeliever:~/btech/project/minikube$ eval $(./out/minikube docker-env --ssh-host)
Identity added: /home/bhavya/.minikube/machines/minikube/id_rsa (/home/bhavya/.minikube/machines/minikube/id_rsa)

bhavya@bhavyaBeliever:~/btech/project/minikube$ docker ps
CONTAINER ID   IMAGE                          COMMAND                  CREATED          STATUS          PORTS     NAMES
5b5b163f36db   6e38f40d628d                   "/storage-provisioner"   10 seconds ago   Up 9 seconds              k8s_storage-provisioner_storage-provisioner_kube-system_da069fdf-7f20-4983-8f82-ce82daf8991c_1
168300ab68c5   6521110cdb01                   "/usr/local/bin/kube…"   40 seconds ago   Up 40 seconds             k8s_kube-proxy_kube-proxy-rbh8g_kube-system_ac4cca72-b0f1-4ea4-a93d-8a34e7a18cb6_0
...
```

Before for containerd runtime:
```
bhavya@bhavyaBeliever:~/btech/project/minikube$ minikube docker-env
❗  Using the docker-env command with the containerd runtime is a highly experimental feature, please provide feedback or contribute to make it better
export DOCKER_HOST="ssh://docker@127.0.0.1:32768"
export MINIKUBE_ACTIVE_DOCKERD="minikube"
export SSH_AUTH_SOCK="/tmp/ssh-AejB0xf0BXMm/agent.15030"
export SSH_AGENT_PID="15031"

# To point your shell to minikube's docker-daemon, run:
# eval $(minikube -p minikube docker-env --ssh-host)
Identity added: /home/bhavya/.minikube/machines/minikube/id_rsa (/home/bhavya/.minikube/machines/minikube/id_rsa)
Host added: /home/bhavya/.ssh/known_hosts ([127.0.0.1]:32768)
bhavya@bhavyaBeliever:~/btech/project/minikube$ eval $(minikube docker-env)
❗  Using the docker-env command with the containerd runtime is a highly experimental feature, please provide feedback or contribute to make it better
Identity added: /home/bhavya/.minikube/machines/minikube/id_rsa (/home/bhavya/.minikube/machines/minikube/id_rsa)
bhavya@bhavyaBeliever:~/btech/project/minikube$ docker ps
CONTAINER ID   IMAGE                                             COMMAND                  CREATED          STATUS    PORTS     NAMES
02632595d5e1   registry.k8s.io/pause:3.10.1                      "/pause"                 53 seconds ago   Up                  k8s://kube-system/etcd-minikube
0ffec6f18c43   registry.k8s.io/kube-apiserver:v1.34.0            "kube-apiserver --ad…"   52 seconds ago   Up                  k8s://kube-system/kube-apiserver-minikube/kube-apiserver
1dada935757b   kindest/kindnetd:v20250512-df8de77b               "/bin/kindnetd"          43 seconds ago   Up                  k8s://kube-system/kindnet-prnp8/kindnet-cni
...
```
After:
```
bhavya@bhavyaBeliever:~/btech/project/minikube$ ./out/minikube docker-env
❗  Using the docker-env command with the containerd runtime is a highly experimental feature, please provide feedback or contribute to make it better
export DOCKER_HOST="ssh://root@127.0.0.1:32773"
export MINIKUBE_ACTIVE_DOCKERD="minikube"
export SSH_AUTH_SOCK="/tmp/ssh-GFtWGd6689YW/agent.19593"
export SSH_AGENT_PID="19594"

# To point your shell to minikube's docker-daemon, run:
# eval $(minikube -p minikube docker-env --ssh-host)
Identity added: /home/bhavya/.minikube/machines/minikube/id_rsa (/home/bhavya/.minikube/machines/minikube/id_rsa)
bhavya@bhavyaBeliever:~/btech/project/minikube$ eval $(./out/minikube docker-env)
❗  Using the docker-env command with the containerd runtime is a highly experimental feature, please provide feedback or contribute to make it better
Identity added: /home/bhavya/.minikube/machines/minikube/id_rsa (/home/bhavya/.minikube/machines/minikube/id_rsa)
bhavya@bhavyaBeliever:~/btech/project/minikube$ docker ps
CONTAINER ID   IMAGE                                             COMMAND                  CREATED         STATUS    PORTS     NAMES
c8f84a7253f5   registry.k8s.io/coredns/coredns:v1.13.1           "/coredns -conf /etc…"   2 minutes ago   Up                  k8s://kube-system/coredns-7d764666f9-rgzdn/coredns
002723522430   gcr.io/k8s-minikube/storage-provisioner:v5        "/storage-provisioner"   2 minutes ago   Up                  k8s://kube-system/storage-provisioner/storage-provisioner
...
```
Fixes #22360 