### PR TITLE
image load: make removeExistingImage best-effort to fix silent failure when image is in use

### DIFF
--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -283,9 +283,8 @@ func transferAndLoadImage(cr command.Runner, k8s config.KubernetesConfig, src st
 		return fmt.Errorf("runtime: %w", err)
 	}
 
-	if err := removeExistingImage(r, src, imgName); err != nil {
-		return err
-	}
+	// Best-effort removal of the existing image; see removeExistingImage for details.
+	removeExistingImage(r, src, imgName)
 
 	klog.Infof("Loading image from: %s", src)
 	filename := filepath.Base(src)
@@ -323,24 +322,22 @@ func transferAndLoadImage(cr command.Runner, k8s config.KubernetesConfig, src st
 	return nil
 }
 
-func removeExistingImage(r cruntime.Manager, src string, imgName string) error {
+// removeExistingImage attempts to remove an existing image before loading a new
+// one. This is best-effort: removal may fail (e.g., the image does not exist
+// yet, or is in use by a running container) and that is acceptable because
+// container runtimes (docker load, ctr images import) can overwrite an existing
+// tag without prior removal. Any old image that cannot be removed becomes
+// dangling and can be cleaned up separately (e.g., "docker image prune").
+func removeExistingImage(r cruntime.Manager, src string, imgName string) {
 	// if loading an image from tar, skip deleting as we don't have the actual image name
 	// ie. imgName = "C:\this_is_a_dir\image.tar.gz"
 	if src == imgName {
-		return nil
+		return
 	}
 
-	err := r.RemoveImage(imgName)
-	if err == nil {
-		return nil
+	if err := r.RemoveImage(imgName); err != nil {
+		klog.Warningf("failed to remove existing image %q (will attempt load anyway): %v", imgName, err)
 	}
-
-	errStr := strings.ToLower(err.Error())
-	if !strings.Contains(errStr, "no such image") && !strings.Contains(errStr, "unable to remove the image") {
-		return fmt.Errorf("removing image: %w", err)
-	}
-
-	return nil
 }
 
 // SaveCachedImages saves from the container runtime to the cache

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -336,7 +336,7 @@ func removeExistingImage(r cruntime.Manager, src string, imgName string) {
 	}
 
 	if err := r.RemoveImage(imgName); err != nil {
-		klog.Warningf("failed to remove existing image %q (will attempt load anyway): %v", imgName, err)
+		klog.V(1).Infof("failed to remove existing image %q (will attempt load anyway): %v", imgName, err)
 	}
 }
 

--- a/pkg/minikube/machine/cache_images_test.go
+++ b/pkg/minikube/machine/cache_images_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/minikube/pkg/minikube/cruntime"
+)
+
+// mockRuntime implements the subset of cruntime.Manager used by removeExistingImage.
+type mockRuntime struct {
+	cruntime.Manager
+	removeErr error    // error to return from RemoveImage
+	removed   []string // records which images RemoveImage was called with
+}
+
+func (m *mockRuntime) RemoveImage(name string) error {
+	m.removed = append(m.removed, name)
+	return m.removeErr
+}
+
+func TestRemoveExistingImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string // source path of the cached image file (e.g., "/cache/myapp_latest")
+		imgName   string // image name to remove (e.g., "myapp:latest")
+		removeErr error  // error that mockRuntime.RemoveImage returns
+		wantCalls int    // expected number of RemoveImage invocations
+	}{
+		{
+			name:      "src equals imgName should skip removal",
+			src:       "/tmp/image.tar",
+			imgName:   "/tmp/image.tar",
+			wantCalls: 0,
+		},
+		{
+			name:      "successful removal",
+			src:       "/cache/myapp_latest",
+			imgName:   "myapp:latest",
+			removeErr: nil,
+			wantCalls: 1,
+		},
+		{
+			name:      "removal error should not prevent loading",
+			src:       "/cache/myapp_latest",
+			imgName:   "myapp:latest",
+			removeErr: fmt.Errorf("removal failed for any reason"),
+			wantCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &mockRuntime{removeErr: tt.removeErr}
+			removeExistingImage(r, tt.src, tt.imgName)
+			if len(r.removed) != tt.wantCalls {
+				t.Errorf("RemoveImage called %d times, want %d", len(r.removed), tt.wantCalls)
+			}
+		})
+	}
+}

--- a/pkg/minikube/machine/cache_images_test.go
+++ b/pkg/minikube/machine/cache_images_test.go
@@ -72,6 +72,9 @@ func TestRemoveExistingImage(t *testing.T) {
 			if len(r.removed) != tt.wantCalls {
 				t.Errorf("RemoveImage called %d times, want %d", len(r.removed), tt.wantCalls)
 			}
+			if tt.wantCalls == 1 && r.removed[0] != tt.imgName {
+				t.Errorf("RemoveImage called with %q, want %q", r.removed[0], tt.imgName)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`minikube image load <image:tag>` silently fails to update an image when a container using that image is already running inside minikube. This is a common scenario during development: rebuild a Docker image with the same tag (e.g.,
`myapp:0.1.0-SNAPSHOT`), then reload it into minikube while the previous deployment is still running.

The command exits successfully with no error message, but the image inside minikube is not updated.

Related to #11276 (originally fixed in #11366).

## Root cause

`transferAndLoadImage` calls `removeExistingImage` before loading the new image ([ref: v1.38.1 source][1]). `removeExistingImage` runs the runtime's remove command (e.g., `docker rmi <image:tag>`) inside minikube, which fails when a running container references the image:

```
conflict: unable to remove repository reference "myapp:0.1.0" (must force)
- container abc123 is using its referenced image def456
```

The error-handling in `removeExistingImage` uses ad-hoc string matching against a hard-coded list of "acceptable" error messages ([ref: v1.38.1 source][2]):

- `"no such image"`
- `"unable to remove the image"` (added in #19312)

Any error that does not match is treated as fatal. This includes Docker's `"unable to remove repository reference"` error shown above, as well as any new error messages that container runtimes may introduce in the future. When the error is treated as fatal, `LoadImage` is never called. Additionally, `DoLoadImages` swallows the error (returns nil), so the user sees no indication of failure.

Note: with older versions of `crictl rmi` (cri-tools ≤ v1.31), the error message for any removal failure was a catch-all `"unable to remove the image(s)"` ([ref: v1.29.0 source][4]), which happened to match the hard-coded pattern. Since cri-tools v1.32.0 ([ref: cri-tools PR 1639][5]), image removal was parallelized and the catch-all was replaced with per-image error messages, meaning the pattern match no longer works for newer CRI runtimes either. This further demonstrates that ad-hoc string matching is not a sustainable approach.

More fundamentally, removal of the old image **cannot** be a precondition for loading the new one. A running container holds a reference to the image it was started from, and that reference is not released until the container is stopped - not even after a new image is loaded with the same tag. This means a "remove-then-load" sequence will always fail when a container is running with the target image. Since container runtimes (`docker load`, `ctr images import`) can overwrite an existing tag without prior removal, the removal step should be best-effort rather than a gate.

[1]: https://github.com/kubernetes/minikube/blob/v1.38.1/pkg/minikube/machine/cache_images.go#L280-L288
[2]: https://github.com/kubernetes/minikube/blob/v1.38.1/pkg/minikube/machine/cache_images.go#L338-L341
[4]: https://github.com/kubernetes-sigs/cri-tools/blob/v1.29.0/cmd/crictl/image.go#L458-L460
[5]: https://github.com/kubernetes-sigs/cri-tools/pull/1639

## Fix

Make `removeExistingImage` best-effort: log a warning on failure and always proceed to `LoadImage`. Remove the brittle error-message pattern matching entirely.

It looks like this approach was originally suggested by @medyagh during the review of #11366 ([comment][6]):

> or alternatively we could do
>
> `klog.Warniningf("failed to remove image (which might be okay if it doesn't exists")`

The initial commit of that PR ([`32a91d6`][8]) implemented this as a warning, but a follow-up commit within the same PR ([`16dbac1`][9]) changed it to a fatal error to address performance concerns around `ListImages`. This fix reverts to the non-fatal approach without reintroducing the `ListImages` call - `RemoveImage` is called directly and its failure is simply logged. See the [full commit history of #11366][7] for context.

Any old image that cannot be removed becomes dangling and can be cleaned up separately (e.g., `docker image prune`). This is already the case today: the `"unable to remove the image"` pattern added in #19312 allows loading to proceed even when removal fails, which also results in dangling images.

Note: `DoLoadImages` currently swallows errors from `LoadCachedImages` (returns `nil` regardless of failure). This is a separate issue and is not addressed in this PR.

[6]: https://github.com/kubernetes/minikube/pull/11366#discussion_r631437500
[7]: https://github.com/kubernetes/minikube/pull/11366/commits
[8]: https://github.com/kubernetes/minikube/pull/11366/changes/32a91d6eb29c477e4f197b4387f5bbee5592b2af
[9]: https://github.com/kubernetes/minikube/pull/11366/changes/16dbac1f66e00ab11b33d1e0fc10ae835ed60ae6

## Changes

- `removeExistingImage`: a) change return type from `error` to nothing, b) log warning on failure instead of returning a fatal error, and c) remove ad-hoc error-message pattern matching.
- `transferAndLoadImage`: call `removeExistingImage` without error check.
- Add unit tests for `removeExistingImage`: verify `RemoveImage` is called (or skipped for tar files) and that no error prevents loading.

## Manual integration test

**Setup**: minikube running with Docker runtime.

**Dockerfiles**:

```dockerfile
# Dockerfile.v1
FROM busybox:latest
RUN echo "version1" > /version.txt
```

```dockerfile
# Dockerfile.v2
FROM busybox:latest
RUN echo "version2" > /version.txt
RUN echo "sample content" > /sample.txt
```

**Steps**:

```bash
# 1. Build and load v1
docker buildx build -f Dockerfile.v1 -t repro-test:0.1.0 .
minikube image load repro-test:0.1.0

# 2. Verify v1 is loaded
minikube ssh -- docker run --rm repro-test:0.1.0 cat /version.txt
# Expected: version1

# 3. Start a container using the image (simulates a running deployment)
minikube ssh -- docker run -d --name repro-running repro-test:0.1.0 sleep 3600

# 4. Build v2 with the same tag
docker buildx build -f Dockerfile.v2 -t repro-test:0.1.0 .

# 5. Load v2 with --overwrite
minikube image load --overwrite repro-test:0.1.0

# 6. Verify v2 is loaded
minikube ssh -- docker run --rm repro-test:0.1.0 cat /version.txt
# Before fix: "version1" (silent failure)
# After fix:  "version2"

minikube ssh -- docker run --rm repro-test:0.1.0 cat /sample.txt
# Before fix: "cat: can't open '/sample.txt': No such file or directory"
# After fix:  "sample content"

# 7. Cleanup
minikube ssh -- docker rm -f repro-running
minikube ssh -- docker rmi repro-test:0.1.0
docker rmi repro-test:0.1.0
```
