### PR TITLE
ci: fix automation for bumping golang

### DIFF
--- a/.github/workflows/update-golang-version.yml
+++ b/.github/workflows/update-golang-version.yml
@@ -22,7 +22,7 @@ jobs:
         id: bumpGolang
         run: |
           echo "OLD_VERSION=$(DEP=golang make get-dependency-version)" >> "$GITHUB_OUTPUT"
-          make update-golang-version
+          make update-golang-version GOTOOLCHAIN=auto
           echo "NEW_VERSION=$(DEP=golang make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
           echo "changes<<EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION


I have fixed the workflow file to prevent it from failing when bumping the minor version of Go.

What was the issue?
```
I0420 09:34:04.495758    3460 update.go:99] Local repo successfully updated
make gomodtidy
make[1]: Entering directory '/home/runner/work/minikube/minikube'
go mod tidy
go: go.mod requires go >= 1.26.0 (running go 1.25.5; GOTOOLCHAIN=go1.25.5)
make[1]: *** [Makefile:850: gomodtidy] Error 1
make[1]: Leaving directory '/home/runner/work/minikube/minikube'
make: *** [Makefile:881: update-golang-version] Error 2
```

Example https://github.com/kubernetes/minikube/actions/runs/24659206091/job/72100451774

The logs showed that make update-golang-version calls a Go script that updates go.mod to require a newer Go version (e.g., 1.26.0). Immediately after, it runs make gomodtidy which executes go mod tidy. However, the Makefile in minikube explicitly exports GOTOOLCHAIN pinned to the current Go version (e.g., go1.25.5), which prevents Go from automatically downloading the newer toolchain requested by the updated go.mod. This resulted in the error: