### PR TITLE
Authenticate GitHub API call in K8s version discovery

### DIFF
--- a/cmd/minikube/cmd/config/kubernetes_version.go
+++ b/cmd/minikube/cmd/config/kubernetes_version.go
@@ -19,9 +19,11 @@ package config
 import (
 	"context"
 	"net/http"
+	"os"
 
 	"github.com/google/go-github/v84/github"
 	"golang.org/x/mod/semver"
+	"golang.org/x/oauth2"
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
@@ -39,11 +41,22 @@ func supportedKubernetesVersions() (releases []string) {
 	return releases
 }
 
+// newGitHubClient creates a GitHub client, using GITHUB_TOKEN for authentication when available.
+var newGitHubClient = func(ctx context.Context) *github.Client {
+	var httpClient *http.Client
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+		httpClient = oauth2.NewClient(ctx, ts)
+	}
+	return github.NewClient(httpClient)
+}
+
 // IsInGitHubKubernetesVersions checks whether ver is in the GitHub list of K8s versions
 func IsInGitHubKubernetesVersions(ver string) (bool, error) {
-	ghc := github.NewClient(nil)
+	ctx := context.Background()
+	ghc := newGitHubClient(ctx)
 
-	_, resp, err := ghc.Repositories.GetReleaseByTag(context.Background(), "kubernetes", "kubernetes", ver)
+	_, resp, err := ghc.Repositories.GetReleaseByTag(ctx, "kubernetes", "kubernetes", ver)
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return false, nil

--- a/cmd/minikube/cmd/config/kubernetes_version_test.go
+++ b/cmd/minikube/cmd/config/kubernetes_version_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2022 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-github/v84/github"
+)
+
+// fakeGitHubServer creates an httptest.Server that mimics the GitHub Releases API.
+// releasesByTag maps tag names to HTTP status codes (e.g. 200 for found, 404 for not found).
+func fakeGitHubServer(t *testing.T, releasesByTag map[string]int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Expected path: /repos/kubernetes/kubernetes/releases/tags/{tag}
+		prefix := "/repos/kubernetes/kubernetes/releases/tags/"
+		if len(r.URL.Path) <= len(prefix) {
+			http.NotFound(w, r)
+			return
+		}
+		tag := r.URL.Path[len(prefix):]
+		status, ok := releasesByTag[tag]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		if status == http.StatusOK {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"tag_name": %q}`, tag)
+			return
+		}
+		w.WriteHeader(status)
+		fmt.Fprintf(w, `{"message": "Not Found"}`)
+	}))
+}
+
+// testGitHubClient returns a newGitHubClient replacement that points at the given test server
+// and optionally verifies the Authorization header.
+func testGitHubClient(t *testing.T, serverURL string, wantAuth bool) func(context.Context) *github.Client {
+	t.Helper()
+	return func(ctx context.Context) *github.Client {
+		if wantAuth {
+			// Wrap transport to verify auth header is set
+			client := github.NewClient(nil).WithAuthToken("test-token")
+			client.BaseURL.Scheme = "http"
+			client.BaseURL.Host = serverURL[len("http://"):]
+			return client
+		}
+		client := github.NewClient(nil)
+		client.BaseURL.Scheme = "http"
+		client.BaseURL.Host = serverURL[len("http://"):]
+		return client
+	}
+}
+
+func TestIsInGitHubKubernetesVersions(t *testing.T) {
+	server := fakeGitHubServer(t, map[string]int{
+		"v1.30.0": http.StatusOK,
+		"v1.99.0": http.StatusNotFound,
+	})
+	defer server.Close()
+
+	origClient := newGitHubClient
+	defer func() { newGitHubClient = origClient }()
+
+	newGitHubClient = testGitHubClient(t, server.URL, false)
+
+	t.Run("existing release returns true", func(t *testing.T) {
+		found, err := IsInGitHubKubernetesVersions("v1.30.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !found {
+			t.Fatal("expected found=true for existing release")
+		}
+	})
+
+	t.Run("non-existing release returns false", func(t *testing.T) {
+		found, err := IsInGitHubKubernetesVersions("v1.99.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found {
+			t.Fatal("expected found=false for non-existing release")
+		}
+	})
+}
+
+func TestNewGitHubClientRespectsToken(t *testing.T) {
+	// Verify that when GITHUB_TOKEN is set, the client sends an Authorization header.
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"tag_name": "v1.30.0"}`)
+	}))
+	defer server.Close()
+
+	origClient := newGitHubClient
+	defer func() { newGitHubClient = origClient }()
+
+	t.Run("with GITHUB_TOKEN", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "test-secret-token")
+
+		// Call the real newGitHubClient (not a fake), but point it at our test server
+		ctx := context.Background()
+		ghc := origClient(ctx)
+		ghc.BaseURL.Scheme = "http"
+		ghc.BaseURL.Host = server.URL[len("http://"):]
+
+		gotAuth = ""
+		_, _, err := ghc.Repositories.GetReleaseByTag(ctx, "kubernetes", "kubernetes", "v1.30.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotAuth == "" {
+			t.Fatal("expected Authorization header to be set when GITHUB_TOKEN is provided")
+		}
+		if gotAuth != "Bearer test-secret-token" {
+			t.Fatalf("unexpected Authorization header: %q", gotAuth)
+		}
+	})
+
+	t.Run("without GITHUB_TOKEN", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "")
+
+		ctx := context.Background()
+		ghc := origClient(ctx)
+		ghc.BaseURL.Scheme = "http"
+		ghc.BaseURL.Host = server.URL[len("http://"):]
+
+		gotAuth = ""
+		_, _, err := ghc.Repositories.GetReleaseByTag(ctx, "kubernetes", "kubernetes", "v1.30.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotAuth != "" {
+			t.Fatalf("expected no Authorization header when GITHUB_TOKEN is empty, got: %q", gotAuth)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`IsInGitHubKubernetesVersions` creates an unauthenticated GitHub client, which causes
rate-limit errors (HTTP 403) when running minikube within a GitHub Action where
`GITHUB_TOKEN` is available.

This change reuses the existing oauth2 pattern from `pkg/minikube/download/gh/gh.go`
so that the client respects the `GITHUB_TOKEN` environment variable, falling back to
an unauthenticated client when no token is set.

## Changes

- Extract GitHub client creation into a `newGitHubClient` package-level variable
  for testability (same pattern used in `cmd/minikube/cmd/delete.go`,
  `cmd/minikube/cmd/start.go`, etc.)
- Use `GITHUB_TOKEN` with oauth2 when available (same wiring as `gh.go`)
- Add unit tests for both the release lookup logic and the auth wiring

## Follow-up

A cleaner refactor could export a shared `NewClient` helper from
`pkg/minikube/download/gh` to avoid duplicating the oauth2 wiring across packages.
Would this be a welcome change? Happy to send a follow-up PR if so.