### PR TITLE
start: add --mdns flag to enable mDNS on every VM start

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -177,6 +177,10 @@ var settings = []Setting{
 		set:         SetStringSlice,
 		validations: []setFn{IsValidIPAddressSlice},
 	},
+	{
+		name: config.MDNS,
+		set:  SetBool,
+	},
 }
 
 // ConfigCmd represents the config command

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -152,6 +152,7 @@ const (
 	rosetta                 = "rosetta"
 	vmnetOffloading         = "vmnet-offloading"
 	dnsServers              = config.DNSServers
+	mdns                    = config.MDNS
 )
 
 var (
@@ -318,6 +319,7 @@ func initNetworkingFlags() {
 
 	// dns
 	startCmd.Flags().StringSlice(dnsServers, nil, "Static DNS server IP addresses for the VM (VM drivers only)")
+	startCmd.Flags().Bool(mdns, false, "Enable mDNS (.local address resolution) by configuring systemd-resolved inside the node (VM drivers only)")
 
 	// socket vmnet
 	startCmd.Flags().String(socketVMnetClientPath, "", "Path to the socket vmnet client binary (QEMU driver only)")
@@ -636,6 +638,23 @@ func getDNSServers(cmd *cobra.Command, driverName string) []netip.Addr {
 	return addrs
 }
 
+// getMDNS returns true if mDNS should be enabled for the given driver.
+// For non-VM drivers the value is ignored since mDNS configuration via
+// systemd-resolved is not applicable.
+func getMDNS(cmd *cobra.Command, driverName string) bool {
+	enabled := viper.GetBool(mdns)
+	if !enabled {
+		return false
+	}
+	if !driver.IsVM(driverName) || driver.IsSSH(driverName) {
+		if cmd.Flags().Changed(mdns) {
+			out.WarningT("--mdns flag is only valid with VM drivers, it will be ignored")
+		}
+		return false
+	}
+	return enabled
+}
+
 // generateNewConfigFromFlags generate a config.ClusterConfig based on flags
 func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime string, drvName string, options *run.CommandOptions) config.ClusterConfig {
 	var cc config.ClusterConfig
@@ -743,6 +762,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 		Rosetta:            getRosetta(drvName),
 		VmnetOffloading:    getVmnetOffloading(drvName),
 		DNSServers:         getDNSServers(cmd, drvName),
+		MDNS:               getMDNS(cmd, drvName),
 	}
 	cc.VerifyComponents = interpretWaitFlag(*cmd)
 

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -61,6 +61,8 @@ const (
 	MaxAuditEntries = "MaxAuditEntries"
 	// DNSServers is the key for static DNS server addresses for VM drivers
 	DNSServers = "dns-servers"
+	// MDNS is the key for the mDNS parameter (boolean)
+	MDNS = "mdns"
 )
 
 var (

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -113,6 +113,7 @@ type ClusterConfig struct {
 	Rosetta                 bool          // Only used by vfkit driver
 	VmnetOffloading         bool          // Only used by krunkit driver
 	DNSServers              []netip.Addr  // Static DNS servers for the VM (VM drivers only)
+	MDNS                    bool          // Enable mDNS (.local) resolution via systemd-resolved
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/node/dns.go
+++ b/pkg/minikube/node/dns.go
@@ -27,6 +27,10 @@ import (
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
+// primaryInterface is the main network interface in the buildroot-based minikube ISO.
+// Update this if the ISO switches to a different distro or naming scheme.
+const primaryInterface = "eth0"
+
 // configureDNS configures static DNS servers on the VM, overriding DHCP-provided
 // DNS settings. This fixes DNS resolution on managed Macs where network extensions
 // block DNS traffic from the VM bridge to the host resolver.
@@ -54,10 +58,10 @@ func configureDNS(runner command.Runner, servers []netip.Addr) {
 	dnsServers := strings.Join(values, " ")
 
 	script := fmt.Sprintf(`
-resolvectl dns eth0 %s
-resolvectl domain eth0 "~."
+resolvectl dns %s %s
+resolvectl domain %s "~."
 resolvectl flush-caches
-`, dnsServers)
+`, primaryInterface, dnsServers, primaryInterface)
 
 	cmd := exec.Command("sudo", "bash", "-o", "errexit", "-c", script)
 	if _, err := runner.RunCmd(cmd); err != nil {
@@ -67,4 +71,20 @@ resolvectl flush-caches
 	}
 
 	klog.Infof("Configured static DNS servers: %s", dnsServers)
+}
+
+// configureMDNS enables mDNS (.local address resolution) on the VM by configuring
+// systemd-resolved. This allows the guest to resolve other machines on the local
+// network that advertise via mDNS.
+func configureMDNS(runner command.Runner, enabled bool) {
+	if !enabled {
+		return
+	}
+	cmd := exec.Command("sudo", "resolvectl", "mdns", primaryInterface, "yes")
+	if _, err := runner.RunCmd(cmd); err != nil {
+		klog.Warningf("Failed to enable mDNS on %s: %v", primaryInterface, err)
+		out.WarningT("Failed to enable mDNS on {{.iface}}", out.V{"iface": primaryInterface})
+		return
+	}
+	klog.Infof("Enabled mDNS on %s", primaryInterface)
 }

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -671,6 +671,7 @@ func startMachine(cfg *config.ClusterConfig, node *config.Node, delOnFail bool, 
 	}
 
 	configureDNS(runner, cfg.DNSServers)
+	configureMDNS(runner, cfg.MDNS)
 
 	ip, err := validateNetwork(hostInfo, runner, cfg.KubernetesConfig.ImageRepository)
 	if err != nil {


### PR DESCRIPTION
Add an opt-in `--mdns` start flag and `minikube config set mdns true` option that enables mDNS (.local address resolution) inside the cluster node by running `resolvectl mdns eth0 yes` on every start.

The resolvectl call lives in `configureMDNS()` in `pkg/minikube/node/dns.go` and is invoked from `startMachine` (not provisioning) so it persists across stop/start cycles, since resolvectl is a runtime setting that does not survive a VM reboot.

- Flag is create-time only: baked into cluster config at first start, no need to repeat on subsequent starts
- Flag defaults to `false`, no behavior change for existing users
- Non-VM drivers (docker, podman) silently skipped via `driver.IsVM()` guard
- Failures logged as user-visible warnings via `out.WarningT`, start continues

Fixes #22804