### PR TITLE
fix: warn against virtualbox only when the flag is explicit

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -209,6 +209,11 @@ func runStart(cmd *cobra.Command, _ []string) {
 	}
 
 	validateSpecifiedDriver(existing, options)
+	if existing == nil {
+		// driver-selection warnings are only meaningful for fresh clusters;
+		// an existing cluster keeps its original driver
+		warnVirtualBoxDriver(options)
+	}
 	validateKubernetesVersion(existing)
 	validateContainerRuntime(existing)
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/proxy"
 	"k8s.io/minikube/pkg/minikube/reason"
+	"k8s.io/minikube/pkg/minikube/registry"
 	"k8s.io/minikube/pkg/minikube/run"
 	"k8s.io/minikube/pkg/minikube/style"
 	pkgutil "k8s.io/minikube/pkg/util"
@@ -1068,4 +1069,48 @@ func checkExtraDiskOptions(cmd *cobra.Command, driverName string) {
 			out.WarningT("Specifying extra disks is currently only supported for the following drivers: {{.supported_drivers}}. If you can contribute to add this feature, please create a PR.", out.V{"supported_drivers": supportedDrivers})
 		}
 	}
+}
+
+// warnVirtualBoxDriver warns the user when the configured driver is
+// virtualbox (--driver/--vm-driver flag or MINIKUBE_DRIVER env) and better
+// alternatives are installed and healthy. This intentionally lives in the argument-validation
+// phase so the warning never fires when minikube auto-selects virtualbox
+// (auto-selection already implies the alternatives were rejected). Callers
+// must skip it when reusing an existing cluster, which keeps its original
+// driver.
+func warnVirtualBoxDriver(options *run.CommandOptions) {
+	if !viper.GetBool(config.WantVirtualBoxDriverWarning) {
+		return
+	}
+
+	requested := viper.GetString("driver")
+	if requested == "" {
+		requested = viper.GetString("vm-driver")
+	}
+	if !driver.IsVirtualBox(requested) {
+		return
+	}
+
+	var altDriverList strings.Builder
+	for _, choice := range driver.Choices(true, options) {
+		if !driver.IsVirtualBox(choice.Name) && choice.Priority != registry.Discouraged && choice.State.Installed && choice.State.Healthy {
+			fmt.Fprintf(&altDriverList, "\n\t- %s", choice.Name)
+		}
+	}
+	if altDriverList.Len() == 0 {
+		return
+	}
+
+	out.Boxed(`You have selected "virtualbox" driver, but there are better options !
+For better performance and support consider using a different driver: {{.drivers}}
+
+To turn off this warning run:
+
+	$ minikube config set WantVirtualBoxDriverWarning false
+
+
+To learn more about on minikube drivers checkout https://minikube.sigs.k8s.io/docs/drivers/
+To see benchmarks checkout https://minikube.sigs.k8s.io/docs/benchmarks/cpuusage/
+
+`, out.V{"drivers": altDriverList.String()})
 }

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -64,7 +64,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/out/register"
 	"k8s.io/minikube/pkg/minikube/proxy"
 	"k8s.io/minikube/pkg/minikube/reason"
-	"k8s.io/minikube/pkg/minikube/registry"
 	"k8s.io/minikube/pkg/minikube/run"
 	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/minikube/vmpath"
@@ -218,11 +217,6 @@ func Start(starter Starter, options *run.CommandOptions) (*kubeconfig.Settings, 
 		list := addons.ToEnable(starter.Cfg, starter.ExistingAddons, addonList)
 		wg.Add(1)
 		go addons.Enable(&wg, starter.Cfg, list, enabledAddons, options)
-	}
-
-	// discourage use of the virtualbox driver
-	if starter.Cfg.Driver == driver.VirtualBox && viper.GetBool(config.WantVirtualBoxDriverWarning) {
-		warnVirtualBox(options)
 	}
 
 	// special ops for "none" driver on control-plane node, like change minikube directory
@@ -995,29 +989,4 @@ func addCoreDNSEntry(runner command.Runner, name, ip string, cc config.ClusterCo
 	klog.Infof("{%q: %s} host record injected into CoreDNS's ConfigMap", name, ip)
 
 	return nil
-}
-
-// prints a warning to the console against the use of the 'virtualbox' driver, if alternatives are available and healthy
-func warnVirtualBox(options *run.CommandOptions) {
-	var altDriverList strings.Builder
-	for _, choice := range driver.Choices(true, options) {
-		if !driver.IsVirtualBox(choice.Name) && choice.Priority != registry.Discouraged && choice.State.Installed && choice.State.Healthy {
-			fmt.Fprintf(&altDriverList, "\n\t- %s", choice.Name)
-		}
-	}
-
-	if altDriverList.Len() != 0 {
-		out.Boxed(`You have selected "virtualbox" driver, but there are better options !
-For better performance and support consider using a different driver: {{.drivers}}
-
-To turn off this warning run:
-
-	$ minikube config set WantVirtualBoxDriverWarning false
-
-
-To learn more about on minikube drivers checkout https://minikube.sigs.k8s.io/docs/drivers/
-To see benchmarks checkout https://minikube.sigs.k8s.io/docs/benchmarks/cpuusage/
-
-`, out.V{"drivers": altDriverList.String()})
-	}
 }


### PR DESCRIPTION
**Fixes #15456** — moves the "don't use VirtualBox if better options exist" warning out of the post-provisioning path (`node.Start`) into `minikube start` argument-validation, so it only fires when the user actually selected VirtualBox, not when minikube auto-selected it.

Implements the structure @nirs suggested in #22959 (companion PR, to be closed in favor of this one): no `DriverSpecified` flag threaded through `Starter` — the warning lives in `cmd/minikube/cmd/start_flags.go::warnVirtualBoxDriver` and consults `viper.GetString("driver")` directly. Skipped when reusing an existing cluster (`--driver` is ignored on restart).

## Behavior matrix

| Invocation | Before any fix | This PR |
|---|---|---|
| `minikube start` (auto-pick lands on virtualbox) | warns (the bug) | silent ✅ |
| `minikube start --driver=virtualbox` (alternatives healthy) | warns | warns |
| `minikube start --vm-driver=virtualbox` (legacy) | warns | warns |
| `--driver=docker`, docker fails, fallback to virtualbox | warns | silent (flag is "docker") |
| reusing an existing virtualbox profile | warns | silent (existing cluster) |
| `--driver=virtualbox` reusing an existing profile | warns | silent (`--driver` ignored on restart) |
| opted out via `WantVirtualBoxDriverWarning=false` | silent | silent |
| `--driver=docker` | silent | silent |

## Tests

Per @nirs's review, the original table-driven unit test was removed: it monkey-patched global viper/stdout state, which is fragile and unsafe under `t.Parallel()`. The remaining logic is a handful of trivial short-circuit guards; the alternative-driver discovery branch (`driver.Choices` over a populated registry) is covered by the integration/e2e path, where a unit test would need a populated registry to add little signal.

Single DCO-signed commit.

