### PR TITLE
ci: Fix release_notes.sh to generate PR links

### DIFF
--- a/hack/changelog/changelog.go
+++ b/hack/changelog/changelog.go
@@ -255,7 +255,7 @@ func printGroups(groups map[string][]*github.PullRequest) {
 			return ti < tj
 		})
 		for _, pr := range prs {
-			fmt.Printf("* %s (#%d)\n", pr.GetTitle(), pr.GetNumber())
+			fmt.Printf("* %s ([#%d](https://github.com/kubernetes/minikube/pull/%d))\n", pr.GetTitle(), pr.GetNumber(), pr.GetNumber())
 		}
 		fmt.Println()
 	}


### PR DESCRIPTION
Ref #22578

## Output example

Before:

```markdown
Addon Headlamp: Update Headlamp image from v0.35.0 to v0.36.0 (#21706)
```

After:

```markdown
Addon Headlamp: Update Headlamp image from v0.35.0 to v0.36.0 ([#21706](https://github.com/kubernetes/minikube/pull/21706))
```

Both will render exactly the same, that is:

Addon Headlamp: Update Headlamp image from v0.35.0 to v0.36.0 (#21706)    <--- [GitHub autolinking](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#issues-and-pull-requests) in action
Addon Headlamp: Update Headlamp image from v0.35.0 to v0.36.0 ([#21706](https://github.com/kubernetes/minikube/pull/21706))

But, only the latter is portable outside the GitHub.