### PR TITLE
docker-runtime: make storage-driver overlayfs for version greater than v29

### DIFF
--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -133,6 +133,7 @@ func (r *Docker) Active() bool {
 
 // Enable idempotently enables Docker on a host
 func (r *Docker) Enable(disOthers bool, cgroupDriver string, inUserNamespace bool) error {
+	storageDriver := r.selectStorageDriver()
 	if inUserNamespace {
 		if err := CheckKernelCompatibility(r.Runner, 5, 11); err != nil {
 			// For using overlayfs
@@ -163,8 +164,9 @@ func (r *Docker) Enable(disOthers bool, cgroupDriver string, inUserNamespace boo
 	if err := r.Init.Enable("docker.socket"); err != nil {
 		klog.ErrorS(err, "Failed to enable", "service", "docker.socket")
 	}
+	klog.Infof("Configuring docker service ...")
 
-	if err := r.configureDocker(cgroupDriver); err != nil {
+	if err := r.configureDocker(cgroupDriver, storageDriver); err != nil {
 		return err
 	}
 
@@ -551,15 +553,21 @@ func (r *Docker) SystemLogCmd(length int) string {
 }
 
 type dockerDaemonConfig struct {
-	ExecOpts       []string              `json:"exec-opts"`
-	LogDriver      string                `json:"log-driver"`
-	LogOpts        dockerDaemonLogOpts   `json:"log-opts"`
-	StorageDriver  string                `json:"storage-driver"`
-	DefaultRuntime string                `json:"default-runtime,omitempty"`
-	Runtimes       *dockerDaemonRuntimes `json:"runtimes,omitempty"`
+	ExecOpts            []string              `json:"exec-opts"`
+	LogDriver           string                `json:"log-driver"`
+	LogOpts             dockerDaemonLogOpts   `json:"log-opts"`
+	StorageDriver       string                `json:"storage-driver"`
+	DefaultRuntime      string                `json:"default-runtime,omitempty"`
+	Runtimes            *dockerDaemonRuntimes `json:"runtimes,omitempty"`
+	Features            dockerDaemonFeatures  `json:"features"`
+	ContainerdNamespace string                `json:"containerd-namespace,omitempty"`
 }
 type dockerDaemonLogOpts struct {
 	MaxSize string `json:"max-size"`
+}
+type dockerDaemonFeatures struct {
+	ContainerdSnapshotter bool `json:"containerd-snapshotter"`
+	ContainerdMigration   bool `json:"containerd-migration"`
 }
 type dockerDaemonRuntimes struct {
 	Nvidia struct {
@@ -570,20 +578,39 @@ type dockerDaemonRuntimes struct {
 
 // configureDocker configures the docker daemon to use driver as cgroup manager
 // ref: https://docs.docker.com/engine/reference/commandline/dockerd/#options-for-the-runtime
-func (r *Docker) configureDocker(driver string) error {
+func (r *Docker) configureDocker(driver string, storageDriver string) error {
 	if driver == constants.UnknownCgroupDriver {
 		return errors.New("unable to configure docker to use unknown cgroup driver")
 	}
 
 	klog.Infof("configuring docker to use %q as cgroup driver...", driver)
+
+	var isOverlayfs bool
+	if storageDriver == "overlayfs" {
+		isOverlayfs = true
+	} else {
+		isOverlayfs = false
+	}
+
 	daemonConfig := dockerDaemonConfig{
 		ExecOpts:  []string{"native.cgroupdriver=" + driver},
 		LogDriver: "json-file",
 		LogOpts: dockerDaemonLogOpts{
 			MaxSize: "100m",
 		},
-		StorageDriver: "overlay2",
+		StorageDriver: storageDriver,
+		Features: dockerDaemonFeatures{
+			ContainerdSnapshotter: isOverlayfs,
+			ContainerdMigration:   isOverlayfs,
+		},
 	}
+
+	if isOverlayfs {
+		// the docker uses containerd's preload images which are present in k8s.io namespace
+		daemonConfig.ContainerdNamespace = "k8s.io"
+	}
+
+	klog.Infof("Configured docker with storageDriver: %s", storageDriver)
 
 	switch r.GPUs {
 	case "all", "nvidia", "nvidia.com":
@@ -602,6 +629,26 @@ func (r *Docker) configureDocker(driver string) error {
 	}
 	ma := assets.NewMemoryAsset(daemonConfigBytes, "/etc/docker", "daemon.json", "0644")
 	return r.Runner.Copy(ma)
+}
+
+func (r *Docker) selectStorageDriver() string {
+	ver, err := r.Version()
+
+	if err == nil {
+		if v, err := semver.Make(ver); err == nil && v.GTE(semver.Version{Major: 29}) {
+			return "overlayfs"
+		}
+	}
+	return "overlay2"
+}
+
+func (r *Docker) getStorageDriver() string {
+	c := exec.Command("docker", "info", "-f", "{{.Info.Driver}}")
+	rr, err := r.Runner.RunCmd(c)
+	if err != nil {
+		return ""
+	}
+	return strings.Split(rr.Stdout.String(), "\n")[0]
 }
 
 // Preload preloads docker with k8s images:
@@ -628,6 +675,10 @@ func (r *Docker) Preload(cc config.ClusterConfig) error {
 	refStore := docker.NewStorage(r.Runner)
 	if err := refStore.Save(); err != nil {
 		klog.Infof("error saving reference store: %v", err)
+	}
+
+	if r.getStorageDriver() == "overlayfs" {
+		cRuntime = "containerd"
 	}
 
 	tarballPath := download.TarballPath(k8sVersion, cRuntime)
@@ -822,7 +873,7 @@ func (r *Docker) restartServiceWithExpoRetry(service string) error {
 	// try to restart service if stopped, restart until it works
 	return retry.Expo(
 		func() error {
-			if !r.Init.Active(service) {
+			if !r.Init.Active(service) && r.getStorageDriver() != r.selectStorageDriver() {
 				r.Init.ResetFailed(service)
 				r.Init.Restart(service)
 				return fmt.Errorf("%s not running", service)

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -79,6 +79,10 @@ func TarballName(k8sVersion, containerRuntime string) string {
 	} else {
 		storageDriver = "overlay2"
 	}
+
+	if containerRuntime == "docker" {
+		containerRuntime = "containerd"
+	}
 	return fmt.Sprintf("preloaded-images-k8s-%s-%s-%s-%s-%s.tar.lz4", PreloadVersion, k8sVersion, containerRuntime, storageDriver, runtime.GOARCH)
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

This implementation generates preload image according to docker version inside the KIC driver (for docker runtime). If the version is greater than v29, docker is configured to use storage driver as overlayfs else it uses overlay2 and respectively builds preload image. 

The changes are tested by generating a new preload image locally. 

Before:
<img width="672" height="62" alt="image" src="https://github.com/user-attachments/assets/dcff01ac-fb5f-4bd6-a662-33cd23332da2" />

After generating a new preload image and start a new cluster:

<img width="672" height="66" alt="image" src="https://github.com/user-attachments/assets/cc2384df-2ed2-4f2d-85ea-8347bb289dfd" />

fixes #22057 