### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -723,8 +723,8 @@ func getPids(path string) ([]int, error) {
 	klog.Infof("pidfile contents: %s", data)
 
 	pids := []int{}
-	strPids := strings.Fields(string(data))
-	for _, p := range strPids {
+	strPids := strings.FieldsSeq(string(data))
+	for p := range strPids {
 		intPid, err := strconv.Atoi(p)
 		if err != nil {
 			return nil, err

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -323,8 +323,8 @@ func removePid(path string, pid string) error {
 	pids := []string{}
 	// we're splitting the mount-pids file content into a slice of strings
 	// so that we can compare each to the PID we're looking for
-	strPids := strings.Fields(string(data))
-	for _, p := range strPids {
+	strPids := strings.FieldsSeq(string(data))
+	for p := range strPids {
 		// If we find the PID, we don't add it to the slice
 		if p == pid {
 			continue

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -375,8 +375,8 @@ func ContainerExists(ociBin string, name string, warnSlow ...bool) (bool, error)
 		return false, err
 	}
 
-	containers := strings.Split(rr.Stdout.String(), "\n")
-	for _, c := range containers {
+	containers := strings.SplitSeq(rr.Stdout.String(), "\n")
+	for c := range containers {
 		if strings.TrimSpace(c) == name {
 			return true, nil
 		}

--- a/pkg/drivers/kic/oci/types.go
+++ b/pkg/drivers/kic/oci/types.go
@@ -131,7 +131,7 @@ func ParseMountString(spec string) (m Mount, err error) {
 	case 1:
 		m.ContainerPath = fields[0]
 	case 3:
-		for _, opt := range strings.Split(fields[2], ",") {
+		for opt := range strings.SplitSeq(fields[2], ",") {
 			switch opt {
 			case "Z":
 				m.SelinuxRelabel = true

--- a/pkg/drivers/virtualbox/virtualbox.go
+++ b/pkg/drivers/virtualbox/virtualbox.go
@@ -992,7 +992,7 @@ func parseHostOnlyNet(listOutput, name string) (mask net.IPMask, network net.IP,
 		return true, m, lip.Mask(m), nil
 	}
 
-	for _, line := range strings.Split(listOutput, "\n") {
+	for line := range strings.SplitSeq(listOutput, "\n") {
 		parts := strings.SplitN(strings.TrimSpace(line), ":", 2)
 		if len(parts) != 2 {
 			continue

--- a/pkg/drivers/vmware/driver.go
+++ b/pkg/drivers/vmware/driver.go
@@ -423,7 +423,7 @@ func (d *Driver) getMacAddressFromVmx() (string, error) {
 	// Look for generatedAddress as we're passing a VMX with addressType = "generated".
 	var macaddr string
 	vmxparse := regexp.MustCompile(`^ethernet0.generatedAddress\s*=\s*"(.*?)"\s*$`)
-	for _, line := range strings.Split(string(vmxcontent), "\n") {
+	for line := range strings.SplitSeq(string(vmxcontent), "\n") {
 		matches := vmxparse.FindStringSubmatch(line)
 		if matches == nil {
 			continue
@@ -504,7 +504,7 @@ func (d *Driver) getIPfromVmnetConfigurationFile(conffile, macaddr string) (stri
 	// we use a block depth so that just in case inner blocks exists
 	// we are not being fooled by them
 	blockdepth := 0
-	for _, line := range strings.Split(string(confcontent), "\n") {
+	for line := range strings.SplitSeq(string(confcontent), "\n") {
 
 		if matches := hostbegin.FindStringSubmatch(line); matches != nil {
 			blockdepth++
@@ -597,7 +597,7 @@ func (d *Driver) getIPfromDHCPLeaseFile(dhcpfile, macaddr string) (string, error
 	// Get the MAC address associated.
 	leasemac := regexp.MustCompile(`^\s*hardware ethernet (.+?);\r?$`)
 
-	for _, line := range strings.Split(string(dhcpcontent), "\n") {
+	for line := range strings.SplitSeq(string(dhcpcontent), "\n") {
 
 		if matches := leaseip.FindStringSubmatch(line); matches != nil {
 			lastipmatch = matches[1]

--- a/pkg/libmachine/provision/utils.go
+++ b/pkg/libmachine/provision/utils.go
@@ -215,7 +215,7 @@ func matchNetstatOut(reDaemonListening, netstatOut string) bool {
 	// manipulation hokey-pokey.
 	//
 	// TODO: Unit test this matching.
-	for _, line := range strings.Split(netstatOut, "\n") {
+	for line := range strings.SplitSeq(netstatOut, "\n") {
 		match, err := regexp.MatchString(reDaemonListening, line)
 		if err != nil {
 			log.Warnf("Regex warning: %s", err)

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -801,7 +801,7 @@ func parseMapString(str string) map[string]string {
 	if str == "" {
 		return mapResult
 	}
-	for _, pairText := range strings.Split(str, ",") {
+	for pairText := range strings.SplitSeq(str, ",") {
 		vals := strings.Split(pairText, "=")
 		if len(vals) != 2 {
 			out.WarningT("Ignoring invalid pair entry {{.pair}}", out.V{"pair": pairText})

--- a/pkg/minikube/bootstrapper/bsutil/binaries.go
+++ b/pkg/minikube/bootstrapper/bsutil/binaries.go
@@ -92,7 +92,7 @@ func binariesExist(cfg config.KubernetesConfig, c command.Runner) (bool, error) 
 	}
 	stdout := rr.Stdout.String()
 	foundBinaries := map[string]struct{}{}
-	for _, binary := range strings.Split(stdout, "\n") {
+	for binary := range strings.SplitSeq(stdout, "\n") {
 		foundBinaries[binary] = struct{}{}
 	}
 	for _, name := range constants.KubernetesReleaseBinaries {

--- a/pkg/minikube/bootstrapper/bsutil/featuregates.go
+++ b/pkg/minikube/bootstrapper/bsutil/featuregates.go
@@ -39,7 +39,7 @@ func supportedFG(featureName string) bool {
 func parseFeatureArgs(featureGates string) (map[string]bool, string, error) {
 	kubeadmFeatureArgs := map[string]bool{}
 	componentFeatureArgs := ""
-	for _, s := range strings.Split(featureGates, ",") {
+	for s := range strings.SplitSeq(featureGates, ",") {
 		if len(s) == 0 {
 			continue
 		}

--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -79,8 +79,8 @@ func tagFromKubeadm(v, name string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed getting kubeadm image list: %v", err)
 	}
-	lines := strings.Split(string(b), "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(string(b), "\n")
+	for line := range lines {
 		if !strings.Contains(line, name) {
 			continue
 		}

--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -90,7 +90,7 @@ func listCRIContainers(cr CommandRunner, root string, o ListContainersOptions) (
 	// Avoid an id named ""
 	var ids []string
 	seen := map[string]bool{}
-	for _, id := range strings.Split(rr.Stdout.String(), "\n") {
+	for id := range strings.SplitSeq(rr.Stdout.String(), "\n") {
 		klog.Infof("found id: %q", id)
 		if id != "" && !seen[id] {
 			ids = append(ids, id)

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -362,7 +362,7 @@ func (r *CRIO) CGroupDriver() (string, error) {
 		return "", err
 	}
 	cgroupManager := "systemd" // default
-	for _, line := range strings.Split(rr.Stdout.String(), "\n") {
+	for line := range strings.SplitSeq(rr.Stdout.String(), "\n") {
 		if strings.HasPrefix(line, "cgroup_manager") {
 			// cgroup_manager = "cgroupfs"
 			f := strings.Split(strings.TrimSpace(line), " = ")

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -300,8 +300,8 @@ func (f *FakeRunner) dockerPs(args []string) (string, error) {
 }
 
 func (f *FakeRunner) dockerStop(args []string) (string, error) {
-	ids := strings.Split(args[1], " ")
-	for _, id := range ids {
+	ids := strings.SplitSeq(args[1], " ")
+	for id := range ids {
 		f.t.Logf("fake docker: Stopping id %q", id)
 		if f.containers[id] == "" {
 			return "", errors.New("no such container")

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -451,7 +451,7 @@ func (r *Docker) ListContainers(o ListContainersOptions) ([]string, error) {
 		return nil, fmt.Errorf("docker: %w", err)
 	}
 	var ids []string
-	for _, line := range strings.Split(rr.Stdout.String(), "\n") {
+	for line := range strings.SplitSeq(rr.Stdout.String(), "\n") {
 		if line != "" {
 			ids = append(ids, line)
 		}
@@ -686,7 +686,7 @@ func dockerImagesPreloaded(runner command.Runner, imgs []string) bool {
 		return false
 	}
 	preloadedImages := map[string]struct{}{}
-	for _, i := range strings.Split(rr.Stdout.String(), "\n") {
+	for i := range strings.SplitSeq(rr.Stdout.String(), "\n") {
 		i = image.TrimDockerIO(i)
 		preloadedImages[i] = struct{}{}
 	}

--- a/pkg/minikube/out/out_reason.go
+++ b/pkg/minikube/out/out_reason.go
@@ -56,7 +56,7 @@ func indentMultiLine(s string) string {
 	}
 
 	cleaned := []string{"\n"}
-	for _, sn := range strings.Split(s, "\n") {
+	for sn := range strings.SplitSeq(s, "\n") {
 		cleaned = append(cleaned, style.Indented+strings.TrimSpace(sn))
 	}
 	return strings.Join(cleaned, "\n")

--- a/pkg/minikube/proxy/proxy.go
+++ b/pkg/minikube/proxy/proxy.go
@@ -115,8 +115,8 @@ func checkEnv(ip string, env string) bool {
 		return true
 	}
 	// Checks if included in IP ranges, i.e., 192.168.39.13/24
-	noProxyBlocks := strings.Split(v, ",")
-	for _, b := range noProxyBlocks {
+	noProxyBlocks := strings.SplitSeq(v, ",")
+	for b := range noProxyBlocks {
 		yes, err := isInBlock(ip, b)
 		if err != nil {
 			klog.Warningf("fail to check proxy env: %v", err)

--- a/pkg/minikube/tunnel/route_darwin.go
+++ b/pkg/minikube/tunnel/route_darwin.go
@@ -76,7 +76,7 @@ func (router *osRouter) Inspect(route *Route) (exists bool, conflict string, ove
 func (router *osRouter) parseTable(table []byte) routingTable {
 	t := routingTable{}
 	skip := true
-	for _, line := range strings.Split(string(table), "\n") {
+	for line := range strings.SplitSeq(string(table), "\n") {
 		// header
 		if strings.HasPrefix(line, "Destination") {
 			skip = false


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901
