### PR TITLE
pkg/proxy: walk RoundTripper wrappers to strip proxy on inner *http.Transport

### DIFF
--- a/pkg/minikube/proxy/proxy.go
+++ b/pkg/minikube/proxy/proxy.go
@@ -27,6 +27,7 @@ import (
 
 	"errors"
 
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -145,15 +146,32 @@ func UpdateTransport(cfg *rest.Config) *rest.Config {
 		if wt != nil {
 			rt = wt(rt)
 		}
-		if ht, ok := rt.(*http.Transport); ok {
-			ht.Proxy = nil
-			rt = ht
-		} else {
-			klog.Errorf("Error while casting RoundTripper (of type %T) to *http.Transport : %v", rt, ok)
+		if t := wrappedHTTPTransport(rt); t != nil {
+			t.Proxy = nil
+		} else if rt != nil {
+			klog.Errorf("transport %T could not be unwrapped to *http.Transport; proxy stripping was skipped", rt)
 		}
 		return rt
 	}
 	return cfg
+}
+
+// wrappedHTTPTransport returns the *http.Transport at the bottom of any
+// RoundTripperWrapper chain wrapping rt, or nil if the chain does not end
+// in one (or rt itself is nil). See
+// https://github.com/kubernetes/minikube/issues/22896 for context.
+func wrappedHTTPTransport(rt http.RoundTripper) *http.Transport {
+	cur := rt
+	for {
+		switch t := cur.(type) {
+		case *http.Transport:
+			return t
+		case utilnet.RoundTripperWrapper:
+			cur = t.WrappedRoundTripper()
+		default:
+			return nil
+		}
+	}
 }
 
 // SetDockerEnv sets the proxy environment variables in the docker environment.

--- a/pkg/minikube/proxy/proxy_test.go
+++ b/pkg/minikube/proxy/proxy_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"testing"
 
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/rest"
 )
 
@@ -188,6 +189,24 @@ func TestExcludeIP(t *testing.T) {
 	}
 }
 
+// fakeRoundTripperWrapper satisfies utilnet.RoundTripperWrapper for tests
+// that need to simulate the way client-go 0.36's *trackedTransport (or any
+// future wrapping layer) interposes between WrapTransport callers and the
+// underlying *http.Transport.
+type fakeRoundTripperWrapper struct{ rt http.RoundTripper }
+
+func (f *fakeRoundTripperWrapper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f.rt.RoundTrip(req)
+}
+
+func (f *fakeRoundTripperWrapper) WrappedRoundTripper() http.RoundTripper { return f.rt }
+
+// Compile-time assertion: fakeRoundTripperWrapper must satisfy
+// utilnet.RoundTripperWrapper so the test exercises the same interface the
+// helper walks at runtime. Future client-go interface changes will surface
+// here as a build failure rather than a silently irrelevant test.
+var _ utilnet.RoundTripperWrapper = (*fakeRoundTripperWrapper)(nil)
+
 func TestUpdateTransport(t *testing.T) {
 	t.Run("new", func(t *testing.T) {
 		rcBefore := rest.Config{}
@@ -221,6 +240,36 @@ func TestUpdateTransport(t *testing.T) {
 		rt := c.WrapTransport(nil)
 		if rt != nil {
 			t.Fatalf("Expected RoundTripper nil for invocation WrapTransport(nil)")
+		}
+	})
+	t.Run("wrapped", func(t *testing.T) {
+		inner := &http.Transport{Proxy: http.ProxyFromEnvironment}
+		wrapped := &fakeRoundTripperWrapper{rt: inner}
+
+		rc := rest.Config{}
+		c := UpdateTransport(&rc)
+		result := c.WrapTransport(wrapped)
+
+		if result != wrapped {
+			t.Fatalf("expected wrapper to be returned unchanged, got %T", result)
+		}
+		if inner.Proxy != nil {
+			t.Errorf("expected inner transport's Proxy to be nil, got non-nil")
+		}
+	})
+	t.Run("proxy-stripping", func(t *testing.T) {
+		inner := &http.Transport{Proxy: http.ProxyFromEnvironment}
+
+		rc := rest.Config{}
+		c := UpdateTransport(&rc)
+		result := c.WrapTransport(inner)
+
+		resultHT, ok := result.(*http.Transport)
+		if !ok {
+			t.Fatalf("expected *http.Transport from no-wrap path, got %T", result)
+		}
+		if resultHT.Proxy != nil {
+			t.Errorf("expected Proxy to be nil after UpdateTransport, got non-nil")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

After [#22876](https://github.com/kubernetes/minikube/pull/22876) bumped `k8s.io/client-go` from 0.35.1 to 0.36.0, [`kubernetes/client-go@f5fc1e5f`](https://github.com/kubernetes/client-go/commit/f5fc1e5f67e9f487e6e1b96384c16788e1a9db9a) wraps the cached HTTP transport in `*trackedTransport` to anchor garbage collection of the TLS transport cache. `proxy.UpdateTransport` was downcasting directly to `*http.Transport`; that assertion now fails on every minikube start, logging three `Errorf` lines and tripping `TestErrorSpam/setup` on every PR against current master.

This PR walks `RoundTripperWrapper` layers via `WrappedRoundTripper()` until the underlying `*http.Transport` is reached, then nils `Proxy` in place. The outer wrapper is returned unchanged so client-go's TLS cache GC anchoring continues to work.

## Changes

- Extracts the proxy-disable logic into `disableProxyOnTransport` so it can be unit-tested without `UpdateTransport`'s closure scaffolding.
- `UpdateTransport`'s `WrapTransport` closure delegates to the new helper; behavior is unchanged on the no-wrapping path that worked before client-go 0.36.
- Adds `TestUpdateTransport/wrapped`, the regression test (wraps `*http.Transport` in a fake `RoundTripperWrapper`, asserts inner `Proxy` is nilled).
- Adds `TestUpdateTransport/proxy-stripping`, pinning the no-wrap branch so it does not silently regress in future refactors.

## Test plan

- [x] `go test ./pkg/minikube/proxy/...` passes locally
- [x] `go build ./...` clean
- [x] `gocyclo` clean on `pkg/minikube/proxy/proxy.go`
- [x] End-to-end: `minikube start` produces zero `Error while casting RoundTripper` lines on stderr (was three per start)
- [ ] CI green

## Related

Fixes #22896. #22901 reports the same `TestErrorSpam/setup` symptom; both should resolve once this lands.
