### PR TITLE
testspam: allow warnning for docker runtime

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -348,7 +348,8 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 
 	rtime := getContainerRuntime(existing)
 	if rtime == constants.Docker && (existing == nil || viper.IsSet(containerRuntime)) {
-		out.WarningT(`Starting v1.39.0, minikube will default to "containerd" container runtime. See #21973 for more info.`)
+		// TODO: remove this warning in minikube v1.40
+		out.WarningT(constants.DefaultContainerRuntimeChangeWarning)
 	}
 	cc, n, err := generateClusterConfig(cmd, existing, k8sVersion, rtime, driverName, options)
 	if err != nil {

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -67,6 +67,8 @@ const (
 	Docker = "docker"
 	// DefaultContainerRuntime is our default container runtime
 	DefaultContainerRuntime = ""
+	// DefaultContainerRuntimeChangeWarning is shown when the default runtime will change.
+	DefaultContainerRuntimeChangeWarning = `Starting v1.39.0, minikube will default to "containerd" container runtime. See #21973 for more info.`
 
 	// cgroup drivers
 	DefaultCgroupDriver  = "systemd"

--- a/test/integration/error_spam_test.go
+++ b/test/integration/error_spam_test.go
@@ -27,6 +27,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"k8s.io/minikube/pkg/minikube/constants"
 )
 
 // stderrAllow are regular expressions acceptable to find in normal stderr
@@ -52,6 +54,8 @@ var stderrAllow = []string{
 	// Warning of issues with specific Kubernetes versions
 	`Kubernetes .* has a known `,
 	`For more information, see`,
+	// warning about upcoming default container runtime change
+	regexp.QuoteMeta(constants.DefaultContainerRuntimeChangeWarning),
 }
 
 // stderrAllowRe combines rootCauses into a single regex


### PR DESCRIPTION
this test should not fail as the warnning is allowed

TODO:
https://github.com/kubernetes/minikube/issues/22601