### PR TITLE
ssh: Avoid unneeded sleep when waiting for SSH server

### DIFF
--- a/pkg/drivers/common/ssh.go
+++ b/pkg/drivers/common/ssh.go
@@ -29,7 +29,13 @@ import (
 	"k8s.io/minikube/pkg/libmachine/log"
 )
 
-var (
+const (
+	// retryThreshold is the minimum check duration before we consider it a fast
+	// return that needs throttling. Checks shorter than this (e.g. immediate
+	// "connection refused") trigger a sleep to avoid busy-looping.
+	retryThreshold = 500 * time.Millisecond
+
+	// retryDelay is how long to sleep after a fast dial return.
 	retryDelay = time.Second
 
 	// We have 2 cases:
@@ -61,6 +67,7 @@ func WaitForSSHAccess(d drivers.Driver) error {
 	dialer := net.Dialer{Deadline: deadline}
 
 	for {
+		checkStart := time.Now()
 		done, err := checkSSHAccess(&dialer, addr)
 		if err != nil {
 			return err
@@ -69,7 +76,9 @@ func WaitForSSHAccess(d drivers.Driver) error {
 			log.Infof("SSH server %q is accessible in %.3f seconds", addr, time.Since(start).Seconds())
 			return nil
 		}
-		time.Sleep(retryDelay)
+		if time.Since(checkStart) < retryThreshold {
+			time.Sleep(retryDelay)
+		}
 	}
 }
 


### PR DESCRIPTION
The previous code slept unconditionally after each failed attempt.
Sleep only if the check returned in under 500ms (retryThreshold); if
the dial already blocked in the kernel, sleeping again just adds
unnecessary delay.
    
On local machines with vmnet, the dial typically blocks 1-5 seconds
in the kernel before returning "connection refused". The sleep is
skipped, saving 1 second per attempt.
    
In GitHub runners, where the VM takes longer to boot, we observe three
phases during the SSH wait:
    
- "operation timed out": dial blocks 10-16 seconds in the kernel (host
  not up, no ARP response). The sleep is skipped, saving 1 second per
  attempt.
    
- "host is down": kernel returns instantly after cached ARP failure.
  The sleep prevents a busy loop, retrying every 1 second.
    
- "connection refused": guest network is up but sshd not yet listening.
  Returns in under 100ms. Same as above, we sleep 1 second.

## Examples from GitHub Actions

### Sleep eliminated — dial blocked in kernel

vfkit second boot — dial blocked 75s, retried immediately (no 1s sleep):

```console
I0519 01:16:03.137589  libmachine: Dialing to SSH server "192.168.65.2:22"
I0519 01:17:18.137821  libmachine: Failed to dial: dial tcp 192.168.65.2:22: connect: operation timed out
I0519 01:17:18.137897  libmachine: Dialing to SSH server "192.168.65.2:22"
```

QEMU (socket_vmnet) second boot — dial blocked 16s, retried immediately:

```console
I0519 01:18:53.298024  libmachine: Dialing to SSH server "192.168.105.2:22"
I0519 01:19:09.156964  libmachine: Failed to dial: dial tcp 192.168.105.2:22: connect: operation timed out
I0519 01:19:09.157063  libmachine: Dialing to SSH server "192.168.105.2:22"
```

### Sleep kept — dial returned instantly

"host is down" returned in <1ms, slept 1s before retry:

```console
I0519 01:19:29.562156  libmachine: Dialing to SSH server "192.168.105.2:22"
I0519 01:19:29.562318  libmachine: Failed to dial: dial tcp 192.168.105.2:22: connect: host is down
I0519 01:19:30.563060  libmachine: Dialing to SSH server "192.168.105.2:22"
```

"connection refused" returned in 50ms, slept 1s before retry:

```console
I0519 01:22:17.421092  libmachine: Dialing to SSH server "192.168.105.2:22"
I0519 01:22:17.471344  libmachine: Failed to dial: dial tcp 192.168.105.2:22: connect: connection refused
I0519 01:22:18.472487  libmachine: Dialing to SSH server "192.168.105.2:22"
```
---
Assisted by Cursor/Claude Opus 4.6