### PR TITLE
chore: Obtain token with new gh commnd in release_notes.sh

### DIFF
--- a/hack/release_notes.sh
+++ b/hack/release_notes.sh
@@ -20,7 +20,7 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 # Parse the token from `gh auth`
 GH_TOKEN=$(mktemp)
-gh auth status -t 2>&1 | sed -n -r 's/^.*Token: ([a-zA-Z0-9_]*)/\1/p' > "$GH_TOKEN"
+gh auth token > "$GH_TOKEN"
 
 # Ensure the token is deleted when the script exits, so the token is not leaked.
 function cleanup_token() {


### PR DESCRIPTION
Utilization of `gh auth status` to obtain the token is a legacy method,
https://github.com/cli/cli/pull/2157 which was replaced with
`gh auth token` command, https://github.com/cli/cli/pull/6324
