### PR TITLE
fix: allow multiple minikube profiles to share the same network

### DIFF
--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/cruntime"
 	"k8s.io/minikube/pkg/minikube/download"
-	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/reason"
@@ -110,14 +109,11 @@ func (d *Driver) Create() error {
 		params.IP = staticIP
 	} else if gateway != nil {
 		params.Network = networkName
-		ip := gateway.To4()
-		// calculate the container IP based on guessing the machine index
-		index := driver.IndexFromMachineName(d.NodeConfig.MachineName)
-		if int(ip[3])+index > 253 { // reserve last client ip address for multi-control-plane loadbalancer vip address in ha cluster
-			return fmt.Errorf("too many machines to calculate an IP")
+		ip, err := oci.AllocateFreeContainerIP(d.OCIBinary, networkName, gateway)
+		if err != nil {
+			return fmt.Errorf("allocate IP in network %s: %w", networkName, err)
 		}
-		ip[3] += byte(index)
-		klog.Infof("calculated static IP %q for the %q container", ip.String(), d.NodeConfig.MachineName)
+		klog.Infof("allocated IP %q for the %q container", ip.String(), d.NodeConfig.MachineName)
 		params.IP = ip.String()
 	}
 	drv := d.DriverName()

--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -229,21 +229,30 @@ func podmanContainerIP(ociBin string, name string) (string, string, error) {
 	return output, "", nil
 }
 
+// dockerContainerInspect is a variable to allow mocking in tests.
+var dockerContainerInspect = inspect
+
 // dockerContainerIP returns ipv4, ipv6 of container or error
 func dockerContainerIP(ociBin string, name string) (string, string, error) {
 	// retrieve the IP address of the node using docker inspect
-	lines, err := inspect(ociBin, name, "{{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}{{end}}")
+	// use \n separator so each network entry is on its own line, supporting multiple attached networks
+	lines, err := dockerContainerInspect(ociBin, name, "{{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}\n{{end}}")
 	if err != nil {
 		return "", "", fmt.Errorf("inspecting NetworkSettings.Networks: %w", err)
 	}
 
-	if len(lines) != 1 {
-		return "", "", fmt.Errorf("IPs output should only be one line, got %d lines", len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		ips := strings.Split(line, ",")
+		if len(ips) != 2 {
+			return "", "", fmt.Errorf("container addresses should have 2 values, got %d values: %+v", len(ips), ips)
+		}
+		if ips[0] != "" {
+			return ips[0], ips[1], nil
+		}
 	}
-
-	ips := strings.Split(lines[0], ",")
-	if len(ips) != 2 {
-		return "", "", fmt.Errorf("container addresses should have 2 values, got %d values: %+v", len(ips), ips)
-	}
-	return ips[0], ips[1], nil
+	return "", "", fmt.Errorf("no IP address found for container %s", name)
 }

--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -120,6 +120,38 @@ func CreateNetwork(ociBin, networkName, subnet, staticIP string) (net.IP, error)
 	return info.gateway, fmt.Errorf("failed to create %s network %s: %w", ociBin, networkName, err)
 }
 
+// AllocateFreeContainerIP returns the first IP address within the network's
+// subnet (starting just above the gateway) that is not already assigned to an
+// existing container. This allows multiple minikube profiles to share the same
+// docker network without IP collisions.
+func AllocateFreeContainerIP(ociBin, networkName string, gateway net.IP) (net.IP, error) {
+	info, err := containerNetworkInspect(ociBin, networkName)
+	if err != nil {
+		return nil, fmt.Errorf("inspect network %s: %w", networkName, err)
+	}
+
+	used := make(map[string]bool, len(info.containerIPs))
+	for _, ip := range info.containerIPs {
+		used[ip.String()] = true
+	}
+
+	base := gateway.To4()
+	if base == nil {
+		return nil, fmt.Errorf("gateway %s is not an IPv4 address", gateway)
+	}
+	baseOctet := int(base[3])
+	for i := 1; baseOctet+i <= 253; i++ {
+		candidate := make(net.IP, 4)
+		copy(candidate, base)
+		candidate[3] = byte(baseOctet + i)
+		if !used[candidate.String()] {
+			klog.Infof("allocated free IP %q in network %q", candidate.String(), networkName)
+			return candidate, nil
+		}
+	}
+	return nil, fmt.Errorf("no free IP available in network %s", networkName)
+}
+
 func tryCreateDockerNetwork(ociBin string, subnet *network.Parameters, mtu int, name string) (net.IP, error) {
 	gateway := net.ParseIP(subnet.Gateway)
 	klog.Infof("attempt to create %s network %s %s with gateway %s and MTU of %d ...", ociBin, name, subnet.CIDR, subnet.Gateway, mtu)
@@ -168,10 +200,11 @@ func tryCreateDockerNetwork(ociBin string, subnet *network.Parameters, mtu int, 
 
 // netInfo holds part of a docker or podman network information relevant to kic drivers
 type netInfo struct {
-	name    string
-	subnet  *net.IPNet
-	gateway net.IP
-	mtu     int
+	name         string
+	subnet       *net.IPNet
+	gateway      net.IP
+	mtu          int
+	containerIPs []net.IP // IP addresses of containers already connected to this network
 }
 
 func containerNetworkInspect(ociBin string, name string) (netInfo, error) {
@@ -229,6 +262,15 @@ func dockerNetworkInspect(name string) (netInfo, error) {
 	_, info.subnet, err = net.ParseCIDR(vals.Subnet)
 	if err != nil {
 		return info, fmt.Errorf("parse subnet for %s: %w", name, err)
+	}
+
+	for _, cidr := range vals.ContainerIPs {
+		ip, _, err := net.ParseCIDR(cidr)
+		if err != nil {
+			klog.Warningf("skipping unparseable container IP %q in network %s: %v", cidr, name, err)
+			continue
+		}
+		info.containerIPs = append(info.containerIPs, ip)
 	}
 
 	return info, nil

--- a/pkg/drivers/kic/oci/network_create_test.go
+++ b/pkg/drivers/kic/oci/network_create_test.go
@@ -38,6 +38,7 @@ func TestDockerInspect(t *testing.T) {
 		gateway               string
 		subnetIP              string
 		mtu                   int
+		containerIPs          []string
 	}{
 		{
 			name:                  "withMTU",
@@ -53,13 +54,19 @@ func TestDockerInspect(t *testing.T) {
 			subnetIP:              "172.19.0.0",
 			mtu:                   0,
 		},
+		{
+			name:                  "withContainerIPs",
+			dockerInspectResponse: `{"Name": "mynet","Driver": "bridge","Subnet": "192.168.49.0/24","Gateway": "192.168.49.1","MTU": 1500, "ContainerIPs": ["192.168.49.2/24","192.168.49.3/24"]}`,
+			gateway:               "192.168.49.1",
+			subnetIP:              "192.168.49.0",
+			mtu:                   1500,
+			containerIPs:          []string{"192.168.49.2", "192.168.49.3"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			dockerInspectResponseWithMtu := tc.dockerInspectResponse
-
 			// setting up mock funcs
-			dockerResponse = dockerInspectResponseWithMtu
+			dockerResponse = tc.dockerInspectResponse
 			dockerInspectGetter = dockerInspectGetterMock
 
 			netInfo, err := dockerNetworkInspect("m2")
@@ -78,6 +85,61 @@ func TestDockerInspect(t *testing.T) {
 
 			if !netInfo.subnet.IP.Equal(net.ParseIP(tc.subnetIP)) {
 				t.Errorf("Expected subnet to be %v but got %v", tc.subnetIP, netInfo.subnet.IP)
+			}
+
+			if len(netInfo.containerIPs) != len(tc.containerIPs) {
+				t.Errorf("Expected %d containerIPs but got %d: %v", len(tc.containerIPs), len(netInfo.containerIPs), netInfo.containerIPs)
+			} else {
+				for i, want := range tc.containerIPs {
+					if !netInfo.containerIPs[i].Equal(net.ParseIP(want)) {
+						t.Errorf("containerIPs[%d]: got %v, want %v", i, netInfo.containerIPs[i], want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestAllocateFreeContainerIP(t *testing.T) {
+	gateway := net.ParseIP("192.168.49.1")
+
+	tests := []struct {
+		name          string
+		inspectJSON   string
+		wantIP        string
+		wantErr       bool
+	}{
+		{
+			name:        "no existing containers — returns gateway+1",
+			inspectJSON: `{"Name": "mynet","Driver": "bridge","Subnet": "192.168.49.0/24","Gateway": "192.168.49.1","MTU": 1500, "ContainerIPs": []}`,
+			wantIP:      "192.168.49.2",
+		},
+		{
+			name:        "first ip taken by another profile — returns next free",
+			inspectJSON: `{"Name": "mynet","Driver": "bridge","Subnet": "192.168.49.0/24","Gateway": "192.168.49.1","MTU": 1500, "ContainerIPs": ["192.168.49.2/24"]}`,
+			wantIP:      "192.168.49.3",
+		},
+		{
+			name:        "multiple ips taken — returns first gap",
+			inspectJSON: `{"Name": "mynet","Driver": "bridge","Subnet": "192.168.49.0/24","Gateway": "192.168.49.1","MTU": 1500, "ContainerIPs": ["192.168.49.2/24","192.168.49.3/24","192.168.49.4/24"]}`,
+			wantIP:      "192.168.49.5",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dockerResponse = tc.inspectJSON
+			dockerInspectGetter = dockerInspectGetterMock
+
+			got, err := AllocateFreeContainerIP(Docker, "mynet", gateway)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr=%v, got err=%v", tc.wantErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if !got.Equal(net.ParseIP(tc.wantIP)) {
+				t.Errorf("got IP %v, want %v", got, tc.wantIP)
 			}
 		})
 	}

--- a/pkg/drivers/kic/oci/network_test.go
+++ b/pkg/drivers/kic/oci/network_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDockerContainerIP(t *testing.T) {
+	tests := []struct {
+		name        string
+		inspectOut  []string // lines returned by the mocked inspect call
+		wantIPv4    string
+		wantIPv6    string
+		wantErr     bool
+	}{
+		{
+			name:       "single network with ipv4",
+			inspectOut: []string{"10.0.0.2,"},
+			wantIPv4:   "10.0.0.2",
+			wantIPv6:   "",
+		},
+		{
+			name:       "single network with ipv4 and ipv6",
+			inspectOut: []string{"10.0.0.2,fe80::1"},
+			wantIPv4:   "10.0.0.2",
+			wantIPv6:   "fe80::1",
+		},
+		{
+			name:       "multiple networks returns first with ipv4",
+			inspectOut: []string{"10.0.0.2,", "192.168.1.5,"},
+			wantIPv4:   "10.0.0.2",
+			wantIPv6:   "",
+		},
+		{
+			name:       "first network has no ipv4 falls through to next",
+			inspectOut: []string{",fe80::1", "10.0.0.2,"},
+			wantIPv4:   "10.0.0.2",
+			wantIPv6:   "",
+		},
+		{
+			name:       "blank lines are skipped",
+			inspectOut: []string{"", "  ", "10.0.0.2,"},
+			wantIPv4:   "10.0.0.2",
+			wantIPv6:   "",
+		},
+		{
+			name:       "no network has ipv4",
+			inspectOut: []string{",fe80::1"},
+			wantErr:    true,
+		},
+		{
+			name:       "empty output",
+			inspectOut: []string{},
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := dockerContainerInspect
+			t.Cleanup(func() { dockerContainerInspect = orig })
+
+			dockerContainerInspect = func(_, _, _ string) ([]string, error) {
+				return tc.inspectOut, nil
+			}
+
+			ipv4, ipv6, err := dockerContainerIP("docker", "minikube")
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr=%v, got err=%v", tc.wantErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if ipv4 != tc.wantIPv4 {
+				t.Errorf("ipv4: got %q, want %q", ipv4, tc.wantIPv4)
+			}
+			if ipv6 != tc.wantIPv6 {
+				t.Errorf("ipv6: got %q, want %q", ipv6, tc.wantIPv6)
+			}
+		})
+	}
+}
+
+func TestDockerContainerIPMalformedLine(t *testing.T) {
+	orig := dockerContainerInspect
+	t.Cleanup(func() { dockerContainerInspect = orig })
+
+	// A line with more or fewer than 2 comma-separated fields should error.
+	dockerContainerInspect = func(_, _, _ string) ([]string, error) {
+		return []string{"10.0.0.2"}, nil // missing the comma separator
+	}
+
+	_, _, err := dockerContainerIP("docker", "minikube")
+	if err == nil {
+		t.Error("expected error for malformed inspect line, got nil")
+	}
+	if !strings.Contains(err.Error(), "container addresses should have 2 values") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}


### PR DESCRIPTION
fixes #14799.

This change makes it possible to start multiple minikube profiles and provide the same value for `--network`. 
Previously, this would fail because both profiles would attempt to use the same IP in that network, and trigger this error:
` ❌  Exiting due to GUEST_PROVISION: Failed to start host: can't create with that IP, address already in use`

The fix here is in `pkg/drivers/kic/oci/network_create.go` (as suggested by @medyagh in the issue linked above): surface the ContainerIPs that docker network inspect already returns (they were parsed but discarded). Add AllocateFreeContainerIP, which inspects the live container IPs on a network and returns the first unoccupied address starting from gateway+1. This is analogous to how FreeSubnet works for network allocation.
I also made a minor change to `pkg/drivers/kic/oci/network.go` to handle containers attached to multiple networks. This could be useful if you wanted to attach a shared network to the two profiles *after* start time.

My use case for this:
I'm working on an application that involves multiple kubernetes clusters, and some of the pods within each cluster will need to send traffic to a pod in another cluster. Modeling that setup with minikube (for testing) isn't possible right now because there's no way for a pod in cluster A to route its traffic to cluster B since they are on separate networks. 

I welcome your thoughts!