### PR TITLE
ci: fix kubernetes auto-updater template for k8s version above 1.36.0

### DIFF
--- a/hack/update/kubernetes_version/kubernetes_version.go
+++ b/hack/update/kubernetes_version/kubernetes_version.go
@@ -48,60 +48,6 @@ var (
 				`'latest' for .*\)`: `'latest' for {{.LatestVersion}})`,
 			},
 		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/containerd-api-port.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/containerd-api-port.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/containerd-pod-network-cidr.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/containerd-pod-network-cidr.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/containerd.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/containerd.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/crio-options-gates.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/crio-options-gates.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/crio.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/crio.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/default.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/default.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/dns.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/dns.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/image-repository.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/image-repository.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/options.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/options.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
-			},
-		},
 	}
 )
 
@@ -128,6 +74,7 @@ func main() {
 	}
 	data := Data{StableVersion: stable, LatestVersion: latest, LatestVersionMM: latestMM, LatestVersionP0: latestP0}
 
+	addTestDataItemsToSchema(latestMM, "{{.LatestVersionMM}}", "{{.LatestVersionP0}}")
 	updateCurrentTestDataFiles(latestMM, &data)
 
 	// Print PR title for GitHub action.
@@ -155,6 +102,36 @@ func k8sVersions(ctx context.Context, owner, repo string) (stable, latest, lates
 	return stable, latest, latestMM, latestP0, nil
 }
 
+// addTestDataItemsToSchema populates the schema map with testdata file targets for a given major-minor version.
+func addTestDataItemsToSchema(versionMM string, mmVar string, p0Var string) {
+	tmplDir := "update/kubernetes_version/templates/v1beta4"
+	if semver.Compare(versionMM, "v1.36") >= 0 {
+		tmplDir = "update/kubernetes_version/templates/v1beta4-v1.36+"
+	}
+
+	files := []string{
+		"containerd-api-port.yaml",
+		"containerd-pod-network-cidr.yaml",
+		"containerd.yaml",
+		"crio-options-gates.yaml",
+		"crio.yaml",
+		"default.yaml",
+		"dns.yaml",
+		"image-repository.yaml",
+		"options.yaml",
+	}
+
+	for _, f := range files {
+		targetPath := fmt.Sprintf("pkg/minikube/bootstrapper/bsutil/testdata/%s/%s", mmVar, f)
+		schema[targetPath] = update.Item{
+			Content: update.Loadf(fmt.Sprintf("%s/%s", tmplDir, f)),
+			Replace: map[string]string{
+				`kubernetesVersion:.*`: fmt.Sprintf("kubernetesVersion: %s", p0Var),
+			},
+		}
+	}
+}
+
 // updateCurrentTestDataFiles the point of this function it to update the testdata files for the current `NewestKubernetesVersion`
 // otherwise, we can run into an issue where there's a new Kubernetes minor version, so the existing testdata files are ignored
 // but they're not ending in `.0` and are potentially ending with a prerelease tag such as `v1.29.0-rc.2`, resulting in the unit
@@ -170,64 +147,5 @@ func updateCurrentTestDataFiles(latestMM string, data *Data) {
 	data.CurrentVersionMM = currentMM
 	data.CurrentVersionP0 = currentMM + ".0"
 
-	currentSchema := map[string]update.Item{
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/containerd-api-port.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/containerd-api-port.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/containerd-pod-network-cidr.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/containerd-pod-network-cidr.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/containerd.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/containerd.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/crio-options-gates.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/crio-options-gates.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/crio.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/crio.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/default.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/default.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/dns.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/dns.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/image-repository.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/image-repository.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
-			},
-		},
-		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/options.yaml": {
-			Content: update.Loadf("update/kubernetes_version/templates/v1beta4/options.yaml"),
-			Replace: map[string]string{
-				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
-			},
-		},
-	}
-
-	for k, v := range currentSchema {
-		schema[k] = v
-	}
+	addTestDataItemsToSchema(currentMM, "{{.CurrentVersionMM}}", "{{.CurrentVersionP0}}")
 }

--- a/hack/update/kubernetes_version/templates/v1beta4-v1.36+/containerd-api-port.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4-v1.36+/containerd-api-port.yaml
@@ -1,0 +1,78 @@
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 1.1.1.1
+  bindPort: 12345
+bootstrapTokens:
+  - groups:
+      - system:bootstrappers:kubeadm:default-node-token
+    ttl: 24h0m0s
+    usages:
+      - signing
+      - authentication
+nodeRegistration:
+  criSocket: unix:///run/containerd/containerd.sock
+  name: "mk"
+  kubeletExtraArgs:
+    - name: "node-ip"
+      value: "1.1.1.1"
+  taints: []
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+apiServer:
+  certSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
+  extraArgs:
+    - name: "enable-admission-plugins"
+      value: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+controllerManager:
+  extraArgs:
+    - name: "allocate-node-cidrs"
+      value: "true"
+    - name: "leader-elect"
+      value: "false"
+scheduler:
+  extraArgs:
+    - name: "leader-elect"
+      value: "false"
+certificatesDir: /var/lib/minikube/certs
+clusterName: mk
+controlPlaneEndpoint: control-plane.minikube.internal:12345
+etcd:
+  local:
+    dataDir: /var/lib/minikube/etcd
+kubernetesVersion: v1.23.0
+networking:
+  dnsDomain: cluster.local
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: 10.96.0.0/12
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
+containerRuntimeEndpoint: unix:///run/containerd/containerd.sock
+hairpinMode: hairpin-veth
+runtimeRequestTimeout: 15m
+clusterDomain: "cluster.local"
+# disable disk resource management by default
+imageGCHighThresholdPercent: 100
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"
+failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+clusterCIDR: "10.244.0.0/16"
+metricsBindAddress: 0.0.0.0:10249
+conntrack:
+  maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/hack/update/kubernetes_version/templates/v1beta4-v1.36+/containerd-pod-network-cidr.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4-v1.36+/containerd-pod-network-cidr.yaml
@@ -1,0 +1,78 @@
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 1.1.1.1
+  bindPort: 8443
+bootstrapTokens:
+  - groups:
+      - system:bootstrappers:kubeadm:default-node-token
+    ttl: 24h0m0s
+    usages:
+      - signing
+      - authentication
+nodeRegistration:
+  criSocket: unix:///run/containerd/containerd.sock
+  name: "mk"
+  kubeletExtraArgs:
+    - name: "node-ip"
+      value: "1.1.1.1"
+  taints: []
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+apiServer:
+  certSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
+  extraArgs:
+    - name: "enable-admission-plugins"
+      value: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+controllerManager:
+  extraArgs:
+    - name: "allocate-node-cidrs"
+      value: "true"
+    - name: "leader-elect"
+      value: "false"
+scheduler:
+  extraArgs:
+    - name: "leader-elect"
+      value: "false"
+certificatesDir: /var/lib/minikube/certs
+clusterName: mk
+controlPlaneEndpoint: control-plane.minikube.internal:8443
+etcd:
+  local:
+    dataDir: /var/lib/minikube/etcd
+kubernetesVersion: v1.23.0
+networking:
+  dnsDomain: cluster.local
+  podSubnet: "192.168.32.0/20"
+  serviceSubnet: 10.96.0.0/12
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
+containerRuntimeEndpoint: unix:///run/containerd/containerd.sock
+hairpinMode: hairpin-veth
+runtimeRequestTimeout: 15m
+clusterDomain: "cluster.local"
+# disable disk resource management by default
+imageGCHighThresholdPercent: 100
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"
+failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+clusterCIDR: "192.168.32.0/20"
+metricsBindAddress: 0.0.0.0:10249
+conntrack:
+  maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/hack/update/kubernetes_version/templates/v1beta4-v1.36+/containerd.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4-v1.36+/containerd.yaml
@@ -1,0 +1,78 @@
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 1.1.1.1
+  bindPort: 8443
+bootstrapTokens:
+  - groups:
+      - system:bootstrappers:kubeadm:default-node-token
+    ttl: 24h0m0s
+    usages:
+      - signing
+      - authentication
+nodeRegistration:
+  criSocket: unix:///run/containerd/containerd.sock
+  name: "mk"
+  kubeletExtraArgs:
+    - name: "node-ip"
+      value: "1.1.1.1"
+  taints: []
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+apiServer:
+  certSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
+  extraArgs:
+    - name: "enable-admission-plugins"
+      value: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+controllerManager:
+  extraArgs:
+    - name: "allocate-node-cidrs"
+      value: "true"
+    - name: "leader-elect"
+      value: "false"
+scheduler:
+  extraArgs:
+    - name: "leader-elect"
+      value: "false"
+certificatesDir: /var/lib/minikube/certs
+clusterName: mk
+controlPlaneEndpoint: control-plane.minikube.internal:8443
+etcd:
+  local:
+    dataDir: /var/lib/minikube/etcd
+kubernetesVersion: v1.23.0
+networking:
+  dnsDomain: cluster.local
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: 10.96.0.0/12
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
+containerRuntimeEndpoint: unix:///run/containerd/containerd.sock
+hairpinMode: hairpin-veth
+runtimeRequestTimeout: 15m
+clusterDomain: "cluster.local"
+# disable disk resource management by default
+imageGCHighThresholdPercent: 100
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"
+failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+clusterCIDR: "10.244.0.0/16"
+metricsBindAddress: 0.0.0.0:10249
+conntrack:
+  maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/hack/update/kubernetes_version/templates/v1beta4-v1.36+/crio-options-gates.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4-v1.36+/crio-options-gates.yaml
@@ -1,0 +1,91 @@
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 1.1.1.1
+  bindPort: 8443
+bootstrapTokens:
+  - groups:
+      - system:bootstrappers:kubeadm:default-node-token
+    ttl: 24h0m0s
+    usages:
+      - signing
+      - authentication
+nodeRegistration:
+  criSocket: unix:///var/run/crio/crio.sock
+  name: "mk"
+  kubeletExtraArgs:
+    - name: "node-ip"
+      value: "1.1.1.1"
+  taints: []
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+apiServer:
+  certSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
+  extraArgs:
+    - name: "enable-admission-plugins"
+      value: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+    - name: "fail-no-swap"
+      value: "true"
+    - name: "feature-gates"
+      value: "a=b"
+controllerManager:
+  extraArgs:
+    - name: "allocate-node-cidrs"
+      value: "true"
+    - name: "feature-gates"
+      value: "a=b"
+    - name: "kube-api-burst"
+      value: "32"
+    - name: "leader-elect"
+      value: "false"
+scheduler:
+  extraArgs:
+    - name: "feature-gates"
+      value: "a=b"
+    - name: "leader-elect"
+      value: "false"
+    - name: "scheduler-name"
+      value: "mini-scheduler"
+certificatesDir: /var/lib/minikube/certs
+clusterName: mk
+controlPlaneEndpoint: control-plane.minikube.internal:8443
+etcd:
+  local:
+    dataDir: /var/lib/minikube/etcd
+kubernetesVersion: v1.23.0
+networking:
+  dnsDomain: cluster.local
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: 10.96.0.0/12
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
+containerRuntimeEndpoint: unix:///var/run/crio/crio.sock
+hairpinMode: hairpin-veth
+runtimeRequestTimeout: 15m
+clusterDomain: "cluster.local"
+# disable disk resource management by default
+imageGCHighThresholdPercent: 100
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"
+failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+clusterCIDR: "10.244.0.0/16"
+metricsBindAddress: 0.0.0.0:10249
+conntrack:
+  maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
+mode: "iptables"

--- a/hack/update/kubernetes_version/templates/v1beta4-v1.36+/crio.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4-v1.36+/crio.yaml
@@ -1,0 +1,78 @@
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 1.1.1.1
+  bindPort: 8443
+bootstrapTokens:
+  - groups:
+      - system:bootstrappers:kubeadm:default-node-token
+    ttl: 24h0m0s
+    usages:
+      - signing
+      - authentication
+nodeRegistration:
+  criSocket: unix:///var/run/crio/crio.sock
+  name: "mk"
+  kubeletExtraArgs:
+    - name: "node-ip"
+      value: "1.1.1.1"
+  taints: []
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+apiServer:
+  certSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
+  extraArgs:
+    - name: "enable-admission-plugins"
+      value: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+controllerManager:
+  extraArgs:
+    - name: "allocate-node-cidrs"
+      value: "true"
+    - name: "leader-elect"
+      value: "false"
+scheduler:
+  extraArgs:
+    - name: "leader-elect"
+      value: "false"
+certificatesDir: /var/lib/minikube/certs
+clusterName: mk
+controlPlaneEndpoint: control-plane.minikube.internal:8443
+etcd:
+  local:
+    dataDir: /var/lib/minikube/etcd
+kubernetesVersion: v1.23.0
+networking:
+  dnsDomain: cluster.local
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: 10.96.0.0/12
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
+containerRuntimeEndpoint: unix:///var/run/crio/crio.sock
+hairpinMode: hairpin-veth
+runtimeRequestTimeout: 15m
+clusterDomain: "cluster.local"
+# disable disk resource management by default
+imageGCHighThresholdPercent: 100
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"
+failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+clusterCIDR: "10.244.0.0/16"
+metricsBindAddress: 0.0.0.0:10249
+conntrack:
+  maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/hack/update/kubernetes_version/templates/v1beta4-v1.36+/default.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4-v1.36+/default.yaml
@@ -1,0 +1,84 @@
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 1.1.1.1
+  bindPort: 8443
+bootstrapTokens:
+  - groups:
+      - system:bootstrappers:kubeadm:default-node-token
+    ttl: 24h0m0s
+    usages:
+      - signing
+      - authentication
+nodeRegistration:
+  criSocket: unix:///var/run/dockershim.sock
+  name: "mk"
+  kubeletExtraArgs:
+    - name: "node-ip"
+      value: "1.1.1.1"
+  taints: []
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+apiServer:
+  certSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
+  extraArgs:
+    - name: "enable-admission-plugins"
+      value: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+    - name: "feature-gates"
+      value: "ExtendWebSocketsToKubelet=false"
+controllerManager:
+  extraArgs:
+    - name: "allocate-node-cidrs"
+      value: "true"
+    - name: "feature-gates"
+      value: "ExtendWebSocketsToKubelet=false"
+    - name: "leader-elect"
+      value: "false"
+scheduler:
+  extraArgs:
+    - name: "feature-gates"
+      value: "ExtendWebSocketsToKubelet=false"
+    - name: "leader-elect"
+      value: "false"
+certificatesDir: /var/lib/minikube/certs
+clusterName: mk
+controlPlaneEndpoint: control-plane.minikube.internal:8443
+etcd:
+  local:
+    dataDir: /var/lib/minikube/etcd
+kubernetesVersion: v1.23.0
+networking:
+  dnsDomain: cluster.local
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: 10.96.0.0/12
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
+containerRuntimeEndpoint: unix:///var/run/dockershim.sock
+hairpinMode: hairpin-veth
+runtimeRequestTimeout: 15m
+clusterDomain: "cluster.local"
+# disable disk resource management by default
+imageGCHighThresholdPercent: 100
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"
+failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+clusterCIDR: "10.244.0.0/16"
+metricsBindAddress: 0.0.0.0:10249
+conntrack:
+  maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/hack/update/kubernetes_version/templates/v1beta4-v1.36+/dns.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4-v1.36+/dns.yaml
@@ -1,0 +1,84 @@
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 1.1.1.1
+  bindPort: 8443
+bootstrapTokens:
+  - groups:
+      - system:bootstrappers:kubeadm:default-node-token
+    ttl: 24h0m0s
+    usages:
+      - signing
+      - authentication
+nodeRegistration:
+  criSocket: unix:///var/run/dockershim.sock
+  name: "mk"
+  kubeletExtraArgs:
+    - name: "node-ip"
+      value: "1.1.1.1"
+  taints: []
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+apiServer:
+  certSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
+  extraArgs:
+    - name: "enable-admission-plugins"
+      value: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+    - name: "feature-gates"
+      value: "ExtendWebSocketsToKubelet=false"
+controllerManager:
+  extraArgs:
+    - name: "allocate-node-cidrs"
+      value: "true"
+    - name: "feature-gates"
+      value: "ExtendWebSocketsToKubelet=false"
+    - name: "leader-elect"
+      value: "false"
+scheduler:
+  extraArgs:
+    - name: "feature-gates"
+      value: "ExtendWebSocketsToKubelet=false"
+    - name: "leader-elect"
+      value: "false"
+certificatesDir: /var/lib/minikube/certs
+clusterName: mk
+controlPlaneEndpoint: control-plane.minikube.internal:8443
+etcd:
+  local:
+    dataDir: /var/lib/minikube/etcd
+kubernetesVersion: v1.23.0
+networking:
+  dnsDomain: minikube.local
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: 10.96.0.0/12
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
+containerRuntimeEndpoint: unix:///var/run/dockershim.sock
+hairpinMode: hairpin-veth
+runtimeRequestTimeout: 15m
+clusterDomain: "minikube.local"
+# disable disk resource management by default
+imageGCHighThresholdPercent: 100
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"
+failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+clusterCIDR: "10.244.0.0/16"
+metricsBindAddress: 0.0.0.0:10249
+conntrack:
+  maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/hack/update/kubernetes_version/templates/v1beta4-v1.36+/image-repository.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4-v1.36+/image-repository.yaml
@@ -1,0 +1,85 @@
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 1.1.1.1
+  bindPort: 8443
+bootstrapTokens:
+  - groups:
+      - system:bootstrappers:kubeadm:default-node-token
+    ttl: 24h0m0s
+    usages:
+      - signing
+      - authentication
+nodeRegistration:
+  criSocket: unix:///var/run/dockershim.sock
+  name: "mk"
+  kubeletExtraArgs:
+    - name: "node-ip"
+      value: "1.1.1.1"
+  taints: []
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+imageRepository: test/repo
+apiServer:
+  certSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
+  extraArgs:
+    - name: "enable-admission-plugins"
+      value: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+    - name: "feature-gates"
+      value: "ExtendWebSocketsToKubelet=false"
+controllerManager:
+  extraArgs:
+    - name: "allocate-node-cidrs"
+      value: "true"
+    - name: "feature-gates"
+      value: "ExtendWebSocketsToKubelet=false"
+    - name: "leader-elect"
+      value: "false"
+scheduler:
+  extraArgs:
+    - name: "feature-gates"
+      value: "ExtendWebSocketsToKubelet=false"
+    - name: "leader-elect"
+      value: "false"
+certificatesDir: /var/lib/minikube/certs
+clusterName: mk
+controlPlaneEndpoint: control-plane.minikube.internal:8443
+etcd:
+  local:
+    dataDir: /var/lib/minikube/etcd
+kubernetesVersion: v1.23.0
+networking:
+  dnsDomain: cluster.local
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: 10.96.0.0/12
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
+containerRuntimeEndpoint: unix:///var/run/dockershim.sock
+hairpinMode: hairpin-veth
+runtimeRequestTimeout: 15m
+clusterDomain: "cluster.local"
+# disable disk resource management by default
+imageGCHighThresholdPercent: 100
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"
+failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+clusterCIDR: "10.244.0.0/16"
+metricsBindAddress: 0.0.0.0:10249
+conntrack:
+  maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/hack/update/kubernetes_version/templates/v1beta4-v1.36+/options.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4-v1.36+/options.yaml
@@ -1,0 +1,91 @@
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 1.1.1.1
+  bindPort: 8443
+bootstrapTokens:
+  - groups:
+      - system:bootstrappers:kubeadm:default-node-token
+    ttl: 24h0m0s
+    usages:
+      - signing
+      - authentication
+nodeRegistration:
+  criSocket: unix:///var/run/dockershim.sock
+  name: "mk"
+  kubeletExtraArgs:
+    - name: "node-ip"
+      value: "1.1.1.1"
+  taints: []
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+apiServer:
+  certSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
+  extraArgs:
+    - name: "enable-admission-plugins"
+      value: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+    - name: "fail-no-swap"
+      value: "true"
+    - name: "feature-gates"
+      value: "ExtendWebSocketsToKubelet=false"
+controllerManager:
+  extraArgs:
+    - name: "allocate-node-cidrs"
+      value: "true"
+    - name: "feature-gates"
+      value: "ExtendWebSocketsToKubelet=false"
+    - name: "kube-api-burst"
+      value: "32"
+    - name: "leader-elect"
+      value: "false"
+scheduler:
+  extraArgs:
+    - name: "feature-gates"
+      value: "ExtendWebSocketsToKubelet=false"
+    - name: "leader-elect"
+      value: "false"
+    - name: "scheduler-name"
+      value: "mini-scheduler"
+certificatesDir: /var/lib/minikube/certs
+clusterName: mk
+controlPlaneEndpoint: control-plane.minikube.internal:8443
+etcd:
+  local:
+    dataDir: /var/lib/minikube/etcd
+kubernetesVersion: v1.23.0
+networking:
+  dnsDomain: cluster.local
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: 10.96.0.0/12
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
+containerRuntimeEndpoint: unix:///var/run/dockershim.sock
+hairpinMode: hairpin-veth
+runtimeRequestTimeout: 15m
+clusterDomain: "cluster.local"
+# disable disk resource management by default
+imageGCHighThresholdPercent: 100
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"
+failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+clusterCIDR: "10.244.0.0/16"
+metricsBindAddress: 0.0.0.0:10249
+conntrack:
+  maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
+mode: "iptables"


### PR DESCRIPTION
since k8s 1.36.0 we need to add special feauregates for docker runtime and that breaks the automation
https://github.com/kubernetes/minikube/pull/22963