### PR TITLE
Add --vmnet-offloading start flag for krunkit driver

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -147,6 +147,7 @@ const (
 	autoPauseInterval       = "auto-pause-interval"
 	preloadSrc              = "preload-source"
 	rosetta                 = "rosetta"
+	vmnetOffloading         = "vmnet-offloading"
 )
 
 var (
@@ -290,6 +291,9 @@ func initDriverFlags() {
 
 	// vfkit
 	startCmd.Flags().Bool(rosetta, false, "Enable Rosetta to support apps built for Intel processor on a Mac with Apple silicon (vfkit driver only)")
+
+	// krunkit
+	startCmd.Flags().Bool(vmnetOffloading, false, "Enable vmnet checksum and TSO offloading. See krunkit driver documentation for known limitations (krunkit driver only)")
 }
 
 // initNetworkingFlags inits the commandline flags for connectivity related flags for start
@@ -572,6 +576,15 @@ func getRosetta(driverName string) bool {
 	return enabled
 }
 
+func getVmnetOffloading(driverName string) bool {
+	enabled := viper.GetBool(vmnetOffloading)
+	if enabled && !driver.IsKrunkit(driverName) {
+		out.WarningT("--vmnet-offloading flag is only valid with the krunkit driver, it will be ignored")
+		return false
+	}
+	return enabled
+}
+
 // generateNewConfigFromFlags generate a config.ClusterConfig based on flags
 func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime string, drvName string, options *run.CommandOptions) config.ClusterConfig {
 	var cc config.ClusterConfig
@@ -677,6 +690,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 		GPUs:               viper.GetString(gpus),
 		AutoPauseInterval:  viper.GetDuration(autoPauseInterval),
 		Rosetta:            getRosetta(drvName),
+		VmnetOffloading:    getVmnetOffloading(drvName),
 	}
 	cc.VerifyComponents = interpretWaitFlag(*cmd)
 
@@ -908,6 +922,7 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 	updateStringFromFlag(cmd, &cc.SocketVMnetPath, socketVMnetPath)
 	updateDurationFromFlag(cmd, &cc.AutoPauseInterval, autoPauseInterval)
 	updateBoolFromFlag(cmd, &cc.Rosetta, rosetta)
+	updateBoolFromFlag(cmd, &cc.VmnetOffloading, vmnetOffloading)
 
 	if cmd.Flags().Changed(kubernetesVersion) {
 		kubeVer, err := getKubernetesVersion(existing)

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -110,6 +110,7 @@ type ClusterConfig struct {
 	GPUs                    string
 	AutoPauseInterval       time.Duration // Specifies interval of time to wait before checking if cluster should be paused
 	Rosetta                 bool          // Only used by vfkit driver
+	VmnetOffloading         bool          // Only used by krunkit driver
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/registry/drvs/krunkit/krunkit.go
+++ b/pkg/minikube/registry/drvs/krunkit/krunkit.go
@@ -89,6 +89,7 @@ func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
 		VmnetHelper: vmnet.Helper{
 			MachineDir:  filepath.Join(storePath, "machines", machineName),
 			InterfaceID: u,
+			Offloading:  cfg.VmnetOffloading,
 		},
 	}, nil
 }

--- a/site/content/en/docs/drivers/krunkit.md
+++ b/site/content/en/docs/drivers/krunkit.md
@@ -71,6 +71,29 @@ users or other groups.
 minikube start --driver krunkit
 ```
 
+### Vmnet offloading
+
+The `--vmnet-offloading` flag enables vmnet checksum and TSO offloading,
+which can improve host network throughput by up to 5x (e.g. pulling images
+from a local registry, RBD mirroring):
+
+```shell
+minikube start --driver krunkit --vmnet-offloading
+```
+
+> [!WARNING]
+> Offloading may not work for all workloads. Review the limitations below
+> and verify that this flag works for your workload before relying on it.
+
+#### Limitations
+
+- All VMs connected to the same vmnet bridge must enable offloading.
+  If any VM on the bridge does not use offloading, the bridge disables
+  TSO and TX performance drops significantly.
+- Pod-to-VM network RX performance is severely degraded when offloading
+  is enabled, making it almost unusable. Pod-to-host network works well
+  and is faster than without offloading.
+
 ## Issues
 
 ### Other


### PR DESCRIPTION
Enable vmnet checksum and TSO offloading for the krunkit driver via a new --vmnet-offloading flag (default: false). When enabled, vmnet-helper starts with --enable-tso --enable-checksum-offload and krunkit uses offloading=true on the virtio-net device.

Host ↔ VM (iperf3 server on host):

| Network | Direction |         Off |          On |   Change |
|---------|-----------|------------:|------------:|---------:|
| host    | TX        |  8.2 Gbit/s | 47.7 Gbit/s |    +5.8x |
| host    | RX        | 10.4 Gbit/s | 31.2 Gbit/s |    +3.0x |
| pod     | TX        |  8.9 Gbit/s | 44.4 Gbit/s |    +5.0x |
| pod     | RX        | 10.3 Gbit/s | 13.6 Gbit/s |    +1.3x |

VM ↔ VM (iperf3 server on another VM):

| Network | Direction |         Off |          On |   Change |
|---------|-----------|------------:|------------:|---------:|
| host    | TX        |  8.5 Gbit/s | 32.6 Gbit/s |    +3.8x |
| host    | RX        | 10.6 Gbit/s | 30.8 Gbit/s |    +2.9x |
| pod     | TX        |  8.7 Gbit/s | 30.6 Gbit/s |    +3.5x |
| pod     | RX        | 10.3 Gbit/s |  2.3 Mbit/s | -4478.0x |

Limitations:

- All VMs on the same vmnet bridge must enable offloading. Mixing VMs with and without offloading causes the bridge to disable TSO, dropping TX to ~1.6 Gbit/s.
- Pod-to-VM RX is severely degraded (10.3 Gbit/s → 2.3 Mbit/s), making it unusable for that traffic pattern.

Fixes #22958
Assisted-by Cursor/Claude Opus 4.6