### PR TITLE
kicbase: fix deterministic machine-id breaking MAC addresses in multi-node Podman rootless clusters

### DIFF
--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -290,6 +290,12 @@ RUN rm -rf \
   /usr/share/doc/* \
   /usr/share/man/* \
   /usr/share/local/*
+
+# Per https://systemd.io/CONTAINER_INTERFACE/, /etc/machine-id must be present
+# but empty in a container image so it is freshly initialized on each boot.
+# Remove /var/lib/dbus/machine-id so that systemd-machine-id-setup cannot fall
+# back to a baked-in value, which would make every container share the same ID.
+RUN truncate -s 0 /etc/machine-id && rm -f /var/lib/dbus/machine-id
 RUN echo "kic! Build: ${COMMIT_SHA} Time :$(date)" > "/kic.txt"
 
 # squash all layers into one

--- a/deploy/kicbase/entrypoint
+++ b/deploy/kicbase/entrypoint
@@ -357,14 +357,6 @@ retryable_fix_cgroup() {
     exit 31
 }
 
-fix_machine_id() {
-  # Deletes the machine-id embedded in the node image and generates a new one.
-  # This is necessary because both kubelet and other components like weave net
-  # use machine-id internally to distinguish nodes.
-  echo 'INFO: clearing and regenerating /etc/machine-id' >&2
-  rm -f /etc/machine-id
-  systemd-machine-id-setup
-}
 
 fix_product_name() {
   # this is a small fix to hide the underlying hardware and fix issue #426
@@ -545,7 +537,6 @@ configure_containerd
 configure_proxy
 fix_mount
 retryable_fix_cgroup
-fix_machine_id
 fix_product_name
 fix_product_uuid
 select_iptables


### PR DESCRIPTION
## Problem

`/var/lib/dbus/machine-id` is baked into the kicbase container image at build time. When the entrypoint's `fix_machine_id` runs `systemd-machine-id-setup`, it finds that file and derives `/etc/machine-id` from it — producing the **same machine ID in every container**.

This breaks anything that depends on the machine ID being unique per node. The most visible symptom is in **multi-node minikube clusters using Podman rootless mode**: a `veth` interface is placed into each Podman container, and systemd configures it according to `MACAddressPolicy=persistent`. That policy selects a MAC address based on the machine ID (via `systemd-machine-id-setup`, which reads from the D-Bus machine ID: https://www.freedesktop.org/software/systemd/man/latest/systemd-machine-id-setup.html). Because all containers share the same machine ID derived from the baked-in D-Bus ID, **all nodes get identical MAC addresses on `eth0`**, causing network failures.

## Fix

Per https://systemd.io/CONTAINER_INTERFACE/, add a `RUN` step to the Dockerfile (before the final squash) that:
- **Truncates `/etc/machine-id` to an empty file** — the spec requires the file to be present but uninitialized so systemd can fill it on boot.
- **Deletes `/var/lib/dbus/machine-id`** — removes the baked-in D-Bus ID that was the source of the deterministic machine ID.

With these changes, systemd generates a fresh random machine ID on every container boot without any entrypoint assistance. This makes the existing `fix_machine_id` function in the entrypoint redundant — it has been **removed**.

## Testing

Tested against the real kicbase image (`gcr.io/k8s-minikube/kicbase-builds:v0.0.50-1772266598-22719`) with Podman rootless.

### Reproducing the bug

Both files contain the same baked-in value in the current image:

```
$ KICBASE=gcr.io/k8s-minikube/kicbase-builds:v0.0.50-1772266598-22719
$ podman run --rm --entrypoint bash $KICBASE -c '
    echo "/etc/machine-id:          $(cat /etc/machine-id)"
    echo "/var/lib/dbus/machine-id: $(cat /var/lib/dbus/machine-id)"
  '
/etc/machine-id:          636135c8833b3f1430bfc1ec69a2a4d1
/var/lib/dbus/machine-id: 636135c8833b3f1430bfc1ec69a2a4d1
```

Running `systemd-machine-id-setup` (as `fix_machine_id` does) produces the same ID every time:

```
$ for i in 1 2 3; do
    podman run --rm --entrypoint bash $KICBASE -c '
      rm -f /etc/machine-id; systemd-machine-id-setup 2>/dev/null; cat /etc/machine-id'
  done
636135c8833b3f1430bfc1ec69a2a4d1
636135c8833b3f1430bfc1ec69a2a4d1
636135c8833b3f1430bfc1ec69a2a4d1
```

### Verifying the fix

Build a patched image applying the fix on top of the current kicbase:

```
$ podman build -t kicbase-patched - <<EOF
FROM $KICBASE
RUN truncate -s 0 /etc/machine-id && rm -f /var/lib/dbus/machine-id
EOF
```

Confirm the image state:

```
$ podman run --rm --entrypoint bash kicbase-patched -c '
    echo "/etc/machine-id size: $(wc -c < /etc/machine-id) bytes"
    ls /var/lib/dbus/machine-id 2>/dev/null || echo "/var/lib/dbus/machine-id: (removed)"
  '
/etc/machine-id size: 0 bytes
/var/lib/dbus/machine-id: (removed)
```

Each container now gets a unique machine ID:

```
$ for i in 1 2 3; do
    podman run --rm --entrypoint bash kicbase-patched -c '
      systemd-machine-id-setup 2>/dev/null; cat /etc/machine-id'
  done
4c971ecb6dc34159ad1da13a867a51c3
2d717cadb4804b1b9863f7b8b2da998d
b25726fead9246f691e97b3a63834de2
```