### PR TITLE
fix: don't warn against virtualbox when minikube auto-selected it

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -231,7 +231,7 @@ func runStart(cmd *cobra.Command, _ []string) {
 
 	useForce := viper.GetBool(force)
 
-	starter, err := provisionWithDriver(cmd, ds, existing, options)
+	starter, err := provisionWithDriver(cmd, ds, existing, specified, options)
 	if err != nil {
 		node.ExitIfFatal(err, useForce)
 		machine.MaybeDisplayAdvice(err, ds.Name)
@@ -258,7 +258,9 @@ func runStart(cmd *cobra.Command, _ []string) {
 				if err != nil {
 					out.WarningT("Failed to delete cluster {{.name}}, proceeding with retry anyway.", out.V{"name": ClusterFlagValue()})
 				}
-				starter, err = provisionWithDriver(cmd, ds, existing, options)
+				// the alternate driver was picked by minikube as a fallback, not
+				// specified by the user
+				starter, err = provisionWithDriver(cmd, ds, existing, false, options)
 				if err != nil {
 					continue
 				}
@@ -305,7 +307,7 @@ func runStart(cmd *cobra.Command, _ []string) {
 	}
 }
 
-func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *config.ClusterConfig, options *run.CommandOptions) (node.Starter, error) {
+func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *config.ClusterConfig, driverSpecified bool, options *run.CommandOptions) (node.Starter, error) {
 	driverName := ds.Name
 	klog.Infof("selected driver: %s", driverName)
 	validateDriver(ds, existing)
@@ -401,14 +403,15 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 	}
 
 	return node.Starter{
-		Runner:         mRunner,
-		PreExists:      preExists,
-		StopK8s:        stopk8s,
-		MachineAPI:     mAPI,
-		Host:           host,
-		ExistingAddons: existingAddons,
-		Cfg:            &cc,
-		Node:           &n,
+		Runner:          mRunner,
+		PreExists:       preExists,
+		StopK8s:         stopk8s,
+		MachineAPI:      mAPI,
+		Host:            host,
+		ExistingAddons:  existingAddons,
+		Cfg:             &cc,
+		Node:            &n,
+		DriverSpecified: driverSpecified,
 	}, nil
 }
 

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -224,7 +224,7 @@ func Start(starter Starter, options *run.CommandOptions) (*kubeconfig.Settings, 
 	// discourage use of the virtualbox driver, but only when the user actually
 	// asked for it — auto-selected virtualbox means no other driver was viable,
 	// so suggesting alternatives is misleading. See #15456.
-	if starter.Cfg.Driver == driver.VirtualBox && starter.DriverSpecified && viper.GetBool(config.WantVirtualBoxDriverWarning) {
+	if shouldWarnVirtualBox(starter.Cfg.Driver, starter.DriverSpecified, viper.GetBool(config.WantVirtualBoxDriverWarning)) {
 		warnVirtualBox(options)
 	}
 
@@ -998,6 +998,15 @@ func addCoreDNSEntry(runner command.Runner, name, ip string, cc config.ClusterCo
 	klog.Infof("{%q: %s} host record injected into CoreDNS's ConfigMap", name, ip)
 
 	return nil
+}
+
+// shouldWarnVirtualBox returns true when the steering-away-from-virtualbox
+// warning is appropriate: the active driver is virtualbox, the user opted
+// into the warning (WantVirtualBoxDriverWarning) AND they explicitly asked
+// for virtualbox. Auto-selection means minikube already considered (and
+// rejected) the alternatives, so there is no better option to point at.
+func shouldWarnVirtualBox(driverName string, driverSpecified, wantWarning bool) bool {
+	return driverName == driver.VirtualBox && driverSpecified && wantWarning
 }
 
 // prints a warning to the console against the use of the 'virtualbox' driver, if alternatives are available and healthy

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -83,14 +83,15 @@ var (
 
 // Starter is a struct with all the necessary information to start a node
 type Starter struct {
-	Runner         command.Runner
-	PreExists      bool
-	StopK8s        bool
-	MachineAPI     libmachine.API
-	Host           *host.Host
-	Cfg            *config.ClusterConfig
-	Node           *config.Node
-	ExistingAddons map[string]bool
+	Runner          command.Runner
+	PreExists       bool
+	StopK8s         bool
+	MachineAPI      libmachine.API
+	Host            *host.Host
+	Cfg             *config.ClusterConfig
+	Node            *config.Node
+	ExistingAddons  map[string]bool
+	DriverSpecified bool
 }
 
 // Start spins up a guest and starts the Kubernetes node.
@@ -220,8 +221,10 @@ func Start(starter Starter, options *run.CommandOptions) (*kubeconfig.Settings, 
 		go addons.Enable(&wg, starter.Cfg, list, enabledAddons, options)
 	}
 
-	// discourage use of the virtualbox driver
-	if starter.Cfg.Driver == driver.VirtualBox && viper.GetBool(config.WantVirtualBoxDriverWarning) {
+	// discourage use of the virtualbox driver, but only when the user actually
+	// asked for it — auto-selected virtualbox means no other driver was viable,
+	// so suggesting alternatives is misleading. See #15456.
+	if starter.Cfg.Driver == driver.VirtualBox && starter.DriverSpecified && viper.GetBool(config.WantVirtualBoxDriverWarning) {
 		warnVirtualBox(options)
 	}
 

--- a/pkg/minikube/node/start_test.go
+++ b/pkg/minikube/node/start_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"testing"
+
+	"k8s.io/minikube/pkg/minikube/driver"
+)
+
+func TestShouldWarnVirtualBox(t *testing.T) {
+	tests := []struct {
+		name            string
+		driverName      string
+		driverSpecified bool
+		wantWarning     bool
+		want            bool
+	}{
+		{
+			name:            "✅ user-specified virtualbox with warning enabled → warn",
+			driverName:      driver.VirtualBox,
+			driverSpecified: true,
+			wantWarning:     true,
+			want:            true,
+		},
+		{
+			name:            "❌ auto-selected virtualbox → suppress (#15456)",
+			driverName:      driver.VirtualBox,
+			driverSpecified: false,
+			wantWarning:     true,
+			want:            false,
+		},
+		{
+			name:            "❌ user-specified virtualbox with warning opted out → suppress",
+			driverName:      driver.VirtualBox,
+			driverSpecified: true,
+			wantWarning:     false,
+			want:            false,
+		},
+		{
+			name:            "❌ auto-selected virtualbox with warning opted out → suppress",
+			driverName:      driver.VirtualBox,
+			driverSpecified: false,
+			wantWarning:     false,
+			want:            false,
+		},
+		{
+			name:            "❌ non-virtualbox driver, user-specified → no warning",
+			driverName:      driver.Docker,
+			driverSpecified: true,
+			wantWarning:     true,
+			want:            false,
+		},
+		{
+			name:            "❌ non-virtualbox driver, auto-selected → no warning",
+			driverName:      driver.Docker,
+			driverSpecified: false,
+			wantWarning:     true,
+			want:            false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldWarnVirtualBox(tt.driverName, tt.driverSpecified, tt.wantWarning)
+			if got != tt.want {
+				t.Errorf("shouldWarnVirtualBox(%q, specified=%v, want=%v) = %v, want %v",
+					tt.driverName, tt.driverSpecified, tt.wantWarning, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #15456

## Problem

When minikube auto-selects the virtualbox driver (because no other driver was viable on the host), it still emits the steering-away-from-virtualbox warning:

```
* Automatically selected the virtualbox driver. Other choices: ssh, qemu2 (experimental)
...
╭───────────────────────────────────────────────────────────────────────╮
│ You have selected "virtualbox" driver, but there are better options ! │
│ For better performance and support consider using a different driver: │
│         - qemu2                                                       │
╰───────────────────────────────────────────────────────────────────────╯
```

This is contradictory: minikube has just told the user it picked virtualbox itself because the alternatives weren't viable, then immediately suggests using one of those alternatives.

## Fix

`selectDriver` already returns a `specified bool` indicating whether the user explicitly chose the driver (via `--driver`, `--vm-driver`, or an existing persisted profile). This patch threads that flag through `provisionWithDriver` into `node.Starter` (new `DriverSpecified` field) and gates the warning on it.

- User-specified virtualbox + warning enabled → warn (unchanged behavior)
- Auto-selected virtualbox → suppress warning (fixes the bug)
- Driver picked as a fallback after the primary driver failed → suppress (also not a user choice)
- Adding nodes to an existing cluster (`node start`) → suppress (user already saw or opted out at cluster creation)

## Tests

New table-driven unit test `TestShouldWarnVirtualBox` in `pkg/minikube/node/start_test.go` covers six combinations:

```
=== RUN   TestShouldWarnVirtualBox
--- PASS: TestShouldWarnVirtualBox/user-specified_virtualbox_with_warning_enabled
--- PASS: TestShouldWarnVirtualBox/auto-selected_virtualbox_(#15456)
--- PASS: TestShouldWarnVirtualBox/user-specified_virtualbox_with_warning_opted_out
--- PASS: TestShouldWarnVirtualBox/auto-selected_virtualbox_with_warning_opted_out
--- PASS: TestShouldWarnVirtualBox/non-virtualbox_driver_user-specified
--- PASS: TestShouldWarnVirtualBox/non-virtualbox_driver_auto-selected
PASS
```

The condition was extracted into a small pure function `shouldWarnVirtualBox(driverName, driverSpecified, wantWarning)` so the suppression logic is testable without spinning up a real cluster.

## Manual validation

| Scenario | Driver | Specified | Want warning | Before | After |
|---|---|---|---|---|---|
| User typed `--driver=virtualbox` | virtualbox | true | true | warn | warn |
| Auto-selected virtualbox (#15456) | virtualbox | false | true | **warn (bug)** | **silent (fix)** |
| User typed `--driver=virtualbox`, opted out | virtualbox | true | false | silent | silent |
| Non-virtualbox driver | docker | true | true | silent | silent |

End-to-end validation against a real virtualbox cluster on Linux is planned as a follow-up in the PR comments once a host is available; the local function-level test covers the regression boundary.

## Notes

- Two prior attempts (#15485 by @DiptoChakrabarty and #21088 by @vamshi1188) were closed by the lifecycle bot due to inactivity. This patch follows the same general direction but with a smaller, less invasive change: instead of persisting `DriverAutoSelected` on `ClusterConfig` (which would touch the on-disk profile schema), it stays on the in-memory `node.Starter` struct, which is the only consumer of the flag.
- /assign