### PR TITLE
containerd: skip TestPreload user-image check

### DIFF
--- a/test/integration/preload_test.go
+++ b/test/integration/preload_test.go
@@ -24,6 +24,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"k8s.io/minikube/pkg/minikube/constants"
 )
 
 // TestPreload verifies that disabling the initial preload, pulling a specific image,
@@ -65,6 +67,11 @@ func TestPreload(t *testing.T) {
 		}
 	}) {
 		t.Run("Restart-With-Preload-Check-User-Image", func(t *testing.T) {
+			// containerd preload overwrites /var and drops user images; unlike docker
+			// and cri-o it has no backup/restore yet (#22269), so this check can't pass.
+			if ContainerRuntime() == constants.Containerd {
+				t.Skip("containerd preload drops user images, see https://github.com/kubernetes/minikube/issues/23035")
+			}
 			// re-start the cluster and check if image is preserved with enabled preload
 			startArgs := []string{"start", "-p", profile, "--preload=true", "--alsologtostderr", "-v=1", "--wait=true"}
 			startArgs = append(startArgs, StartArgs()...)


### PR DESCRIPTION
TestPreload/Restart-With-Preload-Check-User-Image has been failing on the required pull-minikube-docker-containerd-linux-x86 job, which blocks other PRs from merging without an admin override.

The test pulls a user image, restarts with --preload=true, and checks the image is still there. On containerd the preload is a filesystem dump that gets untarred over /var, and that overwrites the runtime metadata, taking the user's image with it. docker and cri-o save and restore images around that step, but containerd doesn't do that yet (#22269), so the check can't pass there.

For now this just skips the check when the runtime is containerd, with a message linking back to this issue. docker and cri-o are untouched and keep running it.

Tested locally with the docker driver: on containerd the subtest skips (the setup still runs and passes), and on docker it runs and passes.

The real fix (backup/restore on containerd) is #22269, and #23018 would remove the /var overwrite altogether.

Fixes #23035
