### PR TITLE
kic: fix inspect to read only stdout, ignoring stderr warnings

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -409,11 +409,8 @@ func inspect(ociBin string, containerNameOrID, format string) ([]string, error) 
 	cmd := exec.Command(ociBin, "container", "inspect",
 		"-f", format,
 		containerNameOrID) // ... against the "node" container
-	var buff bytes.Buffer
-	cmd.Stdout = &buff
-	cmd.Stderr = &buff
-	_, err := runCmd(cmd)
-	scanner := bufio.NewScanner(&buff)
+	rr, err := runCmd(cmd)
+	scanner := bufio.NewScanner(&rr.Stdout)
 	var lines []string
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())

--- a/pkg/drivers/kic/oci/oci_test.go
+++ b/pkg/drivers/kic/oci/oci_test.go
@@ -18,6 +18,7 @@ package oci
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -110,6 +111,23 @@ func TestPointToHostPodman(t *testing.T) {
 		if v := os.Getenv(exp.key); v != exp.value {
 			t.Errorf("invalid %v env variable. got: %v, want: %v", exp.value, v, exp.value)
 		}
+	}
+}
+
+func TestInspectIgnoresStderr(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "fake-oci")
+	content := "#!/bin/sh\necho '192.168.49.2'\necho 'WARN[0000] The BoltDB backend is deprecated' >&2\n"
+	if err := os.WriteFile(script, []byte(content), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	lines, err := inspect(script, "test-container", "{{.NetworkSettings.IPAddress}}")
+	if err != nil {
+		t.Fatalf("inspect failed: %v", err)
+	}
+
+	if len(lines) != 1 || lines[0] != "192.168.49.2" {
+		t.Errorf("inspect returned %v, want [\"192.168.49.2\"]", lines)
 	}
 }
 


### PR DESCRIPTION
**Problem:**

The `inspect()` function in `pkg/drivers/kic/oci/oci.go` merged stdout and stderr into a single buffer before passing the command to `runCmd()`. When Podman 5.7.0+ emits warnings to stderr (e.g. BoltDB deprecation: `WARN[0000] The deprecated BoltDB database driver is in use...`), those lines end up in the parsed output. 

**Fix:**

Remove the manual buffer that merged both streams. Let `runCmd()` handle stdout/stderr separation via its default path (which already writes them to separate `rr.Stdout` and `rr.Stderr` buffers), then scan only `rr.Stdout`.

**Testing:**

Added `TestInspectIgnoresStderr` which creates a fake OCI binary that emits to both stdout and stderr, confirming only stdout is parsed.

Fixes #22537