### PR TITLE
podman: propagate network, static-ip, and gpus flags to kic driver

### DIFF
--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -96,8 +96,11 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		KubernetesVersion: cc.KubernetesConfig.KubernetesVersion,
 		ContainerRuntime:  cc.KubernetesConfig.ContainerRuntime,
 		ExtraArgs:         extraArgs,
-		ListenAddress:     cc.ListenAddress,
+		Network:           cc.Network,
 		Subnet:            cc.Subnet,
+		StaticIP:          cc.StaticIP,
+		ListenAddress:     cc.ListenAddress,
+		GPUs:              cc.GPUs,
 	}), nil
 }
 


### PR DESCRIPTION
Fixes #22867.

## Problem

`minikube start --driver=podman --network=foo` silently ignores `--network`; the resulting container is attached to the default `minikube` network instead.

## Root cause

In `pkg/minikube/registry/drvs/podman/podman.go`, the `configure` function builds a `kic.Config` from the `ClusterConfig` but does not copy the `Network`, `StaticIP`, or `GPUs` fields. The equivalent docker driver (`pkg/minikube/registry/drvs/docker/docker.go`) does copy them. As a result, `d.NodeConfig.Network` is always empty when using podman, and `pkg/drivers/kic/kic.go` falls back to `d.NodeConfig.ClusterName` (i.e. `minikube`) as the network name.

## Fix

Copy `cc.Network`, `cc.StaticIP`, and `cc.GPUs` into the podman driver's `kic.Config`, matching the docker driver.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/drivers/kic/... ./pkg/minikube/registry/drvs/podman/...`