### PR TITLE
build: perform stripped builds setting '-s -w' ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ STORAGE_PROVISIONER_IMAGE ?= $(REGISTRY)/storage-provisioner-$(GOARCH):$(STORAGE
 # Set the version information for the Kubernetes servers
 MINIKUBE_LDFLAGS_commit := -X k8s.io/minikube/pkg/version.gitCommitID=$(COMMIT)
 MINIKUBE_LDFLAGS_versions := -X k8s.io/minikube/pkg/version.version=$(VERSION) -X k8s.io/minikube/pkg/version.isoVersion=$(ISO_VERSION) -X k8s.io/minikube/pkg/version.storageProvisionerVersion=$(STORAGE_PROVISIONER_TAG)
-MINIKUBE_LDFLAGS := $(MINIKUBE_LDFLAGS_commit) $(MINIKUBE_LDFLAGS_versions)
+MINIKUBE_LDFLAGS := $(MINIKUBE_LDFLAGS_commit) $(MINIKUBE_LDFLAGS_versions) -s -w
 PROVISIONER_LDFLAGS := "-X k8s.io/minikube/pkg/storage.version=$(STORAGE_PROVISIONER_TAG) -s -w -extldflags '-static'"
 
 MINIKUBEFILES := ./cmd/minikube/

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,9 @@ STORAGE_PROVISIONER_MANIFEST ?= $(REGISTRY)/storage-provisioner:$(STORAGE_PROVIS
 STORAGE_PROVISIONER_IMAGE ?= $(REGISTRY)/storage-provisioner-$(GOARCH):$(STORAGE_PROVISIONER_TAG)
 
 # Set the version information for the Kubernetes servers
-MINIKUBE_LDFLAGS := -X k8s.io/minikube/pkg/version.version=$(VERSION) -X k8s.io/minikube/pkg/version.isoVersion=$(ISO_VERSION) -X k8s.io/minikube/pkg/version.gitCommitID=$(COMMIT) -X k8s.io/minikube/pkg/version.storageProvisionerVersion=$(STORAGE_PROVISIONER_TAG)
+MINIKUBE_LDFLAGS_commit := -X k8s.io/minikube/pkg/version.gitCommitID=$(COMMIT)
+MINIKUBE_LDFLAGS_versions := -X k8s.io/minikube/pkg/version.version=$(VERSION) -X k8s.io/minikube/pkg/version.isoVersion=$(ISO_VERSION) -X k8s.io/minikube/pkg/version.storageProvisionerVersion=$(STORAGE_PROVISIONER_TAG)
+MINIKUBE_LDFLAGS := $(MINIKUBE_LDFLAGS_commit) $(MINIKUBE_LDFLAGS_versions)
 PROVISIONER_LDFLAGS := "-X k8s.io/minikube/pkg/storage.version=$(STORAGE_PROVISIONER_TAG) -s -w -extldflags '-static'"
 
 MINIKUBEFILES := ./cmd/minikube/


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

by mergng this reques, we would:
  * split the `MINIKUBE_LDFLAGS` value into 3 different vars;
    - `MINIKUBE_LDFLAGS_commit`: related to set the commit hash;
    -  `MINIKUBE_LDFLAGS_versions`: getting variables values from vars ending in "version";
    -  `MINIKUBE_LDFLAGS`: the main one aggregating all values
  * have direct visual feedback of the values setting `MINIKUBE_LDFLAGS`;
  * perform stripped build of `minikube` - removing unnecessary data from the binary blob.

comparing the size of current binary with a newer version, built with `-s -w` ldflags added:

```sh
$ ls -lash /opt/homebrew/bin/../Cellar/minikube/1.38.1/bin/minikube
263712 -r-xr-xr-x@ 1 vinicius  admin   129M Feb 19 20:11 /opt/homebrew/bin/../Cellar/minikube/1.38.1/bin/minikube
```

```sh
$ ls -lash out/minikube
186464 -rwxr-xr-x@ 1 vinicius  staff    91M Feb 22 18:35 out/minikube
```

here we have sources that motivated this work:
  * https://github.com/sustainable-computing-io/kepler/pull/2057
  * https://www.codingexplorations.com/blog/reducing-binary-size-in-go-strip-unnecessary-data-with-ldflags-w-s
  * https://words.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/