### PR TITLE
docs: clarify WSL Docker driver access patterns

### DIFF
--- a/site/content/en/docs/drivers/docker.md
+++ b/site/content/en/docs/drivers/docker.md
@@ -15,7 +15,7 @@ The Docker driver allows you to install Kubernetes into an existing Docker insta
 
 - [Install Docker](https://docs.docker.com/engine/install/) 18.09 or higher (20.10 or higher is recommended)
 - amd64 or arm64 system.
-- If using WSL complete [these steps]({{<ref "/docs/tutorials/wsl_docker_driver">}}) first
+- If using WSL, complete [these steps]({{<ref "/docs/tutorials/wsl_docker_driver">}}) first.
 - Don't forget to follow this [step](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) to manage Docker as a non-root user.
 
 ## Usage
@@ -72,6 +72,8 @@ It is recommended to set the `--container-runtime` flag to "containerd".
 - On WSL2 (experimental - see [#5392](https://github.com/kubernetes/minikube/issues/5392)), you may need to run:
 
    `sudo mkdir /sys/fs/cgroup/systemd && sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd`.
+
+- On Windows and WSL with the Docker driver, the node IP is not reachable directly. Use `minikube service --url` for `NodePort` services, and use `minikube tunnel` for `LoadBalancer` services or ingress. For ingress specifically, access it via `127.0.0.1` or `localhost` while the tunnel is running.
 
 Also see [co/docker-driver open issues](https://github.com/kubernetes/minikube/labels/co%2Fdocker-driver).
 

--- a/site/content/en/docs/tutorials/wsl_docker_driver.md
+++ b/site/content/en/docs/tutorials/wsl_docker_driver.md
@@ -1,17 +1,46 @@
 ---
-title: "Setting Up WSL 2 & Docker Desktop"                                 
-linkTitle: "Setting Up WSL 2 & Docker Desktop"
+title: "Setting Up WSL 2 for the Docker driver"
+linkTitle: "Setting Up WSL 2"
 weight: 1
 date: 2022-01-12
 ---
 
 ## Overview
 
-- This guide will show you how to setup WSL 2 and Docker Desktop.
+This guide shows how to prepare WSL 2 so you can run minikube with the Docker driver.
 
+If you install Docker inside your WSL distribution, follow the standard Linux Docker installation guide and complete the post-install steps for non-root usage.
+
+If you use Docker Desktop, make sure WSL integration is enabled for the distribution where you run `minikube`.
 
 ## Steps
-Microsoft and Docker have in-depth guides for both, just follow along for a successful setup!
 
-1. [Install WSL](https://docs.microsoft.com/en-us/windows/wsl/install)
-2. Install and setup [Docker Desktop for Windows](https://docs.docker.com/desktop/windows/wsl/#download)
+1. [Install WSL](https://learn.microsoft.com/windows/wsl/install).
+2. Choose one Docker setup:
+   - Install Docker inside your WSL distribution by following the [Docker Engine installation guide](https://docs.docker.com/engine/install/) and the [Linux post-install steps](https://docs.docker.com/engine/install/linux-postinstall/).
+   - Or install and configure [Docker Desktop for Windows](https://docs.docker.com/desktop/windows/wsl/#download), then enable WSL integration for your distribution.
+3. Verify that Docker works from inside WSL:
+
+   ```shell
+   docker version
+   docker ps
+   ```
+
+4. Start minikube with the Docker driver:
+
+   ```shell
+   minikube start --driver=docker
+   ```
+
+## Accessing services on WSL
+
+When you use the Docker driver on Windows or WSL, the node IP is not reachable directly. If `minikube ip` prints an address such as `127.0.0.1` or `192.168.49.2`, do not rely on that alone to access your workloads from a browser.
+
+- For `NodePort` services, use `minikube service <service-name> --url` and keep that terminal open while you access the forwarded URL.
+- For `LoadBalancer` services or ingress, run `minikube tunnel` in a separate terminal and keep it running while you access the service.
+- For ingress on WSL with the Docker driver, use `127.0.0.1` or `localhost` together with `minikube tunnel` rather than the node IP.
+
+See also:
+
+- [Accessing apps]({{< ref "/docs/handbook/accessing/" >}})
+- [Docker driver]({{< ref "/docs/drivers/docker/" >}})


### PR DESCRIPTION
## Summary
- broaden the WSL Docker driver tutorial so it covers both Docker inside WSL and Docker Desktop with WSL integration
- add explicit service-access guidance for WSL/Windows Docker driver users who cannot reach the node IP directly
- point readers to `minikube service --url`, `minikube tunnel`, and `127.0.0.1` / `localhost` for ingress access

## Validation
- `cd site && npm ci`
- independent doc review against the current handbook and issue discussion

Fixes #7879
