### PR TITLE
Add solution message for SSH handshake TCP-reset (VPN)

### DIFF
--- a/pkg/minikube/reason/known_issues.go
+++ b/pkg/minikube/reason/known_issues.go
@@ -778,6 +778,16 @@ var localNetworkIssues = []match{
 	},
 	{
 		Kind: Kind{
+			ID:       "IF_SSH_TCP_RESET",
+			ExitCode: ExLocalNetworkConfig,
+			Advice:   "Your host is failing to route packets to the minikube VM. If you have VPN software, try turning it off or configuring it so that it does not re-route traffic to the VM IP. If not, check your VM environment routing options.",
+			URL:      vpnDoc,
+			Issues:   []int{9914},
+		},
+		Regexp: re(`ssh: handshake failed: read tcp.*: read: connection reset by peer`),
+	},
+	{
+		Kind: Kind{
 			ID:       "IF_HOST_CIDR_CONFLICT",
 			ExitCode: ExLocalNetworkConflict,
 			Advice:   "Specify an alternate --host-only-cidr value, such as 172.16.0.1/24",

--- a/pkg/minikube/reason/known_issues.go
+++ b/pkg/minikube/reason/known_issues.go
@@ -30,6 +30,11 @@ const (
 	vpnDoc   = "https://minikube.sigs.k8s.io/docs/handbook/vpn_and_proxy/"
 )
 
+// advice strings used by multiple known issues
+const (
+	vpnAdvice = "Your host is failing to route packets to the minikube VM. If you have VPN software, try turning it off or configuring it so that it does not re-route traffic to the VM IP. If not, check your VM environment routing options."
+)
+
 // re is a shortcut around regexp.MustCompile
 func re(s string) *regexp.Regexp {
 	return regexp.MustCompile(s)
@@ -760,7 +765,7 @@ var localNetworkIssues = []match{
 		Kind: Kind{
 			ID:       "IF_SSH_AUTH",
 			ExitCode: ExLocalNetworkConfig,
-			Advice:   "Your host is failing to route packets to the minikube VM. If you have VPN software, try turning it off or configuring it so that it does not re-route traffic to the VM IP. If not, check your VM environment routing options.",
+			Advice:   vpnAdvice,
 			URL:      vpnDoc,
 			Issues:   []int{3930},
 		},
@@ -770,7 +775,7 @@ var localNetworkIssues = []match{
 		Kind: Kind{
 			ID:       "IF_SSH_NO_RESPONSE",
 			ExitCode: ExLocalNetworkConfig,
-			Advice:   "Your host is failing to route packets to the minikube VM. If you have VPN software, try turning it off or configuring it so that it does not re-route traffic to the VM IP. If not, check your VM environment routing options.",
+			Advice:   vpnAdvice,
 			URL:      vpnDoc,
 			Issues:   []int{3388},
 		},
@@ -780,7 +785,7 @@ var localNetworkIssues = []match{
 		Kind: Kind{
 			ID:       "IF_SSH_TCP_RESET",
 			ExitCode: ExLocalNetworkConfig,
-			Advice:   "Your host is failing to route packets to the minikube VM. If you have VPN software, try turning it off or configuring it so that it does not re-route traffic to the VM IP. If not, check your VM environment routing options.",
+			Advice:   vpnAdvice,
 			URL:      vpnDoc,
 			Issues:   []int{9914},
 		},

--- a/pkg/minikube/reason/match_test.go
+++ b/pkg/minikube/reason/match_test.go
@@ -65,6 +65,7 @@ VBoxManage.exe: error: Details: code E_FAIL (0x80004005), component MachineWrap,
 		{8832, "macos", "PR_DOCKER_MOUNTS_EOF", `docker: Error response from daemon: Mounts denied: EOF.`},
 		{9165, "", "HOST_HOME_PERMISSION", `open /Users/conradwt/.minikube/profiles/gcloud-local-dev/config.json: permission denied`},
 		{9175, "", "GUEST_CONFIG_CORRUPT", " updating control plane: generating kubeadm cfg: generating extra component config for kubeadm: controlPlane configuration is corrupt: no name: {Name: IP: Port:8443 KubernetesVersion:v1.19.0 ControlPlane:true Worker:true}"},
+		{9914, "", "IF_SSH_TCP_RESET", `libmachine: Error dialing TCP: ssh: handshake failed: read tcp 127.0.0.1:60486->127.0.0.1:32779: read: connection reset by peer`},
 	}
 	for _, tc := range tests {
 		t.Run(tc.want, func(t *testing.T) {


### PR DESCRIPTION
### Summary
Add a `localNetworkIssues` matcher for the SSH-handshake-then-TCP-reset
error that occurs when a VPN intercepts traffic to the minikube VM.
The user-visible error becomes:

> Your host is failing to route packets to the minikube VM. If you have
> VPN software, try turning it off or configuring it so that it does
> not re-route traffic to the VM IP. If not, check your VM environment
> routing options.

with a link to the existing `vpn_and_proxy` handbook page, instead of
a generic exit. Same advice text and URL as the existing `IF_SSH_AUTH`
and `IF_SSH_NO_RESPONSE` matchers.

### Diff size
2 files, +11 lines, 0 deletions.

### Test plan
- `go test ./pkg/minikube/reason/... -run TestFromError -v`
  All 33 cases pass, including the new `IF_SSH_TCP_RESET`.
- `go vet ./pkg/minikube/reason/...` clean.
- The new test feeds the verbatim error string from the issue:
  `libmachine: Error dialing TCP: ssh: handshake failed: read tcp 127.0.0.1:60486->127.0.0.1:32779: read: connection reset by peer`

### Issue number
Fixes #9914