### PR TITLE
Add --dns-search and --auto-dns-search flags to propagate DNS search domains into minikube node

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -100,6 +100,7 @@ var (
 	ErrKubernetesPatchNotFound = errors.New("Unable to detect the latest patch release for specified Kubernetes version")
 	registryMirror             []string
 	insecureRegistry           []string
+	dnsSearchDomains           []string
 	apiServerNames             []string
 	apiServerIPs               []net.IP
 	hostRe                     = regexp.MustCompile(`^[^-][\w\.-]+$`)

--- a/cmd/minikube/cmd/start_flags_test.go
+++ b/cmd/minikube/cmd/start_flags_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParseHostDNSSearch(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected []string
+	}{
+		{
+			name:     "single search line",
+			content:  "nameserver 8.8.8.8\nsearch corp.example.com\n",
+			expected: []string{"corp.example.com"},
+		},
+		{
+			name:     "multiple domains on one line",
+			content:  "nameserver 8.8.8.8\nsearch corp.example.com eng.example.com\n",
+			expected: []string{"corp.example.com", "eng.example.com"},
+		},
+		{
+			name:     "multiple search lines",
+			content:  "search corp.example.com\nnameserver 8.8.8.8\nsearch eng.example.com\n",
+			expected: []string{"corp.example.com", "eng.example.com"},
+		},
+		{
+			name:     "no search line",
+			content:  "nameserver 8.8.8.8\nnameserver 8.8.4.4\n",
+			expected: nil,
+		},
+		{
+			name:     "empty search line",
+			content:  "search \nnameserver 8.8.8.8\n",
+			expected: nil,
+		},
+		{
+			name:     "search with extra whitespace",
+			content:  "  search   corp.example.com   eng.example.com  \n",
+			expected: []string{"corp.example.com", "eng.example.com"},
+		},
+		{
+			name:     "comments and search",
+			content:  "# This is a comment\nsearch corp.example.com\nnameserver 8.8.8.8\n",
+			expected: []string{"corp.example.com"},
+		},
+		{
+			name:     "empty file",
+			content:  "",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temp resolv.conf
+			tmpDir := t.TempDir()
+			resolvPath := filepath.Join(tmpDir, "resolv.conf")
+			if err := os.WriteFile(resolvPath, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("failed to write test resolv.conf: %v", err)
+			}
+
+			got := parseHostDNSSearchFrom(resolvPath)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("parseHostDNSSearchFrom() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseHostDNSSearch_MissingFile(t *testing.T) {
+	got := parseHostDNSSearchFrom("/nonexistent/resolv.conf")
+	if got != nil {
+		t.Errorf("parseHostDNSSearchFrom(missing file) = %v, want nil", got)
+	}
+}
+
+func TestMergeDNSSearch(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        []string
+		b        []string
+		expected []string
+	}{
+		{
+			name:     "both nil",
+			a:        nil,
+			b:        nil,
+			expected: nil,
+		},
+		{
+			name:     "a only",
+			a:        []string{"corp.com", "eng.com"},
+			b:        nil,
+			expected: []string{"corp.com", "eng.com"},
+		},
+		{
+			name:     "b only",
+			a:        nil,
+			b:        []string{"corp.com"},
+			expected: []string{"corp.com"},
+		},
+		{
+			name:     "no overlap",
+			a:        []string{"corp.com"},
+			b:        []string{"eng.com"},
+			expected: []string{"corp.com", "eng.com"},
+		},
+		{
+			name:     "with duplicates",
+			a:        []string{"corp.com", "eng.com"},
+			b:        []string{"eng.com", "ops.com"},
+			expected: []string{"corp.com", "eng.com", "ops.com"},
+		},
+		{
+			name:     "all duplicates",
+			a:        []string{"corp.com", "eng.com"},
+			b:        []string{"corp.com", "eng.com"},
+			expected: []string{"corp.com", "eng.com"},
+		},
+		{
+			name:     "preserves order from a first",
+			a:        []string{"z.com", "a.com"},
+			b:        []string{"m.com", "a.com"},
+			expected: []string{"z.com", "a.com", "m.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeDNSSearch(tt.a, tt.b)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("mergeDNSSearch(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWarnDNSSearchOverlap(t *testing.T) {
+	// warnDNSSearchOverlap only emits warnings (via out.WarningT), it doesn't return errors.
+	// We just verify it doesn't panic for various inputs.
+	tests := []struct {
+		name          string
+		domains       []string
+		clusterDomain string
+	}{
+		{"nil domains", nil, "cluster.local"},
+		{"empty domains", []string{}, "cluster.local"},
+		{"empty cluster domain", []string{"corp.com"}, ""},
+		{"no overlap", []string{"corp.com", "eng.com"}, "cluster.local"},
+		{"exact match", []string{"cluster.local"}, "cluster.local"},
+		{"subdomain match", []string{"ns1.cluster.local"}, "cluster.local"},
+		{"mixed overlap and non-overlap", []string{"corp.com", "svc.cluster.local"}, "cluster.local"},
+		{"custom cluster domain overlap", []string{"my.domain"}, "my.domain"},
+		{"no false positive on partial match", []string{"notcluster.local"}, "cluster.local"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Should not panic
+			warnDNSSearchOverlap(tt.domains, tt.clusterDomain)
+		})
+	}
+}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -1050,6 +1050,9 @@ func (k *Bootstrapper) configureDNSSearch(cfg config.ClusterConfig) error {
 	if len(cfg.DNSSearch) == 0 {
 		return nil
 	}
+	if driver.IsNone(cfg.Driver) {
+		return fmt.Errorf("dns search is not supported with the none driver")
+	}
 
 	searchLine := "search " + strings.Join(cfg.DNSSearch, " ")
 	klog.Infof("Configuring DNS search domains: %v", cfg.DNSSearch)

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeadm
+
+import (
+	"testing"
+
+	"k8s.io/minikube/pkg/minikube/command"
+	"k8s.io/minikube/pkg/minikube/config"
+)
+
+func TestConfigureDNSSearch_Empty(t *testing.T) {
+	fcr := command.NewFakeCommandRunner()
+	k := &Bootstrapper{c: fcr}
+
+	cfg := config.ClusterConfig{
+		DNSSearch: nil,
+	}
+
+	if err := k.configureDNSSearch(cfg); err != nil {
+		t.Errorf("configureDNSSearch() with empty search returned error: %v", err)
+	}
+}
+
+func TestConfigureDNSSearch_SingleDomain(t *testing.T) {
+	fcr := command.NewFakeCommandRunner()
+	fcr.SetCommandToOutput(map[string]string{
+		`sudo sed -i "/^search /d" /etc/resolv.conf`:               "",
+		`sudo sed -i "1isearch corp.example.com" /etc/resolv.conf`: "",
+	})
+
+	k := &Bootstrapper{c: fcr}
+	cfg := config.ClusterConfig{
+		DNSSearch: []string{"corp.example.com"},
+		KubernetesConfig: config.KubernetesConfig{
+			KubernetesVersion: "v1.28.0",
+		},
+	}
+
+	if err := k.configureDNSSearch(cfg); err != nil {
+		t.Errorf("configureDNSSearch() returned error: %v", err)
+	}
+}
+
+func TestConfigureDNSSearch_MultipleDomains(t *testing.T) {
+	fcr := command.NewFakeCommandRunner()
+	fcr.SetCommandToOutput(map[string]string{
+		`sudo sed -i "/^search /d" /etc/resolv.conf`:                               "",
+		`sudo sed -i "1isearch corp.example.com eng.example.com" /etc/resolv.conf`: "",
+	})
+
+	k := &Bootstrapper{c: fcr}
+	cfg := config.ClusterConfig{
+		DNSSearch: []string{"corp.example.com", "eng.example.com"},
+		KubernetesConfig: config.KubernetesConfig{
+			KubernetesVersion: "v1.28.0",
+		},
+	}
+
+	if err := k.configureDNSSearch(cfg); err != nil {
+		t.Errorf("configureDNSSearch() returned error: %v", err)
+	}
+}
+
+func TestConfigureDNSSearch_K8s125Regression(t *testing.T) {
+	// K8s v1.25.0 has the resolv.conf search regression, so configureDNSSearch
+	// should also update /etc/kubelet-resolv.conf
+	fcr := command.NewFakeCommandRunner()
+	fcr.SetCommandToOutput(map[string]string{
+		`sudo sed -i "/^search /d" /etc/resolv.conf`:                       "",
+		`sudo sed -i "1isearch corp.example.com" /etc/resolv.conf`:         "",
+		`sudo sed -i "/^search /d" /etc/kubelet-resolv.conf`:               "",
+		`sudo sed -i "1isearch corp.example.com" /etc/kubelet-resolv.conf`: "",
+	})
+
+	k := &Bootstrapper{c: fcr}
+	cfg := config.ClusterConfig{
+		DNSSearch: []string{"corp.example.com"},
+		KubernetesConfig: config.KubernetesConfig{
+			KubernetesVersion: "v1.25.0",
+		},
+	}
+
+	if err := k.configureDNSSearch(cfg); err != nil {
+		t.Errorf("configureDNSSearch() with K8s v1.25.0 returned error: %v", err)
+	}
+}
+
+func TestConfigureDNSSearch_K8s125NotAffected(t *testing.T) {
+	// K8s v1.25.3 does NOT have the regression, so only /etc/resolv.conf should be updated.
+	// If kubelet-resolv.conf commands are called, the fake runner will error on unknown commands.
+	fcr := command.NewFakeCommandRunner()
+	fcr.SetCommandToOutput(map[string]string{
+		`sudo sed -i "/^search /d" /etc/resolv.conf`:               "",
+		`sudo sed -i "1isearch corp.example.com" /etc/resolv.conf`: "",
+	})
+
+	k := &Bootstrapper{c: fcr}
+	cfg := config.ClusterConfig{
+		DNSSearch: []string{"corp.example.com"},
+		KubernetesConfig: config.KubernetesConfig{
+			KubernetesVersion: "v1.25.3",
+		},
+	}
+
+	if err := k.configureDNSSearch(cfg); err != nil {
+		t.Errorf("configureDNSSearch() with K8s v1.25.3 returned error: %v", err)
+	}
+}
+
+func TestConfigureDNSSearch_SedDeleteError(t *testing.T) {
+	// Only register the delete command with an error-causing setup:
+	// Don't register the first command so it fails
+	fcr := command.NewFakeCommandRunner()
+	k := &Bootstrapper{c: fcr}
+	cfg := config.ClusterConfig{
+		DNSSearch: []string{"corp.example.com"},
+		KubernetesConfig: config.KubernetesConfig{
+			KubernetesVersion: "v1.28.0",
+		},
+	}
+
+	err := k.configureDNSSearch(cfg)
+	if err == nil {
+		t.Error("configureDNSSearch() should have returned error when sed fails")
+	}
+}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/driver"
 )
 
 func TestConfigureDNSSearch_Empty(t *testing.T) {
@@ -119,6 +120,22 @@ func TestConfigureDNSSearch_K8s125NotAffected(t *testing.T) {
 
 	if err := k.configureDNSSearch(cfg); err != nil {
 		t.Errorf("configureDNSSearch() with K8s v1.25.3 returned error: %v", err)
+	}
+}
+
+func TestConfigureDNSSearch_NoneDriverUnsupported(t *testing.T) {
+	fcr := command.NewFakeCommandRunner()
+	k := &Bootstrapper{c: fcr}
+	cfg := config.ClusterConfig{
+		Driver:    driver.None,
+		DNSSearch: []string{"corp.example.com"},
+		KubernetesConfig: config.KubernetesConfig{
+			KubernetesVersion: "v1.28.0",
+		},
+	}
+
+	if err := k.configureDNSSearch(cfg); err == nil {
+		t.Error("configureDNSSearch() should fail for none driver")
 	}
 }
 

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -110,6 +110,8 @@ type ClusterConfig struct {
 	GPUs                    string
 	AutoPauseInterval       time.Duration // Specifies interval of time to wait before checking if cluster should be paused
 	Rosetta                 bool          // Only used by vfkit driver
+	DNSSearch               []string      // DNS search domains to configure inside the minikube node
+	AutoDNSSearch           bool          // Auto-detect and propagate the host's DNS search domains
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -76,6 +76,11 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		extraArgs = append(extraArgs, "-p", port)
 	}
 
+	envs := map[string]string{}
+	if len(cc.DNSSearch) > 0 {
+		envs["KIND_DNS_SEARCH"] = strings.Join(cc.DNSSearch, " ")
+	}
+
 	return kic.NewDriver(kic.Config{
 		ClusterName:       cc.Name,
 		MachineName:       config.MachineName(cc, n),
@@ -94,6 +99,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		StaticIP:          cc.StaticIP,
 		ListenAddress:     cc.ListenAddress,
 		GPUs:              cc.GPUs,
+		Envs:              envs,
 	}), nil
 }
 

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -83,6 +83,11 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		extraArgs = append(extraArgs, "-p", port)
 	}
 
+	envs := map[string]string{}
+	if len(cc.DNSSearch) > 0 {
+		envs["KIND_DNS_SEARCH"] = strings.Join(cc.DNSSearch, " ")
+	}
+
 	return kic.NewDriver(kic.Config{
 		ClusterName:       cc.Name,
 		MachineName:       config.MachineName(cc, n),
@@ -98,6 +103,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		ExtraArgs:         extraArgs,
 		ListenAddress:     cc.ListenAddress,
 		Subnet:            cc.Subnet,
+		Envs:              envs,
 	}), nil
 }
 

--- a/pkg/minikube/registry/drvs/podman/podman_test.go
+++ b/pkg/minikube/registry/drvs/podman/podman_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podman
+
+import (
+	"testing"
+
+	"k8s.io/minikube/pkg/drivers/kic"
+	"k8s.io/minikube/pkg/minikube/config"
+)
+
+func TestConfigureDNSSearchEnv(t *testing.T) {
+	tests := []struct {
+		name      string
+		dnsSearch []string
+		wantEnv   string
+	}{
+		{
+			name:      "no dns search",
+			dnsSearch: nil,
+			wantEnv:   "",
+		},
+		{
+			name:      "single domain",
+			dnsSearch: []string{"corp.example.com"},
+			wantEnv:   "corp.example.com",
+		},
+		{
+			name:      "multiple domains",
+			dnsSearch: []string{"corp.example.com", "eng.example.com"},
+			wantEnv:   "corp.example.com eng.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cc := config.ClusterConfig{
+				Name:         "test",
+				KicBaseImage: "gcr.io/k8s-minikube/kicbase:test",
+				DNSSearch:    tt.dnsSearch,
+				Nodes: []config.Node{
+					{
+						Name:         "test",
+						Port:         8443,
+						ControlPlane: true,
+					},
+				},
+				KubernetesConfig: config.KubernetesConfig{
+					ContainerRuntime: "containerd",
+				},
+			}
+			n := cc.Nodes[0]
+
+			result, err := configure(cc, n)
+			if err != nil {
+				t.Fatalf("configure() returned error: %v", err)
+			}
+
+			d, ok := result.(*kic.Driver)
+			if !ok {
+				t.Fatalf("configure() returned %T, want *kic.Driver", result)
+			}
+
+			gotEnv := d.NodeConfig.Envs["KIND_DNS_SEARCH"]
+			if gotEnv != tt.wantEnv {
+				t.Errorf("KIND_DNS_SEARCH = %q, want %q", gotEnv, tt.wantEnv)
+			}
+		})
+	}
+}

--- a/test/integration/dns_search_test.go
+++ b/test/integration/dns_search_test.go
@@ -1,0 +1,82 @@
+//go:build integration
+
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestDNSSearchFlag(t *testing.T) {
+	if NoneDriver() {
+		t.Skip("skipping: dns-search is unsupported with none driver")
+	}
+	MaybeParallel(t)
+
+	profile := UniqueProfileName("dns-search")
+	ctx, cancel := context.WithTimeout(context.Background(), Minutes(30))
+	defer CleanupWithLogs(t, profile, cancel)
+
+	startArgs := append([]string{
+		"start",
+		"-p", profile,
+		"--memory=3072",
+		"--wait=apiserver,system_pods,default_sa",
+		"--dns-search=corp.example.com",
+		"--dns-search=eng.example.com",
+	}, StartArgs()...)
+
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
+	if err != nil {
+		t.Fatalf("failed to start minikube with dns-search. args %q: %v", rr.Command(), err)
+	}
+
+	rr, err = Run(t, exec.CommandContext(ctx, Target(), "ssh", "-p", profile, "--", "cat /etc/resolv.conf"))
+	if err != nil {
+		t.Fatalf("failed to inspect node resolv.conf. args %q: %v", rr.Command(), err)
+	}
+	wantSearchLine := "search corp.example.com eng.example.com"
+	if !strings.Contains(rr.Stdout.String(), wantSearchLine) {
+		t.Errorf("node /etc/resolv.conf does not contain %q. output: %s", wantSearchLine, rr.Output())
+	}
+
+	rr, err = Run(t, exec.CommandContext(ctx, KubectlBinary(), "--context", profile,
+		"run", "dns-search-resolv",
+		"--restart=Never",
+		"--image=gcr.io/k8s-minikube/busybox",
+		"--labels=app=dns-search-resolv",
+		"--command", "--", "sh", "-c", "cat /etc/resolv.conf"))
+	if err != nil {
+		t.Fatalf("failed to create pod to inspect pod resolv.conf. args %q: %v", rr.Command(), err)
+	}
+
+	if _, err := PodWait(ctx, t, profile, "default", "app=dns-search-resolv", Minutes(2)); err != nil {
+		t.Fatalf("pod did not become ready/succeeded in time: %v", err)
+	}
+
+	rr, err = Run(t, exec.CommandContext(ctx, KubectlBinary(), "--context", profile, "logs", "dns-search-resolv"))
+	if err != nil {
+		t.Fatalf("failed to read pod resolv.conf output. args %q: %v", rr.Command(), err)
+	}
+	if !strings.Contains(rr.Stdout.String(), "corp.example.com") || !strings.Contains(rr.Stdout.String(), "eng.example.com") {
+		t.Errorf("pod /etc/resolv.conf does not contain expected dns-search domains. output: %s", rr.Output())
+	}
+}


### PR DESCRIPTION
Fixes #1676

## Summary

Adds two new `minikube start` flags that allow users to configure DNS search domains inside the minikube node:

- `--dns-search` (string slice): manually specify DNS search domains
- `--auto-dns-search` (bool): auto-detect and propagate the host's DNS search domains from `/etc/resolv.conf`

Both flags can be combined — auto-detected and manual domains are merged with deduplication.

```bash
minikube start --dns-search=corp.example.com,eng.example.com   # manual
minikube start --auto-dns-search                                # auto-detect from host
minikube start --auto-dns-search --dns-search=extra.corp.com   # combined
```

### Before

No way to propagate DNS search domains into the minikube VM. Users behind corporate firewalls had to manually edit `/etc/resolv.conf` inside the node after every start.

### After

```
$ minikube start --dns-search=corp.example.com
$ minikube ssh -- cat /etc/resolv.conf
search corp.example.com
nameserver 192.168.49.1
```

## How it works

- **VM drivers (kvm2, virtualbox, hyperkit, etc.)**: The kubeadm bootstrapper updates `/etc/resolv.conf` (and `/etc/kubelet-resolv.conf` for K8s v1.25 regression) via `sed` after node provisioning.
- **Container drivers (docker, podman)**: The `KIND_DNS_SEARCH` environment variable is passed to the kicbase entrypoint, which handles resolv.conf configuration at container startup.
- **None driver**: Blocked with a clear error, since modifying the host's `/etc/resolv.conf` directly is unsafe.
- A warning is emitted if any search domain overlaps with the cluster DNS domain (`cluster.local` by default).

## Changes

| File | Change |
|------|--------|
| `cmd/minikube/cmd/start.go` | Add `dnsSearchDomains` variable |
| `cmd/minikube/cmd/start_flags.go` | Register flags, map to config, auto-detect and merge logic, overlap warning |
| `pkg/minikube/config/types.go` | Add `DNSSearch` and `AutoDNSSearch` fields to `ClusterConfig` |
| `pkg/minikube/bootstrapper/kubeadm/kubeadm.go` | Add `configureDNSSearch()` method, call from `UpdateNode()` |
| `pkg/minikube/registry/drvs/docker/docker.go` | Pass `KIND_DNS_SEARCH` env to kic driver |
| `pkg/minikube/registry/drvs/podman/podman.go` | Pass `KIND_DNS_SEARCH` env to kic driver |

## Testing

- Unit tests for `parseHostDNSSearch`, `mergeDNSSearch`, `warnDNSSearchOverlap` (start_flags_test.go)
- Unit tests for `generateClusterConfig` DNS search path (start_test.go)
- Unit tests for `configureDNSSearch` covering: empty input, single/multiple domains, K8s v1.25 regression, none driver rejection, sed failure (kubeadm_test.go)
- Unit tests for Docker and Podman driver `KIND_DNS_SEARCH` env propagation (docker_test.go, podman_test.go)
- Integration test that starts minikube with `--dns-search`, verifies node resolv.conf via SSH, and verifies pod resolv.conf via kubectl (dns_search_test.go)

---
*This PR was developed with AI assistance (Claude Code).*
