### PR TITLE
Update hyperkit to note deprecation, note Apple Silicon hypervisor alternatives

### DIFF
--- a/site/content/en/docs/drivers/hyperkit.md
+++ b/site/content/en/docs/drivers/hyperkit.md
@@ -15,7 +15,7 @@ aliases:
 > have hypervisor options with
 > the preferred [vfkit driver]({{< ref "vfkit.md" >}}) or
 > the experimental [krunit driver]({{< ref "krunkit.md" >}}), or a
-> "[qemu]({{< ref "qemu.md" >}}) virtual machine.
+> [qemu]({{< ref "qemu.md" >}}) virtual machine.
 
 {{% readfile file="/docs/drivers/includes/hyperkit_usage.inc" %}}
 

--- a/site/content/en/docs/drivers/hyperkit.md
+++ b/site/content/en/docs/drivers/hyperkit.md
@@ -12,7 +12,10 @@ aliases:
 > [!WARNING]
 > The brew package "hyperkit" has been deprecated because it is no longer
 > maintained upstream! It was disabled on 2025-06-21. Apple Silicon users 
-> have hypervisor options with "krunkit" or "vfkit".
+> have hypervisor options with
+> the preferred [vfkit driver]({{< ref "vfkit.md" >}}) or
+> the experimental [krunit driver]({{< ref "krunkit.md" >}}), or a
+> "[qemu]({{< ref "qemu.md" >}}) virtual machine.
 
 {{% readfile file="/docs/drivers/includes/hyperkit_usage.inc" %}}
 

--- a/site/content/en/docs/drivers/hyperkit.md
+++ b/site/content/en/docs/drivers/hyperkit.md
@@ -9,6 +9,11 @@ aliases:
 
 [HyperKit](https://github.com/moby/hyperkit) is an open-source hypervisor for macOS hypervisor, optimized for lightweight virtual machines and container deployment.
 
+> [!WARNING]
+> The brew package "hyperkit" has been deprecated because it is no longer
+> maintained upstream! It was disabled on 2025-06-21. Apple Silicon users 
+> have hypervisor options with "krunkit" or "vfkit".
+
 {{% readfile file="/docs/drivers/includes/hyperkit_usage.inc" %}}
 
 ## Special features

--- a/site/content/en/docs/drivers/hyperkit.md
+++ b/site/content/en/docs/drivers/hyperkit.md
@@ -7,15 +7,18 @@ aliases:
 
 ## Overview
 
-[HyperKit](https://github.com/moby/hyperkit) is an open-source hypervisor for macOS hypervisor, optimized for lightweight virtual machines and container deployment.
+{{% alert title="Warning" color="warning" %}}
 
-> [!WARNING]
 > The brew package "hyperkit" has been deprecated because it is no longer
 > maintained upstream! It was disabled on 2025-06-21. Apple Silicon users 
 > have hypervisor options with
 > the preferred [vfkit driver]({{< ref "vfkit.md" >}}) or
 > the experimental [krunit driver]({{< ref "krunkit.md" >}}), or a
 > [qemu]({{< ref "qemu.md" >}}) virtual machine.
+ 
+{{% /alert %}}
+
+[HyperKit](https://github.com/moby/hyperkit) is an open-source hypervisor for macOS hypervisor, optimized for lightweight virtual machines and container deployment.
 
 {{% readfile file="/docs/drivers/includes/hyperkit_usage.inc" %}}
 

--- a/site/content/en/docs/drivers/hyperkit.md
+++ b/site/content/en/docs/drivers/hyperkit.md
@@ -8,14 +8,12 @@ aliases:
 ## Overview
 
 {{% alert title="Warning" color="warning" %}}
-
-> The brew package "hyperkit" has been deprecated because it is no longer
-> maintained upstream! It was disabled on 2025-06-21. Apple Silicon users 
-> have hypervisor options with
-> the preferred [vfkit driver]({{< ref "vfkit.md" >}}) or
-> the experimental [krunit driver]({{< ref "krunkit.md" >}}), or a
-> [qemu]({{< ref "qemu.md" >}}) virtual machine.
- 
+The brew package "hyperkit" has been deprecated because it is no longer
+maintained upstream! It was disabled on 2025-06-21. Apple Silicon users 
+have hypervisor options with
+the preferred [vfkit driver]({{< ref "vfkit.md" >}}) or
+the experimental [krunit driver]({{< ref "krunkit.md" >}}), or a
+[qemu]({{< ref "qemu.md" >}}) virtual machine. 
 {{% /alert %}}
 
 [HyperKit](https://github.com/moby/hyperkit) is an open-source hypervisor for macOS hypervisor, optimized for lightweight virtual machines and container deployment.


### PR DESCRIPTION
Point at the current hypervisor options for Apple Silicon with a warning message at the top of the hyperkit driver page.

fixes #23005

Even if the feature is deprecated the codebase is still there for it; there are other open issues targeting removal of this code. First step is to correctly set expectations for lack of support.

Preview: https://deploy-preview-23027--kubernetes-sigs-minikube.netlify.app/docs/drivers/hyperkit/