### PR TITLE
hack/prow: update cri-dockerd to v0.4.3 for the none-driver integration script

### DIFF
--- a/hack/prow/integration_none_docker_linux_x86.sh
+++ b/hack/prow/integration_none_docker_linux_x86.sh
@@ -45,7 +45,7 @@ if ! which socat &>/dev/null; then
 fi
 
 # cri-dockerd is required for Kubernetes v1.24+ with none driver
-CRI_DOCKERD_VERSION="0.4.1"
+CRI_DOCKERD_VERSION="0.4.3"
 if [[ $(cri-dockerd --version 2>&1) != *"$CRI_DOCKERD_VERSION"* ]]; then
   echo "WARNING: expected version of cri-dockerd is not installed. will try to install."
   sudo systemctl stop cri-docker.socket || true

--- a/hack/update/cri_dockerd_version/cri_dockerd_version.go
+++ b/hack/update/cri_dockerd_version/cri_dockerd_version.go
@@ -61,6 +61,11 @@ var (
 				`CRI_DOCKERD_COMMIT=".*"`:  `CRI_DOCKERD_COMMIT="{{.FullCommit}}"`,
 			},
 		},
+		"hack/prow/integration_none_docker_linux_x86.sh": {
+			Replace: map[string]string{
+				`CRI_DOCKERD_VERSION=".*"`: `CRI_DOCKERD_VERSION="{{.Version}}"`,
+			},
+		},
 	}
 )
 


### PR DESCRIPTION
**Fixes the `pull-minikube-none-docker-linux-x86` presubmit, which currently fails on every PR.**

## The bug

`hack/prow/integration_none_docker_linux_x86.sh:48` pins:

```sh
CRI_DOCKERD_VERSION="0.4.1"
```

and downloads `cri-dockerd-0.4.1.amd64.tgz` from that release tag. But `cri-dockerd` `v0.4.1` was never released — `Mirantis/cri-dockerd` went from `v0.3.25` straight to `v0.4.2` / `v0.4.3` ([releases](https://github.com/Mirantis/cri-dockerd/releases)). The download 404s, `tar` chokes on the HTML error page, and the job dies in setup before any test runs:

```
+ tar -C /tmp -xzvf /tmp/cri-dockerd.tgz
gzip: stdin: not in gzip format
tar: Child returned status 1
```

## Why it regressed

#22916 bumped cri-dockerd `v0.4.1` → `v0.4.3` across kicbase, the ISO packages and the Jenkins none-driver script — but not this Prow script. There was no mechanism to catch it: the script isn't in the `schema` of `hack/update/cri_dockerd_version/cri_dockerd_version.go`, so the version updater never rewrites it, and it silently stayed on the broken `0.4.1`.

## The fix

| File | Change |
|---|---|
| `hack/prow/integration_none_docker_linux_x86.sh` | `CRI_DOCKERD_VERSION`: `0.4.1` → `0.4.3` — the version every other consumer already uses after #22916. `v0.4.2` / `v0.4.3` are CVE / dependency bumps only, no behaviour change. |
| `hack/update/cri_dockerd_version/cri_dockerd_version.go` | Adds the script to the updater `schema`, so future cri-dockerd bumps keep it in sync and it can't drift out again. |

The new `schema` entry only rewrites `CRI_DOCKERD_VERSION` — the Prow script has no `CRI_DOCKERD_COMMIT`, unlike the Jenkins one — and uses the unprefixed `{{.Version}}` to match the script's `"0.4.3"` form.

## Verification

`go build` and `go vet` on the `hack` module pass. The fix is config-only, so the most direct proof is this PR's own `pull-minikube-none-docker-linux-x86` run.

Fixes #22991

/kind bug
