### PR TITLE
Fix ai-playground.md request limits to use the `devices.es/dri`

### DIFF
--- a/site/content/en/docs/tutorials/ai-playground.md
+++ b/site/content/en/docs/tutorials/ai-playground.md
@@ -213,7 +213,7 @@ spec:
         ]
         resources:
           limits:
-            squat.ai/dri: 1
+            devic.es/dri: 1
         volumeMounts:
         - name: models
           mountPath: /mnt/models

--- a/site/content/en/docs/tutorials/ai-playground.md
+++ b/site/content/en/docs/tutorials/ai-playground.md
@@ -295,7 +295,7 @@ spec:
         ]
         resources:
           limits:
-            squat.ai/dri: 3
+            devic.es/dri: 3
         volumeMounts:
         - name: models
           mountPath: /mnt/models


### PR DESCRIPTION
Node allocation

Was following this document and upon trying to deploy granite model, Granite pod stuck in pending status checking further the pod status and describe the events of pod noticed below error

**Warning FailedScheduling 4m8s (x3 over 14m) default-scheduler 0/1 nodes are available: 1 Insufficient squat.ai/dri. no new claims to deallocate, preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.**

On further analysis noticed that node capacity was pointing to wrong limits key

In document it is **squat.ai/dri**, But in minikube node level it is **devic.es/dri**

After updating the same the deployment was successful and granite pod creation is successful

Same issue noticed for **tinyllama**

Before:

<img width="1520" height="118" alt="image" src="https://github.com/user-attachments/assets/066e57a1-62f5-445f-af48-beba1329ede1" />

After changes:

<img width="1118" height="170" alt="image" src="https://github.com/user-attachments/assets/b5a61937-a3a9-4c5c-8807-f209d48386be" />


