### PR TITLE
tunnel/route_windows: fix locale-dependent parsing in route commands

### DIFF
--- a/pkg/minikube/tunnel/route_windows.go
+++ b/pkg/minikube/tunnel/route_windows.go
@@ -49,30 +49,23 @@ func (router *osRouter) EnsureRouteIsAdded(route *Route) error {
 	klog.Infof("About to run command: %s", command.Args)
 	stdInAndOut, err := command.CombinedOutput()
 	message := string(stdInAndOut)
-	if message != " OK!\r\n" {
-		return fmt.Errorf("error adding route: %s, %d", message, len(strings.Split(message, "\n")))
-	}
 	klog.Infof("%s", stdInAndOut)
 	if err != nil {
+		exists, recheckErr := isValidToAddOrDelete(router, route)
+		if recheckErr == nil && exists {
+			return nil
+		}
 		klog.Errorf("error adding Route: %s, %d", message, len(strings.Split(message, "\n")))
-		return err
+		return fmt.Errorf("error adding route: %s, %v", message, err)
 	}
 	return nil
 }
 
 func (router *osRouter) parseTable(table []byte) routingTable {
 	t := routingTable{}
-	skip := true
 	for _, line := range strings.Split(string(table), "\n") {
-		// after first line of header we can start consuming
-		if strings.HasPrefix(line, "Network Destination") {
-			skip = false
-			continue
-		}
-
 		fields := strings.Fields(line)
-		// don't care about the 0.0.0.0 routes
-		if skip || len(fields) == 0 || len(fields) > 0 && (fields[0] == "default" || fields[0] == "0.0.0.0") {
+		if len(fields) == 0 || fields[0] == "default" || fields[0] == "0.0.0.0" {
 			continue
 		}
 		if len(fields) > 2 {
@@ -130,13 +123,10 @@ func (router *osRouter) Cleanup(route *Route) error {
 	klog.Infof("Cleaning up route for CIDR %s to gateway %s\n", serviceCIDR, gatewayIP)
 	command := exec.Command("route", "delete", serviceCIDR)
 	stdInAndOut, err := command.CombinedOutput()
-	if err != nil {
-		return err
-	}
 	message := string(stdInAndOut)
 	klog.Infof("'%s'", message)
-	if message != " OK!\r\n" {
-		return fmt.Errorf("error deleting route: %s, %d", message, len(strings.Split(message, "\n")))
+	if err != nil {
+		return fmt.Errorf("error deleting route: %s, %v", message, err)
 	}
 	return nil
 }


### PR DESCRIPTION
On non-English Windows, `minikube tunnel` enters an endless retry loop because `route_windows.go` relies on English stdout strings that differ across locales.

Three call sites were affected:

- `EnsureRouteIsAdded` compared stdout against `" OK!\r\n"`. On Russian locale this is Cyrillic (`" ОК!\r\n"`), so it errored even when the route was successfully added (exit code 0).
- `parseTable` waited for a `"Network Destination"` header before parsing rows. On localized Windows the header is translated, so the routing table was always empty and `Inspect` could never detect existing routes.
- `Cleanup` had the same `" OK!\r\n"` check.

This PR replaces all three with the command exit code and uses `net.ParseIP` to naturally filter non-route lines in `parseTable`, matching the approach already used in `route_linux.go`. Also re-checks route existence after a failed `route ADD` to handle TOCTOU races gracefully.

Fixes #11645