### PR TITLE
Document that `minikube ssh` can run a single command on the host

### DIFF
--- a/cmd/minikube/cmd/ssh.go
+++ b/cmd/minikube/cmd/ssh.go
@@ -36,9 +36,10 @@ var nativeSSHClient bool
 
 // sshCmd represents the docker-ssh command
 var sshCmd = &cobra.Command{
-	Use:   "ssh",
-	Short: "Log into the minikube environment (for debugging)",
-	Long:  "Log into or run a command on a machine with SSH; similar to 'docker-machine ssh'.",
+	Use:     "ssh",
+	Short:   "Log into the minikube environment (for debugging)",
+	Long:    "Log into or run a command (remember, -- after minikube ssh!) on a machine with SSH; similar to 'docker-machine ssh'.",
+	Example: "minikube ssh -- pwd\nminikube ssh -- df -h",
 	Run: func(_ *cobra.Command, args []string) {
 		options := flags.CommandOptions()
 		cname := ClusterFlagValue()


### PR DESCRIPTION
This is simply expanding documentation for `minikube ssh`.

I struggled to find a way to run a command on nodes programmatically. Delightfully, this feature has already been implemented in Minikube!

I expand the documentation to hopefully make it clearer for future users. I based the documentation on the style of `minikube kubectl`'s. It can probably be improved

# Before
```
$ minikube ssh --help
Log into or run a command on a machine with SSH; similar to 'docker-machine ssh'.

Options:
    --native-ssh=true:
        Use native Golang SSH client (default true). Set to 'false' to use the command line 'ssh' command when
        accessing the docker machine. Useful for the machine drivers when they will not start with 'Waiting for SSH'.

    -n, --node='':
        The node to ssh into. Defaults to the primary control plane.

Usage:
  minikube ssh [flags] [options]

Use "minikube options" for a list of global command-line options (applies to all commands).

```

# After
```bash
$ minikube ssh --help
Log into or run a command (remember -- after minikube ssh!) on a machine with SSH; similar to 'docker-machine ssh'.

Examples:
minikube ssh -- pwd
minikube ssh -- df -h

Options:
    --native-ssh=true:
        Use native Golang SSH client (default true). Set to 'false' to use the command line 'ssh' command when
        accessing the docker machine. Useful for the machine drivers when they will not start with 'Waiting for SSH'.

    -n, --node='':
        The node to ssh into. Defaults to the primary control plane.

Usage:
  minikube ssh [flags] [options]

Use "minikube options" for a list of global command-line options (applies to all commands).

```