### PR TITLE
test: remove duplicate kubernetes versions in tests

### DIFF
--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -61,12 +61,9 @@ func TestDownloadOnly(t *testing.T) { // nolint:gocyclo
 	versions := []string{
 		constants.OldestKubernetesVersion,
 		constants.DefaultKubernetesVersion,
-		constants.NewestKubernetesVersion,
 	}
-
-	// Small optimization, don't run the exact same set of tests twice
-	if constants.DefaultKubernetesVersion == constants.NewestKubernetesVersion {
-		versions = versions[:len(versions)-1]
+	if constants.DefaultKubernetesVersion != constants.NewestKubernetesVersion {
+		versions = append(versions, constants.NewestKubernetesVersion)
 	}
 
 	for _, v := range versions {


### PR DESCRIPTION
Closing as superseded — the duplicate version issue has been addressed with a more robust upstream fix using slices.Contains deduplication in the latest master branch. Thank you!