### PR TITLE
Fix lock file regression by appending UID to the lock driectory

### DIFF
--- a/pkg/util/lock/lock.go
+++ b/pkg/util/lock/lock.go
@@ -107,8 +107,11 @@ func getUserSpecificDirName() string {
 			// Fallback if home dir cannot be obtained
 			return "minikube-locks-windows-default"
 		}
+		// On Windows, os.Getuid() returns -1, so we cannot verify the user ID directly.
+		// Instead, we use the SHA1 hash of the user's home directory as a unique identifier.
+		// This ensures per-user isolation in shared temporary directories.
 		hash := sha1.Sum([]byte(homeDir))
-		return fmt.Sprintf("minikube-locks-windows-%x", hash[:8]) // Use first 8 bytes of hash
+		return fmt.Sprintf("minikube-locks-windows-%x", hash)
 	}
 	return fmt.Sprintf("minikube-locks-%d", os.Getuid())
 }

--- a/pkg/util/lock/lock_test.go
+++ b/pkg/util/lock/lock_test.go
@@ -17,12 +17,18 @@ limitations under the License.
 package lock
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
 
+// TestUserMutexSpec verifies that the MutexSpec generation is deterministic and collision-resistant.
+// It ensures that different paths generate unique 40-character SHA1 based names, which is crucial
+// for avoiding lock collisions between different projects or resources.
 func TestUserMutexSpec(t *testing.T) {
 	var tests = []struct {
 		description string
@@ -174,6 +180,11 @@ func TestMutexConcurrency(t *testing.T) {
 	r2.Release()
 }
 
+// TestLockDirectoryStructure verifies that the lock directory is created with correct permissions and ownership.
+// It addresses security concerns by ensuring:
+// 1. The lock directory is created in a user-specific path to avoid permission denial in multi-user environments.
+// 2. The directory is writable by the current user, ensuring locks can be acquired.
+// 3. On Unix systems, the directory name contains the user's UID for clear isolation (e.g. minikube-locks-1000).
 func TestLockDirectoryStructure(t *testing.T) {
 	// 1. Acquire a lock
 	spec := PathMutexSpec("test-lock-structure")
@@ -195,4 +206,19 @@ func TestLockDirectoryStructure(t *testing.T) {
 	if !info.IsDir() {
 		t.Errorf("Expected %s to be a directory", lockDir)
 	}
+
+	// 3. Verify that the directory matches likely expectation for current user
+	if runtime.GOOS != "windows" {
+		uid := os.Getuid()
+		if !strings.Contains(expectedDir, fmt.Sprintf("%d", uid)) {
+			t.Errorf("Expected dir name %s to contain user UID %d", expectedDir, uid)
+		}
+	}
+
+	// 4. Verify that the directory is writable by the current user
+	testFile := filepath.Join(lockDir, "write-test")
+	if err := os.WriteFile(testFile, []byte("test"), 0600); err != nil {
+		t.Errorf("Expected to be able to write to %s: %v", lockDir, err)
+	}
+	os.Remove(testFile)
 }


### PR DESCRIPTION
fixes a regression introduced in v1.38.0 where the shared lock directory `/tmp/minikube-locks` was created with `0755` permissions. This prevented different users (or CI jobs running as different users) from acquiring locks on the same machine, resulting in `HOST_HOME_PERMISSION` errors.
Changes:
- Append the current user's UID to the lock directory name (e.g., `/tmp/minikube-locks-1000`).
- This ensures each user has a dedicated, writable directory for their lock files.
- Added `TestLockDirectoryStructure` to verify the directory naming convention.
Fixes #22619

fix https://github.com/kubernetes/minikube/issues/22619