### PR TITLE
hack: fix amd-gpu-device-plugin update script version tag mismatch

### DIFF
--- a/hack/update/amd_device_gpu_plugin_version/amd_device_gpu_plugin_version.go
+++ b/hack/update/amd_device_gpu_plugin_version/amd_device_gpu_plugin_version.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/minikube/hack/update"
@@ -39,6 +40,19 @@ type Data struct {
 	SHA     string
 }
 
+// findMatchingImageTag finds the Docker Hub image tag corresponding to a GitHub release tag.
+// Docker Hub tags may include a numeric patch suffix not present in the GitHub release tag
+// (e.g. GitHub "v1.25.2" may correspond to Docker Hub "v1.25.2.8").
+// Tags should be provided newest-first (Docker Hub API default); the first match is returned.
+func findMatchingImageTag(tags []string, ghTag string) (string, error) {
+	for _, tag := range tags {
+		if tag == ghTag || strings.HasPrefix(tag, ghTag+".") {
+			return tag, nil
+		}
+	}
+	return "", fmt.Errorf("no Docker Hub image tag found matching GitHub release tag %s", ghTag)
+}
+
 func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
@@ -47,12 +61,23 @@ func main() {
 	if err != nil {
 		klog.Fatalf("Unable to get stable version: %v", err)
 	}
-	sha, err := update.GetImageSHA(fmt.Sprintf("rocm/k8s-device-plugin:%s", stable.Tag))
+
+	dockerTags, err := update.ImageTagsFromDockerHub("rocm/k8s-device-plugin")
+	if err != nil {
+		klog.Fatalf("failed to get Docker Hub tags for rocm/k8s-device-plugin: %v", err)
+	}
+
+	imageTag, err := findMatchingImageTag(dockerTags, stable.Tag)
+	if err != nil {
+		klog.Fatalf("failed to find Docker Hub image tag matching GitHub release tag %s: %v", stable.Tag, err)
+	}
+
+	sha, err := update.GetImageSHA(fmt.Sprintf("rocm/k8s-device-plugin:%s", imageTag))
 	if err != nil {
 		klog.Fatalf("failed to get image SHA: %v", err)
 	}
 
-	data := Data{Version: stable.Tag, SHA: sha}
+	data := Data{Version: imageTag, SHA: sha}
 
 	if err := update.Apply(schema, data); err != nil {
 		klog.Fatalf("unable to apply update: %v", err)


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 -->

**Fixes #21195**

## What does this PR do?

Fixes the `make update-amd-gpu-device-plugin-version` target which fails because GitHub release tags (e.g. `v1.25.2`) don't match Docker Hub image tags (e.g. `v1.25.2.8`) for `rocm/k8s-device-plugin`.

### Root cause

The update script called `update.GHReleases()` to get the stable release tag, then directly used that tag to pull the Docker Hub image SHA. But the ROCm k8s-device-plugin project publishes Docker Hub images with an extra numeric suffix (e.g. `v1.25.2.8`) not present in the GitHub release tag (`v1.25.2`), causing `manifest unknown` errors.

### Fix

1. Added `findMatchingImageTag(tags, ghTag)` helper that searches Docker Hub tags for one that either exactly matches the GitHub release tag or has it as a prefix (e.g. `v1.25.2` matches `v1.25.2.8`)
2. Updated `main()` to query Docker Hub tags via `update.ImageTagsFromDockerHub()` before resolving the image SHA
3. The resolved Docker Hub tag (not the GitHub tag) is now used for both the SHA lookup and the version written to `addons.go`

### Files changed
- `hack/update/amd_device_gpu_plugin_version/amd_device_gpu_plugin_version.go` — added tag resolution logic

## Testing

- `go build ./hack/update/amd_device_gpu_plugin_version/...` — passes
- `make lint` — 0 issues
- The `findMatchingImageTag` function is a pure function: exact match returns immediately, prefix match with `.` separator handles the `v1.25.2` → `v1.25.2.8` case, and returns an error if no match is found