### PR TITLE
iso: support building the arm64 ISO on an arm64 host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,11 @@ buildroot:
 	if [ ! -d $(BUILD_DIR)/buildroot ]; then \
 		mkdir -p $(BUILD_DIR); \
 		git clone --depth=1 --branch=$(BUILDROOT_BRANCH) https://github.com/buildroot/buildroot $(BUILD_DIR)/buildroot; \
+		for p in $(CURDIR)/deploy/iso/minikube-iso/patches/buildroot/*.patch; do \
+			[ -f "$$p" ] || continue; \
+			echo "Applying buildroot patch: $$p"; \
+			(cd $(BUILD_DIR)/buildroot && patch -p1 -i "$$p") || exit 1; \
+		done; \
 	fi;
 
 # Change buildroot configuration for the minikube ISO

--- a/deploy/iso/minikube-iso/patches/buildroot/0001-host-go-aarch64-stage1.patch
+++ b/deploy/iso/minikube-iso/patches/buildroot/0001-host-go-aarch64-stage1.patch
@@ -1,0 +1,29 @@
+Add aarch64 as a supported host arch for the Go bootstrap stage 1.
+
+The stage1 gate in the upstream buildroot config only default-y's for
+x86, x86_64 and arm hosts. On an aarch64 host this leaves
+BR2_PACKAGE_HOST_GO_BOOTSTRAP_STAGE1_ARCH_SUPPORTS unset, which in
+turn leaves BR2_PACKAGE_HOST_GO_TARGET_ARCH_SUPPORTS unset, which
+silently drops every Go-target package (cri-dockerd, cni-plugins,
+podman, crio-bin, ...) from the build. The resulting arm64 minikube
+ISO is ~80 MB short and the provisioner fails at the docker.service
+restart step because no docker.service file was ever installed.
+
+The gate is correct for host-go-src (source bootstrap of Go has real
+host arch restrictions), but minikube resolves host-go via
+host-go-bin (PROVIDES_HOST_GO="host-go-bin"), and prebuilt Go binaries
+support aarch64 natively. Allow aarch64 in the stage1 default list so
+Go-target packages build correctly when the buildroot host is aarch64
+(e.g. Colima on an Apple Silicon Mac).
+
+This is a local patch; the proper fix belongs upstream in buildroot.
+
+Signed-off-by: Jon Williams <jon@jonwilliams.org.uk>
+
+--- a/package/go/go-bootstrap-stage1/Config.in.host
++++ b/package/go/go-bootstrap-stage1/Config.in.host
+@@ -4,3 +4,4 @@ config BR2_PACKAGE_HOST_GO_BOOTSTRAP_STAGE1_ARCH_SUPPORTS
+ 	default y if BR2_HOSTARCH = "x86"
+ 	default y if BR2_HOSTARCH = "x86_64"
+ 	default y if BR2_HOSTARCH = "arm"
++	default y if BR2_HOSTARCH = "aarch64"


### PR DESCRIPTION
Fix for arm64-host buildroot builds of the minikube arm64 ISO.

## Problem

On an arm64 Linux host (e.g. Colima on Apple Silicon), `make minikube-iso-aarch64` completes with exit 0 but silently produces a **~319 MB** ISO instead of the expected **~403 MB**. The ISO boots fine, but `minikube start` fails during provisioning:

```
diff: can't stat '/lib/systemd/system/docker.service': No such file or directory
Created symlink '/etc/systemd/system/multi-user.target.wants/docker.service' -> '/usr/lib/systemd/system/docker.service'.
Job for docker.service failed because the control process exited with error code.
```

Same failure mode on vfkit, qemu2, and virtualbox (so it isn't driver-specific).

## Root cause

buildroot's `BR2_PACKAGE_HOST_GO_BOOTSTRAP_STAGE1_ARCH_SUPPORTS` only default-y's for x86, x86_64 and arm hosts. When the buildroot host is aarch64 the symbol stays unset, which leaves `BR2_PACKAGE_HOST_GO_TARGET_ARCH_SUPPORTS` unset, which silently drops every Go-target package: `cri-dockerd-aarch64`, `cni-plugins-latest-aarch64`, `podman`, `crio-bin`, plus transitive deps. `docker-bin-aarch64` has no host-go dependency and still installs, which is why the docker binary ends up in the ISO but none of the CRI service glue does.

The gate is the right shape for `host-go-src` (source bootstrap of Go has real host arch restrictions), but minikube resolves host-go via `host-go-bin` which has a prebuilt Go binary for aarch64 and works fine. The stage1 gate is overly strict for the `host-go-bin` case.

## Fix

Adds a buildroot patch at `deploy/iso/minikube-iso/patches/buildroot/0001-host-go-aarch64-stage1.patch`:

```diff
--- a/package/go/go-bootstrap-stage1/Config.in.host
+++ b/package/go/go-bootstrap-stage1/Config.in.host
@@ -4,3 +4,4 @@ config BR2_PACKAGE_HOST_GO_BOOTSTRAP_STAGE1_ARCH_SUPPORTS
 	default y if BR2_HOSTARCH = "x86"
 	default y if BR2_HOSTARCH = "x86_64"
 	default y if BR2_HOSTARCH = "arm"
+	default y if BR2_HOSTARCH = "aarch64"
```

Extends the `buildroot:` target in the top-level Makefile to apply any `*.patch` files dropped into that directory right after the initial `git clone`. Any future per-host fixes can be added there without further Makefile work.

The proper long-term fix belongs upstream in buildroot; this is a pragmatic near-term workaround so local arm64-host builds produce the same artifact as CI.

## Test

On darwin/arm64 (M-series Mac, Colima `--vm-type vz --arch aarch64`):

- Before this PR: ISO 319 MB, provisioning fails on all drivers at docker.service restart.
- After this PR: ISO 403 MB (size-matches the published `minikube-v1.38.0-arm64.iso`), `cri-docker.service`, `crio.service`, `podman.service`, `cri-dockerd`/`crio`/`podman` binaries all present.
- `minikube start --driver=vfkit|qemu2|virtualbox` all produce a `Ready` control-plane node on the newly-built ISO.
- `make minikube-iso-x86_64` unaffected (patch only activates on aarch64 hosts).

Upstream CI (x86_64 builders) is unaffected.

## Related
- Fixes #22866 (the bug this PR works around).
- Found while validating PR #22861 (darwin/arm64 VirtualBox support); the two PRs are independent.

