### PR TITLE
Fix golangci-lint v2.12.2 update & verify exact checksums

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ MINIKUBE_RELEASES_URL=https://github.com/kubernetes/minikube/releases/download
 
 # latest from https://github.com/golangci/golangci-lint/releases
 # update this only by running `make update-golint-version`
-GOLINT_VERSION ?= v2.11.4
+GOLINT_VERSION ?= v2.12.2
 # see https://golangci-lint.run/docs/configuration/file/ for config details
 GOLINT_CONFIG ?= .golangci.min.yaml
 # Set this to --verbose to see details about the linters and formatters used
@@ -486,8 +486,24 @@ gocyclo: ## Run gocyclo (calculates cyclomatic complexities)
 
 out/linters/golangci-lint-$(GOLINT_VERSION):
 	mkdir -p out/linters
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLINT_VERSION)
-	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLINT_VERSION)
+	version="$(GOLINT_VERSION)"; \
+	version=$${version#v}; \
+	os=$$(go env GOOS); \
+	arch=$$(go env GOARCH); \
+	name="golangci-lint-$${version}-$${os}-$${arch}"; \
+	archive="out/linters/$${name}.tar.gz"; \
+	checksums="out/linters/golangci-lint-$${version}-checksums.txt"; \
+	curl -sfL -o "$${archive}" "https://github.com/golangci/golangci-lint/releases/download/$(GOLINT_VERSION)/$${name}.tar.gz"; \
+	curl -sfL -o "$${checksums}" "https://github.com/golangci/golangci-lint/releases/download/$(GOLINT_VERSION)/golangci-lint-$${version}-checksums.txt"; \
+	want=$$(awk -v file="$${name}.tar.gz" '$$2 == file { print $$1; exit }' "$${checksums}"); \
+	test -n "$${want}"; \
+	got=$$(openssl sha256 "$${archive}" | awk '{print $$2}'); \
+	test "$${want}" = "$${got}"; \
+	tmpdir=$$(mktemp -d); \
+	tar -xzf "$${archive}" -C "$${tmpdir}"; \
+	mv "$${tmpdir}/$${name}/golangci-lint" "$@"; \
+	chmod +x "$@"; \
+	rm -rf "$${tmpdir}" "$${archive}" "$${checksums}"
 
 # this one is meant for local use
 .PHONY: lint

--- a/pkg/libmachine/cert/cert.go
+++ b/pkg/libmachine/cert/cert.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -271,19 +270,19 @@ func (xcg *X509CertGenerator) ReadTLSConfig(addr string, authOptions *auth.Optio
 	clientKeyPath := authOptions.ClientKeyPath
 
 	log.Debugf("Reading CA certificate from %s", caCertPath)
-	caCert, err := ioutil.ReadFile(caCertPath)
+	caCert, err := os.ReadFile(caCertPath)
 	if err != nil {
 		return nil, err
 	}
 
 	log.Debugf("Reading client certificate from %s", clientCertPath)
-	clientCert, err := ioutil.ReadFile(clientCertPath)
+	clientCert, err := os.ReadFile(clientCertPath)
 	if err != nil {
 		return nil, err
 	}
 
 	log.Debugf("Reading client key from %s", clientKeyPath)
-	clientKey, err := ioutil.ReadFile(clientKeyPath)
+	clientKey, err := os.ReadFile(clientKeyPath)
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +311,7 @@ func (xcg *X509CertGenerator) ValidateCertificate(addr string, authOptions *auth
 
 func CheckCertificateDate(certPath string) (bool, error) {
 	log.Debugf("Reading certificate data from %s", certPath)
-	certBytes, err := ioutil.ReadFile(certPath)
+	certBytes, err := os.ReadFile(certPath)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/libmachine/mcnutils/b2d.go
+++ b/pkg/libmachine/mcnutils/b2d.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -242,7 +241,7 @@ func (*b2dReleaseGetter) download(dir, file, isoURL string) error {
 	defer src.Close()
 
 	// Download to a temp file first then rename it to avoid partial download.
-	f, err := ioutil.TempFile(dir, file+".tmp")
+	f, err := os.CreateTemp(dir, file+".tmp")
 	if err != nil {
 		return err
 	}
@@ -537,7 +536,7 @@ func MakeDiskImage(publicSSHKeyPath string) (*bytes.Buffer, error) {
 
 	log.Debug("Writing SSH key tar header")
 
-	pubKey, err := ioutil.ReadFile(publicSSHKeyPath)
+	pubKey, err := os.ReadFile(publicSSHKeyPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/libmachine/persist/filestore.go
+++ b/pkg/libmachine/persist/filestore.go
@@ -19,7 +19,6 @@ package persist
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,16 +47,16 @@ func (s Filestore) GetMachinesDir() string {
 
 func (s Filestore) saveToFile(data []byte, file string) error {
 	if _, err := os.Stat(file); os.IsNotExist(err) {
-		return ioutil.WriteFile(file, data, 0600)
+		return os.WriteFile(file, data, 0600)
 	}
 
-	tmpfi, err := ioutil.TempFile(filepath.Dir(file), "config.json.tmp")
+	tmpfi, err := os.CreateTemp(filepath.Dir(file), "config.json.tmp")
 	if err != nil {
 		return err
 	}
 	defer os.Remove(tmpfi.Name())
 
-	if err = ioutil.WriteFile(tmpfi.Name(), data, 0600); err != nil {
+	if err = os.WriteFile(tmpfi.Name(), data, 0600); err != nil {
 		return err
 	}
 
@@ -95,7 +94,7 @@ func (s Filestore) Remove(name string) error {
 }
 
 func (s Filestore) List() ([]string, error) {
-	dir, err := ioutil.ReadDir(s.GetMachinesDir())
+	dir, err := os.ReadDir(s.GetMachinesDir())
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
@@ -124,7 +123,7 @@ func (s Filestore) Exists(name string) (bool, error) {
 }
 
 func (s Filestore) loadConfig(h *host.Host) error {
-	data, err := ioutil.ReadFile(filepath.Join(s.GetMachinesDir(), h.Name, "config.json"))
+	data, err := os.ReadFile(filepath.Join(s.GetMachinesDir(), h.Name, "config.json"))
 	if err != nil {
 		return err
 	}

--- a/pkg/libmachine/provision/utils.go
+++ b/pkg/libmachine/provision/utils.go
@@ -18,8 +18,8 @@ package provision
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -140,16 +140,16 @@ func ConfigureAuth(p Provisioner) error {
 	}
 
 	// upload certs and configure TLS auth
-	caCert, err := ioutil.ReadFile(authOptions.CaCertPath)
+	caCert, err := os.ReadFile(authOptions.CaCertPath)
 	if err != nil {
 		return err
 	}
 
-	serverCert, err := ioutil.ReadFile(authOptions.ServerCertPath)
+	serverCert, err := os.ReadFile(authOptions.ServerCertPath)
 	if err != nil {
 		return err
 	}
-	serverKey, err := ioutil.ReadFile(authOptions.ServerKeyPath)
+	serverKey, err := os.ReadFile(authOptions.ServerKeyPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/libmachine/ssh/client.go
+++ b/pkg/libmachine/ssh/client.go
@@ -19,7 +19,6 @@ package ssh
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -146,7 +145,7 @@ func NewNativeConfig(user string, auth *Auth) (ssh.ClientConfig, error) {
 	)
 
 	for _, k := range auth.Keys {
-		key, err := ioutil.ReadFile(k)
+		key, err := os.ReadFile(k)
 		if err != nil {
 			return ssh.ClientConfig{}, err
 		}
@@ -259,7 +258,7 @@ func (client *NativeClient) Start(command string) (io.ReadCloser, io.ReadCloser,
 
 	client.openClient = conn
 	client.openSession = session
-	return ioutil.NopCloser(stdout), ioutil.NopCloser(stderr), nil
+	return io.NopCloser(stdout), io.NopCloser(stderr), nil
 }
 
 func (client *NativeClient) Wait() error {


### PR DESCRIPTION
Viewed filestore.go:8-37

Here is a draft for the Pull Request title and description:

---

### **Title**
`CI: Fix golangci-lint v2.12.2 update & verify exact checksums`

### **Description**

#### **Problem**
Updating `GOLINT_VERSION` to `v2.12.2` fails in CI due to a checksum verification error:
```
golangci/golangci-lint err hash_sha256_verify checksum for 'golangci-lint-2.12.2-linux-amd64.tar.gz' did not verify 
fd3a137c7e722128143cc8932bcaa00bc73e10adadee18bdb0893453edb2c137 vs 8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553
```

#### **Cause**
The upstream `install.sh` script does a loose string prefix match when looking up the archive checksum. In `golangci-lint` `v2.x`, they introduced `.sbom.json` files. Since `golangci-lint-2.12.2-linux-amd64.tar.gz.sbom.json` contains the `.tar.gz` name as a substring prefix, the installer matched and validated the tarball against the SBOM JSON file's checksum instead.

#### **Solution**
1. **Robust Checksum Validation**: Custom-implemented the download and validation logic for the linter binary inside the `Makefile` to perform an exact-match check (`$$2 == file`) on the filename. This prevents matching `.sbom.json` checksums and resolves the verification failure.
2. **Upgrade Linter**: Upgraded `GOLINT_VERSION` to `v2.12.2` in `Makefile`.
3. **ioutil Migration**: Resolved 15 linter issues regarding the deprecated `io/ioutil` package that were reported by the new linter version, migrating the code in `pkg/libmachine/` to use `os` and `io` packages.

closes https://github.com/kubernetes/minikube/issues/22975