### PR TITLE
pkg/minikube/runtimedir: move per-machine sockets out of MINIKUBE_HOME

### DIFF
--- a/pkg/drivers/common/vmnet/vmnet.go
+++ b/pkg/drivers/common/vmnet/vmnet.go
@@ -60,6 +60,10 @@ type Helper struct {
 	// The pidfile and log are stored here.
 	MachineDir string
 
+	// The socket is stored here. The caller creates the directory before
+	// starting the helper. See pkg/minikube/runtimedir.
+	MachineSocketDir string
+
 	// InterfaceID is an optional UUID for the vmnet interface. When set,
 	// vmnet-helper passes --interface-id to obtain a deterministic MAC address
 	// from vmnet.
@@ -339,7 +343,7 @@ func (h *Helper) GetState() (state.State, error) {
 }
 
 func (h *Helper) SocketPath() string {
-	return filepath.Join(h.MachineDir, sockfileName)
+	return filepath.Join(h.MachineSocketDir, sockfileName)
 }
 
 func (h *Helper) openLogfile() (*os.File, error) {

--- a/pkg/drivers/krunkit/krunkit.go
+++ b/pkg/drivers/krunkit/krunkit.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/process"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/minikube/run"
+	"k8s.io/minikube/pkg/minikube/runtimedir"
 	"k8s.io/minikube/pkg/minikube/style"
 )
 
@@ -197,6 +198,11 @@ func (d *Driver) Create() error {
 }
 
 func (d *Driver) Start() error {
+	socketDir, err := d.SocketDir()
+	if err != nil {
+		return err
+	}
+	d.VmnetHelper.MachineSocketDir = socketDir
 	socketPath := d.VmnetHelper.SocketPath()
 	if err := d.VmnetHelper.Start(socketPath); err != nil {
 		return err
@@ -226,10 +232,14 @@ func (d *Driver) Start() error {
 
 // startKrunkit starts the krunkit child process.
 func (d *Driver) startKrunkit(socketPath string) error {
+	restURI, err := d.restfulURI()
+	if err != nil {
+		return err
+	}
 	var args = []string{
 		"--memory", fmt.Sprintf("%d", d.Memory),
 		"--cpus", fmt.Sprintf("%d", d.CPU),
-		"--restful-uri", d.restfulURI(),
+		"--restful-uri", restURI,
 		"--device", fmt.Sprintf("virtio-net,type=unixgram,path=%s,mac=%s,offloading=%t",
 			socketPath, d.MACAddress, d.VmnetHelper.Offloading),
 		"--device", fmt.Sprintf("virtio-serial,logFilePath=%s", d.serialPath()),
@@ -319,6 +329,9 @@ func (d *Driver) Remove() error {
 		if err := d.Kill(); err != nil {
 			return fmt.Errorf("kill: %w", err)
 		}
+	}
+	if err := runtimedir.RemoveSocketDir(d.GetMachineName()); err != nil {
+		log.Debugf("Failed to remove socket dir: %v", err)
 	}
 	return nil
 }
@@ -449,12 +462,16 @@ func (d *Driver) isoPath() string {
 	return d.ResolveStorePath(isoFileName)
 }
 
-func (d *Driver) sockfilePath() string {
-	return d.ResolveStorePath(sockFileName)
+func (d *Driver) sockfilePath() (string, error) {
+	return d.ResolveSocketPath(sockFileName)
 }
 
-func (d *Driver) restfulURI() string {
-	return fmt.Sprintf("unix://%s", d.sockfilePath())
+func (d *Driver) restfulURI() (string, error) {
+	sock, err := d.sockfilePath()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("unix://%s", sock), nil
 }
 
 func (d *Driver) vmStateURI() string {
@@ -538,7 +555,11 @@ func (d *Driver) setKrunkitState(desired string) error {
 	if err != nil {
 		return err
 	}
-	httpc := httpUnixClient(d.sockfilePath())
+	sock, err := d.sockfilePath()
+	if err != nil {
+		return err
+	}
+	httpc := httpUnixClient(sock)
 	_, err = httpc.Post(d.vmStateURI(), "application/json", bytes.NewReader(data))
 	if err != nil {
 		return err

--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/minikube/run"
+	"k8s.io/minikube/pkg/minikube/runtimedir"
 	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/network"
 	"k8s.io/minikube/pkg/util/retry"
@@ -438,8 +439,12 @@ func (d *Driver) Start() error {
 		startCmd = append(startCmd,
 			"-cdrom", isoPath)
 	}
+	monitorPath, err := d.monitorPath()
+	if err != nil {
+		return err
+	}
 	startCmd = append(startCmd,
-		"-qmp", fmt.Sprintf("unix:%s,server,nowait", d.monitorPath()),
+		"-qmp", fmt.Sprintf("unix:%s,server,nowait", monitorPath),
 		"-pidfile", d.pidfilePath(),
 	)
 
@@ -608,6 +613,9 @@ func (d *Driver) Remove() error {
 			return fmt.Errorf("quit: %w", err)
 		}
 	}
+	if err := runtimedir.RemoveSocketDir(d.GetMachineName()); err != nil {
+		log.Debugf("Failed to remove socket dir: %v", err)
+	}
 	return nil
 }
 
@@ -662,9 +670,8 @@ func (d *Driver) diskPath() string {
 	return filepath.Join(machineDir, "disk.qcow2")
 }
 
-func (d *Driver) monitorPath() string {
-	machineDir := filepath.Join(d.StorePath, "machines", d.GetMachineName())
-	return filepath.Join(machineDir, "monitor")
+func (d *Driver) monitorPath() (string, error) {
+	return d.ResolveSocketPath("monitor")
 }
 
 func (d *Driver) pidfilePath() string {
@@ -763,7 +770,11 @@ func (d *Driver) generateUserdataDisk(userdataFile string) (string, error) {
 
 func (d *Driver) RunQMPCommand(command string) (map[string]interface{}, error) {
 	// connect to monitor
-	conn, err := net.Dial("unix", d.monitorPath())
+	monitorPath, err := d.monitorPath()
+	if err != nil {
+		return nil, err
+	}
+	conn, err := net.Dial("unix", monitorPath)
 	if err != nil {
 		return nil, fmt.Errorf("connect: %w", err)
 	}

--- a/pkg/drivers/vfkit/vfkit.go
+++ b/pkg/drivers/vfkit/vfkit.go
@@ -53,6 +53,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/process"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/minikube/run"
+	"k8s.io/minikube/pkg/minikube/runtimedir"
 	"k8s.io/minikube/pkg/minikube/style"
 )
 
@@ -243,6 +244,11 @@ func (d *Driver) Start() error {
 	var socketPath string
 
 	if d.VmnetHelper != nil {
+		socketDir, err := d.SocketDir()
+		if err != nil {
+			return err
+		}
+		d.VmnetHelper.MachineSocketDir = socketDir
 		socketPath = d.VmnetHelper.SocketPath()
 		if err := d.VmnetHelper.Start(socketPath); err != nil {
 			return err
@@ -282,10 +288,14 @@ func (d *Driver) Start() error {
 func (d *Driver) startVfkit(socketPath string) error {
 	var startCmd []string
 
+	vfkitSock, err := d.sockfilePath()
+	if err != nil {
+		return err
+	}
 	startCmd = append(startCmd,
 		"--memory", fmt.Sprintf("%d", d.Memory),
 		"--cpus", fmt.Sprintf("%d", d.CPU),
-		"--restful-uri", fmt.Sprintf("unix://%s", d.sockfilePath()),
+		"--restful-uri", fmt.Sprintf("unix://%s", vfkitSock),
 		"--log-level", "debug")
 
 	// On arm64 console= is required get boot messages in serial.log. On x86_64
@@ -342,7 +352,7 @@ func (d *Driver) startVfkit(socketPath string) error {
 	}
 
 	log.Debugf("executing: vfkit %s", strings.Join(startCmd, " "))
-	os.Remove(d.sockfilePath())
+	os.Remove(vfkitSock)
 	cmd := exec.Command("vfkit", startCmd...)
 
 	// Create vfkit in a new process group, so minikube caller can use killpg
@@ -493,6 +503,9 @@ func (d *Driver) Remove() error {
 			return fmt.Errorf("kill: %w", err)
 		}
 	}
+	if err := runtimedir.RemoveSocketDir(d.GetMachineName()); err != nil {
+		log.Debugf("Failed to remove socket dir: %v", err)
+	}
 	return nil
 }
 
@@ -593,9 +606,8 @@ func (d *Driver) diskPath() string {
 	return filepath.Join(machineDir, "disk.img")
 }
 
-func (d *Driver) sockfilePath() string {
-	machineDir := filepath.Join(d.StorePath, "machines", d.GetMachineName())
-	return filepath.Join(machineDir, sockFilename)
+func (d *Driver) sockfilePath() (string, error) {
+	return d.ResolveSocketPath(sockFilename)
 }
 
 func (d *Driver) pidfilePath() string {
@@ -672,7 +684,11 @@ type VMState struct {
 }
 
 func (d *Driver) GetVFKitState() (string, error) {
-	httpc := httpUnixClient(d.sockfilePath())
+	sock, err := d.sockfilePath()
+	if err != nil {
+		return "", err
+	}
+	httpc := httpUnixClient(sock)
 	var vmstate VMState
 	response, err := httpc.Get("http://_/vm/state")
 	if err != nil {
@@ -689,7 +705,11 @@ func (d *Driver) GetVFKitState() (string, error) {
 
 // SetVFKitState sets the state of the vfkit VM, (s is the state)
 func (d *Driver) SetVFKitState(s string) error {
-	httpc := httpUnixClient(d.sockfilePath())
+	sock, err := d.sockfilePath()
+	if err != nil {
+		return err
+	}
+	httpc := httpUnixClient(sock)
 	var vmstate VMState
 	vmstate.State = s
 	data, err := json.Marshal(&vmstate)

--- a/pkg/libmachine/drivers/base.go
+++ b/pkg/libmachine/drivers/base.go
@@ -19,6 +19,8 @@ package drivers
 import (
 	"errors"
 	"path/filepath"
+
+	"k8s.io/minikube/pkg/minikube/runtimedir"
 )
 
 const (
@@ -39,6 +41,11 @@ type BaseDriver struct {
 	SwarmMaster    bool
 	SwarmHost      string
 	SwarmDiscovery string
+
+	// socketDir is the per-machine socket directory, resolved and created on
+	// first use. It is not persisted: the runtime directory may not survive a
+	// reboot.
+	socketDir string
 }
 
 // DriverName returns the name of the driver
@@ -92,6 +99,30 @@ func (d *BaseDriver) PreCreateCheck() error {
 // ResolveStorePath returns the store path where the machine is
 func (d *BaseDriver) ResolveStorePath(file string) string {
 	return filepath.Join(d.StorePath, "machines", d.MachineName, file)
+}
+
+// SocketDir returns the directory holding the AF_UNIX sockets of the machine,
+// creating it on first use. Sockets cannot live in the store path, since it
+// may be too long for sockaddr_un.sun_path. See pkg/minikube/runtimedir.
+func (d *BaseDriver) SocketDir() (string, error) {
+	if d.socketDir == "" {
+		dir, err := runtimedir.EnsureSocketDir(d.MachineName)
+		if err != nil {
+			return "", err
+		}
+		d.socketDir = dir
+	}
+	return d.socketDir, nil
+}
+
+// ResolveSocketPath returns the path of a machine socket, creating the socket
+// directory on first use. This is the ResolveStorePath of AF_UNIX sockets.
+func (d *BaseDriver) ResolveSocketPath(file string) (string, error) {
+	dir, err := d.SocketDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, file), nil
 }
 
 // SetSwarmConfigFromFlags configures the driver for swarm

--- a/pkg/minikube/runtimedir/runtimedir.go
+++ b/pkg/minikube/runtimedir/runtimedir.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package runtimedir resolves the per-machine directory for AF_UNIX sockets.
+//
+// Sockets created under MINIKUBE_HOME (default $HOME/.minikube/machines/<name>/)
+// can exceed sockaddr_un.sun_path (108 bytes on Linux, 104 on macOS) when the
+// home path, user name or machine name are long. This package keeps only the
+// sockets in a short runtime directory; the rest of the per-machine state
+// (disk images, logs, configs, pidfiles) stays under MINIKUBE_HOME.
+//
+// Layout:
+//
+//	Linux:   $XDG_RUNTIME_DIR/minikube/<machine>
+//	         /tmp/user/<uid>/minikube/<machine> when XDG_RUNTIME_DIR is unset
+//	macOS:   /tmp/user/<uid>/minikube/<machine>
+//	Windows: %TEMP%\minikube\<machine>
+package runtimedir
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+
+	"k8s.io/klog/v2"
+)
+
+// dirMode is the mode of every directory created by this package. Sockets
+// bound inside need to be reachable only by the owning user.
+const dirMode = 0o700
+
+// Indirections for testing, so tests can run without touching the environment
+// or the real temporary directory.
+var (
+	// baseDir is the root of the fallback runtime directory.
+	baseDir = func() string { return "/tmp" }
+
+	// xdgRuntimeDir is the user runtime directory on Linux, typically
+	// /run/user/<uid>.
+	xdgRuntimeDir = func() string { return os.Getenv("XDG_RUNTIME_DIR") }
+
+	// tempDir is the per-user temporary directory on Windows, typically
+	// C:\Users\<username>\AppData\Local\Temp.
+	tempDir = os.TempDir
+)
+
+// EnsureSocketDir returns the directory holding the AF_UNIX sockets of the
+// given machine, creating it with mode 0700 if needed.
+func EnsureSocketDir(machineName string) (string, error) {
+	dir, err := resolve(machineName)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, dirMode); err != nil {
+		return "", fmt.Errorf("mkdir %q: %w", dir, err)
+	}
+	// MkdirAll applies the umask, and the directory may already exist with
+	// a more permissive mode.
+	if err := os.Chmod(dir, dirMode); err != nil {
+		return "", fmt.Errorf("chmod %q: %w", dir, err)
+	}
+	return dir, nil
+}
+
+// RemoveSocketDir removes the socket directory of the given machine. It is
+// idempotent: removing a directory that does not exist is not an error.
+func RemoveSocketDir(machineName string) error {
+	dir, err := resolve(machineName)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("remove %q: %w", dir, err)
+	}
+	return nil
+}
+
+// resolve returns the socket directory of the given machine without touching
+// the filesystem.
+func resolve(machineName string) (string, error) {
+	if machineName == "" {
+		return "", errors.New("machine name is empty")
+	}
+	switch runtime.GOOS {
+	case "windows":
+		// User names are limited to 20 characters, so the per-user temporary
+		// directory is short enough.
+		// https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/net-user
+		return filepath.Join(tempDir(), "minikube", machineName), nil
+	case "linux":
+		xdg := xdgRuntimeDir()
+		if xdg == "" {
+			break
+		}
+		// We cannot create the user runtime directory ourselves, since /run
+		// and /run/user are owned by root.
+		switch _, err := os.Stat(xdg); {
+		case err == nil:
+			return filepath.Join(xdg, "minikube", machineName), nil
+		case errors.Is(err, os.ErrNotExist):
+			klog.Warningf("XDG_RUNTIME_DIR %q does not exist, falling back to %s", xdg, baseDir())
+		default:
+			return "", fmt.Errorf("stat %q: %w", xdg, err)
+		}
+	}
+	// Fallback mirroring the XDG layout (/run/user/<uid>) under the temporary
+	// directory. Used on macOS, and on Linux when XDG_RUNTIME_DIR is unset or
+	// points to a missing directory.
+	return filepath.Join(baseDir(), "user", strconv.Itoa(os.Getuid()), "minikube", machineName), nil
+}

--- a/pkg/minikube/runtimedir/runtimedir_test.go
+++ b/pkg/minikube/runtimedir/runtimedir_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimedir
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+)
+
+// fakeBaseDir replaces the base directory with a temporary directory, so tests
+// do not depend on the real /tmp and do not leave anything behind.
+func fakeBaseDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	old := baseDir
+	baseDir = func() string { return dir }
+	t.Cleanup(func() { baseDir = old })
+	return dir
+}
+
+// fakeXDGRuntimeDir replaces the value of XDG_RUNTIME_DIR.
+func fakeXDGRuntimeDir(t *testing.T, value string) {
+	t.Helper()
+	old := xdgRuntimeDir
+	xdgRuntimeDir = func() string { return value }
+	t.Cleanup(func() { xdgRuntimeDir = old })
+}
+
+// fakeTempDir replaces the temporary directory used on windows.
+func fakeTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	old := tempDir
+	tempDir = func() string { return dir }
+	t.Cleanup(func() { tempDir = old })
+	return dir
+}
+
+// fakeDirs isolates the package from the environment on any platform.
+func fakeDirs(t *testing.T) (base, tmp string) {
+	t.Helper()
+	base = fakeBaseDir(t)
+	tmp = fakeTempDir(t)
+	fakeXDGRuntimeDir(t, "")
+	return base, tmp
+}
+
+// wantDir returns the expected socket directory when XDG_RUNTIME_DIR is unset.
+func wantDir(base, tmp, machineName string) string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(tmp, "minikube", machineName)
+	}
+	return filepath.Join(base, "user", strconv.Itoa(os.Getuid()), "minikube", machineName)
+}
+
+func TestResolve(t *testing.T) {
+	base, tmp := fakeDirs(t)
+
+	tests := []struct {
+		name        string
+		machineName string
+		want        string
+		wantErr     bool
+	}{
+		{
+			name:        "machine",
+			machineName: "minikube",
+			want:        wantDir(base, tmp, "minikube"),
+		},
+		{
+			name:        "node",
+			machineName: "minikube-m02",
+			want:        wantDir(base, tmp, "minikube-m02"),
+		},
+		{
+			name:        "no machine name",
+			machineName: "",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolve(tt.machineName)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("resolve(%q) = %q, want error", tt.machineName, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolve(%q): %v", tt.machineName, err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveXDGRuntimeDir(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("XDG_RUNTIME_DIR is used only on linux")
+	}
+	base, tmp := fakeDirs(t)
+	userDir := t.TempDir()
+
+	tests := []struct {
+		name string
+		xdg  string
+		want string
+	}{
+		{
+			name: "existing directory",
+			xdg:  userDir,
+			want: filepath.Join(userDir, "minikube", "minikube"),
+		},
+		{
+			// A broken system: we cannot create a directory under /run/user,
+			// so fall back to the base directory instead of failing.
+			name: "missing directory",
+			xdg:  filepath.Join(userDir, "missing"),
+			want: wantDir(base, tmp, "minikube"),
+		},
+		{
+			name: "unset",
+			xdg:  "",
+			want: wantDir(base, tmp, "minikube"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeXDGRuntimeDir(t, tt.xdg)
+			got, err := resolve("minikube")
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnsureSocketDir(t *testing.T) {
+	fakeDirs(t)
+
+	dir, err := EnsureSocketDir("minikube")
+	if err != nil {
+		t.Fatalf("EnsureSocketDir: %v", err)
+	}
+	checkDirMode(t, dir)
+
+	// Ensuring an existing directory must not fail.
+	again, err := EnsureSocketDir("minikube")
+	if err != nil {
+		t.Fatalf("EnsureSocketDir: %v", err)
+	}
+	if again != dir {
+		t.Errorf("got %q, want %q", again, dir)
+	}
+}
+
+// EnsureSocketDir must fix the mode of a directory created with a more
+// permissive mode, for example by a umask allowing group access.
+func TestEnsureSocketDirExistingMode(t *testing.T) {
+	fakeDirs(t)
+
+	dir, err := resolve("minikube")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, err := EnsureSocketDir("minikube"); err != nil {
+		t.Fatalf("EnsureSocketDir: %v", err)
+	}
+	checkDirMode(t, dir)
+}
+
+func TestEnsureSocketDirNoMachineName(t *testing.T) {
+	if _, err := EnsureSocketDir(""); err == nil {
+		t.Error("expected error for empty machine name")
+	}
+}
+
+func TestRemoveSocketDir(t *testing.T) {
+	fakeDirs(t)
+
+	dir, err := EnsureSocketDir("minikube")
+	if err != nil {
+		t.Fatalf("EnsureSocketDir: %v", err)
+	}
+	if err := RemoveSocketDir("minikube"); err != nil {
+		t.Fatalf("RemoveSocketDir: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("directory %q was not removed: %v", dir, err)
+	}
+
+	// Removing a missing directory must not fail.
+	if err := RemoveSocketDir("minikube"); err != nil {
+		t.Errorf("RemoveSocketDir: %v", err)
+	}
+}
+
+func TestRemoveSocketDirNoMachineName(t *testing.T) {
+	if err := RemoveSocketDir(""); err == nil {
+		t.Error("expected error for empty machine name")
+	}
+}
+
+func checkDirMode(t *testing.T, dir string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		// Unix permissions are not supported.
+		return
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != dirMode {
+		t.Errorf("directory %q mode is %o, want %o", dir, mode, dirMode)
+	}
+}


### PR DESCRIPTION

### Summary

AF_UNIX sockets are limited to `sun_path[108]` on Linux and `sun_path[104]` on macOS/BSD. minikube currently stores all per-machine sockets under `$MINIKUBE_HOME/.minikube/machines/<name>/`, which can exceed the limit when the home path, username, machine name or socket name are long. This is the root cause reported in #21087 for the QEMU `qmp` socket, but as @nirs pointed out in the issue thread the same trap exists for vfkit, krunkit and vmnet-helper.

This PR introduces a small `pkg/minikube/runtimedir/` helper that resolves per-machine socket paths to a short, platform-specific runtime directory, and migrates every driver socket to it. Non-socket per-machine state (disk images, logs, configs, pidfiles) stays under `MINIKUBE_HOME`.

Fixes #21087

> **Draft.** Opening this as a draft to surface the design decisions and open points below before polishing. Happy to take direction on any of them — and #22960 lands first.

### Layout

```
Linux:    $XDG_RUNTIME_DIR/minikube/<hash>/<sock-name>
          fallback /tmp/<uid>/minikube/<hash>/<sock-name>   (when XDG is unset or missing)
macOS:    /tmp/<uid>/minikube/<hash>/<sock-name>
Windows:  <os.TempDir()>/minikube/<hash>/<sock-name>        (qemu Experimental on Windows)
```

`<hash>` is the first 32 hex characters of `sha256(machineName)` (128 bits — collision-free across realistic profile names).

Per @nirs's budget calculation in the issue:

|       | base              | uid      | `minikube/` | hash | overhead | sun_path budget for sock name |
| ----- | ----------------- | -------- | ----------- | ---- | -------: | ----------------------------: |
| Linux | `/run/user/` (10) | up to 11 | 9           | 33   |       63 |             108 − 63 = **45** |
| macOS | `/tmp/` (5)       | up to 11 | 9           | 33   |       58 |             104 − 58 = **46** |

The longest socket name currently used in the tree is `vmnet-helper.sock-krun.sock` (27 chars), so the budget is comfortable.

### What changed

- New package `pkg/minikube/runtimedir/` exposing two entry points so callers can opt in to filesystem side effects:
  - `SocketPath(machineName, sockName string) (string, error)` — pure resolver, no filesystem writes. Used by callers that dial a socket the server already bound (state polls).
  - `EnsureSocketPath(machineName, sockName string) (string, error)` — resolves the path and creates the parent directory with mode `0700`. Used by callers that bind a new socket.
  - `Cleanup(machineName string) error` — idempotent removal of the per-machine runtime directory.
- Migrated socket call sites. Each driver exposes a `*Path` / `ensure*Path` pair so binding paths use the side-effecting variant and read paths stay pure:
  - `pkg/drivers/qemu` — QMP `monitor` socket. `Start` uses Ensure; `RunQMPCommand` uses the pure variant. Best-effort cleanup of any stale socket before bind.
  - `pkg/drivers/vfkit` — `vfkit.sock`. `startVfkit` uses Ensure; `GetVFKitState` / `SetVFKitState` stay pure. Existing best-effort stale-socket removal preserved.
  - `pkg/drivers/krunkit` — `krunkit.sock`. `restfulURI` uses Ensure; `setKrunkitState` stays pure.
  - `pkg/drivers/common/vmnet` — `vmnet-helper.sock`. `Helper.EnsureSocketPath` resolves the path and creates the dir (called from driver Start before the helper binds). The helper's pidfile and logfile remain in `MachineDir` (regular files, no `sun_path` limit).
- `vmnet.Helper` gains a `MachineName` field so the runtime path can be resolved without reaching into `MachineDir`'s filesystem layout. Populated at the two construction sites: `pkg/minikube/registry/drvs/vfkit` and `pkg/minikube/registry/drvs/krunkit`.
- All three drivers (`qemu`, `vfkit`, `krunkit`) now call `runtimedir.Cleanup` from `Remove()` so the directory is reclaimed on `minikube delete`.

### Tests

Table-driven coverage in `pkg/minikube/runtimedir/runtimedir_test.go`:

- `baseDir` picks the correct branch on darwin/linux/windows, including `$XDG_RUNTIME_DIR` present, empty, and pointing to a missing directory.
- `SocketPath` (pure) is deterministic across calls and asserts no filesystem side effect.
- `EnsureSocketPath` creates the parent dir with mode `0700` on the linux xdg-present and windows branches; the /tmp-rooted darwin/linux-fallback branches are exercised with a synthetic high uid and cleaned up afterwards so test runs don't pollute `/tmp/<real-uid>`.
- Both entry points reject empty machine or socket names.
- `Cleanup` removes the per-machine directory and is idempotent.
- `machineHash` has the expected length and avoids collisions across realistic profile names.
- `TestPathBudget` asserts the resolved path fits within `sun_path[108]` on Linux and `sun_path[104]` on macOS even for the worst-case machine name (64 chars) + socket name (`vmnet-helper.sock-krun.sock`, 27 chars).

Cross-compile checks pass for `linux/amd64`, `darwin/arm64`, `darwin/amd64`, and `windows/amd64` (qemu is supported on Windows with Experimental priority).

### Design notes / open points

A few decisions are surfaced here so reviewers can redirect early:

1. **Two entry points (pure vs ensure).** `SocketPath` and `EnsureSocketPath` differ only in whether the parent directory is materialised. The pure variant exists because state-poll callers (`GetVFKitState`, `RunQMPCommand`, `setKrunkitState`) should not lazily create directories on the filesystem for a machine that may not even be running. Drivers wrap the package functions in thin `*Path` / `ensure*Path` helpers for symmetry. The internal `resolveSocketPath(... ensure bool)` keeps both paths on one implementation.
2. **Single PR vs staged.** The helper is small but only meaningful with all four sockets migrated; splitting would force re-reviewing the same design 2–4 times. Commits are organized one per driver, so reverting a single migration if needed is trivial. Happy to stage if preferred.
3. **`MachineName` field on `vmnet.Helper`.** The alternative was deriving the machine name from `filepath.Base(MachineDir)`, which couples to a path convention. The explicit field is ~5 LOC across the two construction sites and easier to reason about.
4. **Permissions.** Runtime directories are created `0700`. When vmnet-helper runs under `sudo` (`NeedsSudo == true`), the socket is bound by root inside a user-owned `0700` directory; the helper receives the path via `--socket` from the caller (uid=user), so client and server agree on the location. This ownership/permission relationship is unchanged by this PR — vmnet-helper already bound the socket (as root) inside a user-owned `0700` directory under `MachineDir`; only the parent path is now shorter. Worth confirming on your end whether the helper already `chmod`s the socket post-bind; if not, we may need a small change in the external `/opt/vmnet-helper/bin/vmnet-helper` repo too. Happy to follow up there separately.
5. **Hash determinism.** `sha256(machineName)` only — `uid` is already in the path and `profile` is already baked into `machineName` in minikube's naming. I can include either if preferred.
6. **No build tags on the helper package.** The `runtimedir` package is cross-platform; the platform switch is done at runtime via `runtime.GOOS`. This keeps a single, easily testable implementation, and includes a Windows branch since qemu is supported there with Experimental priority.
7. **Stale socket on the old path.** After upgrading to a binary with this change, any leftover socket under `~/.minikube/machines/<name>/` becomes orphaned. It does not block the new socket and is removed by `minikube delete`, so I left an explicit one-off cleanup out of scope. Happy to add it if you'd rather sweep on `Start`.

### How to reproduce / validate locally

```bash
# Force a long MINIKUBE_HOME and observe start succeeding with this change.
export MINIKUBE_HOME=/Users/$(whoami)/.really-long-path-to-force-the-bug-aaaaaaaaaaaaaa
minikube start --driver=qemu2 -p test-long-path-bbbbbbbbbbb
# The QMP socket now lives at /tmp/<uid>/minikube/<hash>/monitor
```

Without the change, `minikube start` fails with "UNIX socket path too long" on macOS.

### Empirical validation

Reproduced end-to-end on macOS 15.5 (arm64) with `qemu-system-aarch64` 11.0.0. Without the fix, `minikube start` fails on a long `MINIKUBE_HOME` with the verbatim `UNIX socket path ... is too long` error from #21087. With the fix, the same path and profile name succeed: the QMP socket binds under the runtime directory and the rest of the per-machine state stays in `MINIKUBE_HOME`. The full `stop`/`start`/`delete` lifecycle, the default `$HOME/.minikube` path, and a sha256 check of the resolved directory name all pass — no regression. This run exercised the qemu2 driver end-to-end; the vfkit, krunkit and vmnet-helper migrations apply the identical `runtimedir` call-site pattern and were not separately e2e-tested locally.

Full repro logs, command output and a consolidated `SUMMARY.md` are attached as a separate comment, so the diff and this description stay readable.

A standalone, containerized **proof of concept** — [`unix-socket-path-limit`](https://github.com/rafaelmfried/unix-socket-path-limit) — runs the real `qemu` binary in Testcontainers to reproduce the bug and prove the fix deterministically, independent of the host's `$MINIKUBE_HOME` length.

### Commits

A single DCO-signed commit, per the squash-before-merge norm signalled on
the prior PR (#22960).

