### PR TITLE
Fix logic for multi-node CNI warning.

### DIFF
--- a/cmd/minikube/cmd/node_add.go
+++ b/cmd/minikube/cmd/node_add.go
@@ -87,7 +87,7 @@ var nodeAddCmd = &cobra.Command{
 				cc.Memory = 2200
 			}
 
-			if !cc.MultiNodeRequested || cni.IsDisabled(*cc) {
+			if !cc.MultiNodeRequested && cni.IsDisabled(*cc) {
 				warnAboutMultiNodeCNI()
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/19665

This PR fixes the logic for the warning `Cluster was created without any CNI, adding a node to it might cause broken networking.` which should be shown when adding a second node to a single-node cluster created without CNI.

The warning log was added in https://github.com/kubernetes/minikube/pull/9875 in response to this comment thread https://github.com/kubernetes/minikube/pull/9875#discussion_r539703728. The proposed solution was:

> We set and store a cluster config something like CreatedWithMultiNode bool true whenever user provides --node > 1. And we use this value to decide the CNI between KindNet and Disabled. And when a cluster is created with only control plane node and a node is added later, we show a warning that multi node networking might be broken (if it is not reconfigured already).

The warning should be shown when (1) the cluster is created with only a control plane node, and (2) CNI is not configured already. The corresponding change erroneously used an _or_ instead of _and_.

## Output diff

Before:

```
➜  minikube out/minikube start   
😄  minikube v1.38.1 on Darwin 26.3.1 (arm64)
✨  Automatically selected the docker driver
❗  Starting v1.39.0, minikube will default to "containerd" container runtime. See #21973 for more info.
📌  Using Docker Desktop driver with root privileges
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🚜  Pulling base image v0.0.50-1772266598-22719 ...
🔥  Creating docker container (CPUs=2, Memory=8100MB) ...
🐳  Preparing Kubernetes v1.35.1 on Docker 29.2.1 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

➜  minikube out/minikube node add
😄  Adding node m02 to cluster minikube as [worker]
❗  Cluster was created without any CNI, adding a node to it might cause broken networking.
👍  Starting "minikube-m02" worker node in "minikube" cluster
🚜  Pulling base image v0.0.50-1772266598-22719 ...
🔥  Creating docker container (CPUs=2, Memory=2200MB) ...
🐳  Preparing Kubernetes v1.35.1 on Docker 29.2.1 ...
🔎  Verifying Kubernetes components...
🏄  Successfully added m02 to minikube!
```

After:

```
➜  minikube out/minikube start   
😄  minikube v1.38.1 on Darwin 26.3.1 (arm64)
✨  Automatically selected the docker driver
❗  Starting v1.39.0, minikube will default to "containerd" container runtime. See #21973 for more info.
📌  Using Docker Desktop driver with root privileges
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🚜  Pulling base image v0.0.50-1772266598-22719 ...
🔥  Creating docker container (CPUs=2, Memory=8100MB) ...
🐳  Preparing Kubernetes v1.35.1 on Docker 29.2.1 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

➜  minikube out/minikube node add
😄  Adding node m02 to cluster minikube as [worker]
👍  Starting "minikube-m02" worker node in "minikube" cluster
🚜  Pulling base image v0.0.50-1772266598-22719 ...
🔥  Creating docker container (CPUs=2, Memory=2200MB) ...
🐳  Preparing Kubernetes v1.35.1 on Docker 29.2.1 ...
🔎  Verifying Kubernetes components...
🏄  Successfully added m02 to minikube!
```


<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
