### PR TITLE
unit test: Make kubelet_test k8s version dynamic

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/kubelet_test.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubelet_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package bsutil
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -54,7 +55,7 @@ Wants=docker.socket
 
 [Service]
 ExecStart=
-ExecStart=/var/lib/minikube/binaries/v1.28.0/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --config=/var/lib/kubelet/config.yaml --container-runtime=docker --hostname-override=minikube --kubeconfig=/etc/kubernetes/kubelet.conf --node-ip=192.168.1.100
+ExecStart=/var/lib/minikube/binaries/%s/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --config=/var/lib/kubelet/config.yaml --container-runtime=docker --hostname-override=minikube --kubeconfig=/etc/kubernetes/kubelet.conf --node-ip=192.168.1.100
 
 [Install]
 `,
@@ -80,7 +81,7 @@ Wants=crio.service
 
 [Service]
 ExecStart=
-ExecStart=/var/lib/minikube/binaries/v1.35.0/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --config=/var/lib/kubelet/config.yaml --container-runtime=remote --hostname-override=minikube --kubeconfig=/etc/kubernetes/kubelet.conf --node-ip=192.168.1.100
+ExecStart=/var/lib/minikube/binaries/%s/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --config=/var/lib/kubelet/config.yaml --container-runtime=remote --hostname-override=minikube --kubeconfig=/etc/kubernetes/kubelet.conf --node-ip=192.168.1.100
 
 [Install]
 `,
@@ -106,7 +107,7 @@ Wants=containerd.service
 
 [Service]
 ExecStart=
-ExecStart=/var/lib/minikube/binaries/v1.35.0/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --config=/var/lib/kubelet/config.yaml --container-runtime=remote --hostname-override=minikube --kubeconfig=/etc/kubernetes/kubelet.conf --node-ip=192.168.1.100
+ExecStart=/var/lib/minikube/binaries/%s/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --config=/var/lib/kubelet/config.yaml --container-runtime=remote --hostname-override=minikube --kubeconfig=/etc/kubernetes/kubelet.conf --node-ip=192.168.1.100
 
 [Install]
 `,
@@ -139,7 +140,7 @@ Wants=containerd.service
 
 [Service]
 ExecStart=
-ExecStart=/var/lib/minikube/binaries/v1.35.0/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --config=/var/lib/kubelet/config.yaml --container-runtime=remote --hostname-override=minikube --kubeconfig=/etc/kubernetes/kubelet.conf --node-ip=192.168.1.200
+ExecStart=/var/lib/minikube/binaries/%s/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --config=/var/lib/kubelet/config.yaml --container-runtime=remote --hostname-override=minikube --kubeconfig=/etc/kubernetes/kubelet.conf --node-ip=192.168.1.200
 
 [Install]
 `,
@@ -166,7 +167,7 @@ Wants=docker.socket
 
 [Service]
 ExecStart=
-ExecStart=/var/lib/minikube/binaries/v1.35.0/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --config=/var/lib/kubelet/config.yaml --container-runtime=docker --hostname-override=minikube --kubeconfig=/etc/kubernetes/kubelet.conf --node-ip=192.168.1.100
+ExecStart=/var/lib/minikube/binaries/%s/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --config=/var/lib/kubelet/config.yaml --container-runtime=docker --hostname-override=minikube --kubeconfig=/etc/kubernetes/kubelet.conf --node-ip=192.168.1.100
 
 [Install]
 `,
@@ -190,7 +191,9 @@ ExecStart=/var/lib/minikube/binaries/v1.35.0/kubelet --bootstrap-kubeconfig=/etc
 				return
 			}
 
-			if diff := cmp.Diff(tc.expected, string(got)); diff != "" {
+			expected := fmt.Sprintf(tc.expected, tc.cfg.KubernetesConfig.KubernetesVersion)
+
+			if diff := cmp.Diff(expected, string(got)); diff != "" {
 				t.Errorf("GenerateKubeletConfig mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
- TestGenerateKubeletConfig: The tests previously hard-coded v1.35.0 in the expected output, but the global constant in minikube was recently bumped to v1.35.1. I updated the tests in pkg/minikube/bootstrapper/bsutil/kubelet_test.go to expect v1.35.1.
- The commit that broke the tests is 2134869de bump default/newest kubernetes versions (#22665).
- Refactored the tests in pkg/minikube/bootstrapper/bsutil/kubelet_test.go to be robust against future Kubernetes version bumps! Instead of putting hardcoded string literals like v1.35.1 directly into the expected string template structs, I modified them to use the %s format specifier.

