### PR TITLE
Fix usage string for minikube node commands.

### DIFF
--- a/cmd/minikube/cmd/node_delete.go
+++ b/cmd/minikube/cmd/node_delete.go
@@ -34,9 +34,10 @@ import (
 )
 
 var nodeDeleteCmd = &cobra.Command{
-	Use:   "delete",
-	Short: "Deletes a node from a cluster.",
-	Long:  "Deletes a node from a cluster.",
+	Use:     "delete NODE_NAME",
+	Short:   "Deletes a node from a cluster.",
+	Long:    "Deletes a node from a cluster.",
+	Example: "minikube node delete m02",
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) == 0 {
 			exit.Message(reason.Usage, "Usage: minikube node delete [name]")

--- a/cmd/minikube/cmd/node_delete.go
+++ b/cmd/minikube/cmd/node_delete.go
@@ -34,12 +34,13 @@ import (
 )
 
 var nodeDeleteCmd = &cobra.Command{
-	Use:   "delete",
-	Short: "Deletes a node from a cluster.",
-	Long:  "Deletes a node from a cluster.",
+	Use:     "delete NODE_NAME",
+	Short:   "Deletes a node from a cluster.",
+	Long:    "Deletes a node from a cluster.",
+	Example: "minikube node delete m02",
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) == 0 {
-			exit.Message(reason.Usage, "Usage: minikube node delete [name]")
+			exit.Message(reason.Usage, "Usage: minikube node delete NODE_NAME")
 		}
 
 		options := flags.CommandOptions()

--- a/cmd/minikube/cmd/node_start.go
+++ b/cmd/minikube/cmd/node_start.go
@@ -34,9 +34,10 @@ import (
 )
 
 var nodeStartCmd = &cobra.Command{
-	Use:   "start",
-	Short: "Starts a node.",
-	Long:  "Starts an existing stopped node in a cluster.",
+	Use:     "start NODE_NAME",
+	Short:   "Starts a node.",
+	Long:    "Starts an existing stopped node in a cluster.",
+	Example: "minikube node start m02",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			exit.Message(reason.Usage, "Usage: minikube node start [name]")

--- a/cmd/minikube/cmd/node_start.go
+++ b/cmd/minikube/cmd/node_start.go
@@ -34,12 +34,13 @@ import (
 )
 
 var nodeStartCmd = &cobra.Command{
-	Use:   "start",
-	Short: "Starts a node.",
-	Long:  "Starts an existing stopped node in a cluster.",
+	Use:     "start NODE_NAME",
+	Short:   "Starts a node.",
+	Long:    "Starts an existing stopped node in a cluster.",
+	Example: "minikube node start m02",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			exit.Message(reason.Usage, "Usage: minikube node start [name]")
+			exit.Message(reason.Usage, "Usage: minikube node start NODE_NAME")
 		}
 
 		options := flags.CommandOptions()

--- a/cmd/minikube/cmd/node_stop.go
+++ b/cmd/minikube/cmd/node_stop.go
@@ -32,9 +32,10 @@ import (
 )
 
 var nodeStopCmd = &cobra.Command{
-	Use:   "stop",
-	Short: "Stops a node in a cluster.",
-	Long:  "Stops a node in a cluster.",
+	Use:     "stop NODE_NAME",
+	Short:   "Stops a node in a cluster.",
+	Long:    "Stops a node in a cluster.",
+	Example: "minikube node stop m02",
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) == 0 {
 			exit.Message(reason.Usage, "Usage: minikube node stop [name]")

--- a/cmd/minikube/cmd/node_stop.go
+++ b/cmd/minikube/cmd/node_stop.go
@@ -32,12 +32,13 @@ import (
 )
 
 var nodeStopCmd = &cobra.Command{
-	Use:   "stop",
-	Short: "Stops a node in a cluster.",
-	Long:  "Stops a node in a cluster.",
+	Use:     "stop NODE_NAME",
+	Short:   "Stops a node in a cluster.",
+	Long:    "Stops a node in a cluster.",
+	Example: "minikube node stop m02",
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) == 0 {
-			exit.Message(reason.Usage, "Usage: minikube node stop [name]")
+			exit.Message(reason.Usage, "Usage: minikube node stop NODE_NAME")
 		}
 
 		options := flags.CommandOptions()

--- a/site/content/en/docs/commands/node.md
+++ b/site/content/en/docs/commands/node.md
@@ -94,7 +94,13 @@ Deletes a node from a cluster.
 Deletes a node from a cluster.
 
 ```shell
-minikube node delete [flags]
+minikube node delete NODE_NAME [flags]
+```
+
+### Examples
+
+```
+minikube node delete m02
 ```
 
 ### Options inherited from parent commands
@@ -203,7 +209,13 @@ Starts a node.
 Starts an existing stopped node in a cluster.
 
 ```shell
-minikube node start [flags]
+minikube node start NODE_NAME [flags]
+```
+
+### Examples
+
+```
+minikube node start m02
 ```
 
 ### Options
@@ -245,7 +257,13 @@ Stops a node in a cluster.
 Stops a node in a cluster.
 
 ```shell
-minikube node stop [flags]
+minikube node stop NODE_NAME [flags]
+```
+
+### Examples
+
+```
+minikube node stop m02
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
The delete, start and stop commands require the name of the node. This PR fixes the usage strings and adds an example invocation for each of these three commands.

I'm new to the project. This is how I made the change:
1. Edit `cmd/minikube/cmd/node_<action>.go` directly.
2. Run `make generate-docs` to create the changes to the `site/content/en/docs/commands/node.md` file.
3. Run `make` on my machine to generate the diff below.

The style is consistent with the `minikube addons enable` command.

### Help diff

Before:

```
$ out/minikube node delete --help
Deletes a node from a cluster.

Usage:
  minikube node delete [flags] [options]

Use "minikube options" for a list of global command-line options (applies to all commands).
```

After:

```
$ out/minikube node delete --help
Deletes a node from a cluster.

Examples:
minikube node delete m02

Usage:
  minikube node delete NODE_NAME [flags] [options]

Use "minikube options" for a list of global command-line options (applies to all commands).
```

