### PR TITLE
fix(tunnel): use flexible OK check for Windows route command output

### DIFF
--- a/pkg/minikube/tunnel/route_windows.go
+++ b/pkg/minikube/tunnel/route_windows.go
@@ -49,14 +49,17 @@ func (router *osRouter) EnsureRouteIsAdded(route *Route) error {
 	klog.Infof("About to run command: %s", command.Args)
 	stdInAndOut, err := command.CombinedOutput()
 	message := string(stdInAndOut)
-	if message != " OK!\r\n" {
-		return fmt.Errorf("error adding route: %s, %d", message, len(strings.Split(message, "\n")))
-	}
-	klog.Infof("%s", stdInAndOut)
 	if err != nil {
-		klog.Errorf("error adding Route: %s, %d", message, len(strings.Split(message, "\n")))
-		return err
+		klog.Errorf("error adding Route: %s", message)
+		return fmt.Errorf("error adding route: %w, output: %s", err, message)
 	}
+	// Windows route command returns " OK!" on success, but the exact whitespace
+	// and line endings can vary across Windows versions and locales.
+	// Use a case-insensitive contains check instead of strict equality.
+	if !strings.Contains(strings.ToUpper(strings.TrimSpace(message)), "OK") {
+		return fmt.Errorf("error adding route: unexpected output: %q", message)
+	}
+	klog.Infof("Successfully added route, output: %s", stdInAndOut)
 	return nil
 }
 
@@ -135,8 +138,10 @@ func (router *osRouter) Cleanup(route *Route) error {
 	}
 	message := string(stdInAndOut)
 	klog.Infof("'%s'", message)
-	if message != " OK!\r\n" {
-		return fmt.Errorf("error deleting route: %s, %d", message, len(strings.Split(message, "\n")))
+	// Use a case-insensitive contains check for "OK" to handle variations
+	// in Windows route command output across different versions and locales.
+	if !strings.Contains(strings.ToUpper(strings.TrimSpace(message)), "OK") {
+		return fmt.Errorf("error deleting route: unexpected output: %q", message)
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

Fixes #11645

`minikube tunnel` on Windows endlessly retries adding a route because the code does a strict string equality check against `" OK!\r\n"`. The Windows `route` command output can vary across different Windows versions, locales, and system configurations — meaning the exact whitespace or line endings may differ, causing the check to always fail and triggering an infinite retry loop.

## Root Cause

In `pkg/minikube/tunnel/route_windows.go`, both `EnsureRouteIsAdded` and `Cleanup` used:
```go
if message != " OK!\r\n" {
    return fmt.Errorf("error adding route: ...")
}
```
This strict equality fails when the output has slightly different formatting.

## Fix

Replaced the strict equality check with a case-insensitive `strings.Contains` check for `"OK"` after trimming whitespace:
```go
if !strings.Contains(strings.ToUpper(strings.TrimSpace(message)), "OK") {
    return fmt.Errorf("error adding route: unexpected output: %q", message)
}
```
This is robust across different Windows environments while still correctly detecting success vs failure.

Also improved error handling in `EnsureRouteIsAdded` to properly wrap the `err` from `CombinedOutput` using `%w` before checking the output string.

## Testing

- Verified the fix handles `" OK!\r\n"`, `" OK!\n"`, `"OK"`, and other valid success variations
- Verified failure cases (empty output, error messages) still return errors correctly