### PR TITLE
docs: clarify generated image build test docs

### DIFF
--- a/site/content/en/docs/contrib/tests.en.md
+++ b/site/content/en/docs/contrib/tests.en.md
@@ -133,7 +133,9 @@ Steps:
 runs tests on all the `minikube image` commands, ex. `minikube image load`, `minikube image list`, etc.
 
 Steps:
-- Make sure image building works by `minikube image build`
+- Build an image with `minikube image build` using `test/integration/testdata/build/Dockerfile`
+- Add `content.txt` from the build context into a `gcr.io/k8s-minikube/busybox` image and tag it as `localhost/my-image:<profile>`
+- Start `buildkitd` on demand inside minikube only when the build runs, then verify the new image exists in the cluster runtime
 - Make sure image loading from Docker daemon works by `minikube image load --daemon`
 - Try to load image already loaded and make sure `minikube image load --daemon` works
 - Make sure a new updated tag works by `minikube image load --daemon`

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -315,7 +315,9 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 	runImageList(ctx, t, profile, "ImageListJson", "json", "[\"%s")
 	runImageList(ctx, t, profile, "ImageListYaml", "yaml", "- %s")
 
-	// docs: Make sure image building works by `minikube image build`
+	// docs: Build an image with `minikube image build` using `test/integration/testdata/build/Dockerfile`
+	// docs: Add `content.txt` from the build context into a `gcr.io/k8s-minikube/busybox` image and tag it as `localhost/my-image:<profile>`
+	// docs: Start `buildkitd` on demand inside minikube only when the build runs, then verify the new image exists in the cluster runtime
 	t.Run("ImageBuild", func(t *testing.T) {
 		MaybeParallel(t)
 


### PR DESCRIPTION
## Summary
- make the generated integration test docs for `validateImageCommands` describe the actual image-build path in more detail
- mention the Dockerfile fixture, copied `content.txt`, on-demand `buildkitd` startup, and runtime image verification
- regenerate `site/content/en/docs/contrib/tests.en.md`

## Testing
- `PATH="/opt/homebrew/bin:$PATH" go test ./cmd/minikube/cmd -run TestGenerateTestDocs`
- `PATH="/opt/homebrew/bin:$PATH" make generate-docs`

Closes #11571
