### PR TITLE
cmd/config: remove duplicate Header call in addon images table

### DIFF
--- a/cmd/minikube/cmd/config/images.go
+++ b/cmd/minikube/cmd/config/images.go
@@ -65,7 +65,6 @@ func printAddonImagesTable(addon string) {
 
 			var tData [][]string
 			table := tablewriter.NewWriter(os.Stdout)
-			table.Header([]string{"Image Name", "Default Image", "Default Registry"})
 			table.Header("Image Name", "Default Image", "Default Registry")
 			table.Options(
 				tablewriter.WithHeaderAutoFormat(tw.On),


### PR DESCRIPTION
`printAddonImagesTable` in `cmd/minikube/cmd/config/images.go` calls `table.Header(...)` twice in a row with identical content — once with a slice, then again with varargs. The second call overrides the first, so the slice-form call is dead code. Introduced by the table-rendering refactor in #20893.

Removing the unused slice-form call keeps the file consistent with every other `table.Header(...)` call site in the tree (`addons_list.go`, `profile_list.go`, `cache_images.go`, etc.), which all use the varargs form.

## Test plan

- [x] `go build ./cmd/minikube/...`
- [x] `go test ./cmd/minikube/cmd/config/...`