### PR TITLE
vmnet: Fix brew install path on Intel Macs and support brew bin path

### DIFF
--- a/pkg/drivers/common/vmnet/vmnet.go
+++ b/pkg/drivers/common/vmnet/vmnet.go
@@ -37,6 +37,7 @@ import (
 
 	"k8s.io/minikube/pkg/libmachine/log"
 	"k8s.io/minikube/pkg/libmachine/state"
+	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/process"
 	"k8s.io/minikube/pkg/minikube/reason"
@@ -49,10 +50,9 @@ const (
 	logfileName  = "vmnet-helper.log"
 	sockfileName = "vmnet-helper.sock"
 
-	// Installed from GitHub releases.
-	installPath = "/opt/vmnet-helper/bin/vmnet-helper"
-	// Installed via Homebrew (macOS 26+ only).
-	brewInstallPath = "/opt/homebrew/opt/vmnet-helper/libexec/vmnet-helper"
+	// Legacy install path for macOS < 26 (installed from GitHub releases).
+	// Since macOS 26 the recommended install method is Homebrew.
+	legacyInstallPath = "/opt/vmnet-helper/bin/vmnet-helper"
 )
 
 // Helper manages the vmnet-helper process.
@@ -424,8 +424,10 @@ func validateRunningWithSudo(helperPath string, options *run.CommandOptions) err
 }
 
 // findHelper finds the path to the vmnet-helper executable.
+// Prefer brew install path since it is the recommended install method on macOS 26+.
 func findHelper() (string, error) {
-	paths := []string{brewInstallPath, installPath}
+	brewInstallPath := filepath.Join(detect.BrewPrefix(), "opt", "vmnet-helper", "libexec", "vmnet-helper")
+	paths := []string{brewInstallPath, legacyInstallPath}
 	for _, path := range paths {
 		if _, err := os.Stat(path); err != nil {
 			if !errors.Is(err, os.ErrNotExist) {

--- a/pkg/drivers/common/vmnet/vmnet.go
+++ b/pkg/drivers/common/vmnet/vmnet.go
@@ -99,7 +99,18 @@ var (
 // on the first call.
 func getHelperInfo() (helperInfo, error) {
 	once.Do(func() {
-		cached.Path, cached.Err = findHelper()
+		versionStr, err := macOSVersion()
+		if err != nil {
+			cached.Err = err
+			return
+		}
+		// ParseTolerant handles "26.2" by normalizing it to "26.2.0".
+		macOSVer, err := semver.ParseTolerant(versionStr)
+		if err != nil {
+			cached.Err = fmt.Errorf("invalid macOS version %q: %w", versionStr, err)
+			return
+		}
+		cached.Path, cached.Err = findHelper(macOSVer)
 		if cached.Err != nil {
 			return
 		}
@@ -107,12 +118,7 @@ func getHelperInfo() (helperInfo, error) {
 		if cached.Err != nil {
 			return
 		}
-		var macosVersion string
-		macosVersion, cached.Err = macOSVersion()
-		if cached.Err != nil {
-			return
-		}
-		cached.NeedsSudo, cached.Err = helperNeedsSudo(cached.Version, macosVersion)
+		cached.NeedsSudo, cached.Err = helperNeedsSudo(cached.Version, macOSVer)
 	})
 	return cached, cached.Err
 }
@@ -425,9 +431,13 @@ func validateRunningWithSudo(helperPath string, options *run.CommandOptions) err
 
 // findHelper finds the path to the vmnet-helper executable.
 // Prefer brew install path since it is the recommended install method on macOS 26+.
-func findHelper() (string, error) {
-	brewInstallPath := filepath.Join(detect.BrewPrefix(), "opt", "vmnet-helper", "libexec", "vmnet-helper")
-	paths := []string{brewInstallPath, legacyInstallPath}
+func findHelper(macOSVer semver.Version) (string, error) {
+	var paths []string
+	if macOSVer.Major >= 26 {
+		brewInstallPath := filepath.Join(detect.BrewPrefix(), "opt", "vmnet-helper", "libexec", "vmnet-helper")
+		paths = append(paths, brewInstallPath)
+	}
+	paths = append(paths, legacyInstallPath)
 	for _, path := range paths {
 		if _, err := os.Stat(path); err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
@@ -443,13 +453,8 @@ func findHelper() (string, error) {
 
 // helperNeedsSudo returns true if vmnet-helper needs sudo to run based on the
 // helper version and macOS version.
-func helperNeedsSudo(version helperVersion, macosVersion string) (bool, error) {
-	// ParseTolerant handles "26.2" by normalizing it to "26.2.0".
-	macVer, err := semver.ParseTolerant(macosVersion)
-	if err != nil {
-		return false, fmt.Errorf("invalid macOS version %q: %w", macosVersion, err)
-	}
-	if macVer.LT(semver.MustParse("26.0.0")) {
+func helperNeedsSudo(version helperVersion, macOSVer semver.Version) (bool, error) {
+	if macOSVer.Major < 26 {
 		return true, nil
 	}
 

--- a/pkg/drivers/common/vmnet/vmnet.go
+++ b/pkg/drivers/common/vmnet/vmnet.go
@@ -434,8 +434,14 @@ func validateRunningWithSudo(helperPath string, options *run.CommandOptions) err
 func findHelper(macOSVer semver.Version) (string, error) {
 	var paths []string
 	if macOSVer.Major >= 26 {
-		brewInstallPath := filepath.Join(detect.BrewPrefix(), "opt", "vmnet-helper", "libexec", "vmnet-helper")
-		paths = append(paths, brewInstallPath)
+		brewPrefix := detect.BrewPrefix()
+		paths = append(paths,
+			// Homebrew >= 1.0 installs to bin.
+			// See https://github.com/nirs/homebrew-vmnet-helper/issues/4
+			filepath.Join(brewPrefix, "bin", "vmnet-helper"),
+			// Homebrew < 1.0 installs to libexec.
+			filepath.Join(brewPrefix, "opt", "vmnet-helper", "libexec", "vmnet-helper"),
+		)
 	}
 	paths = append(paths, legacyInstallPath)
 	for _, path := range paths {

--- a/pkg/drivers/common/vmnet/vmnet.go
+++ b/pkg/drivers/common/vmnet/vmnet.go
@@ -430,8 +430,24 @@ func validateRunningWithSudo(helperPath string, options *run.CommandOptions) err
 }
 
 // findHelper finds the path to the vmnet-helper executable.
-// Prefer brew install path since it is the recommended install method on macOS 26+.
 func findHelper(macOSVer semver.Version) (string, error) {
+	paths := helperSearchPaths(macOSVer)
+	for _, path := range paths {
+		if _, err := os.Stat(path); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return "", &Error{Kind: reason.HostPathStat, Err: err}
+			}
+			continue
+		}
+		return path, nil
+	}
+	err := fmt.Errorf("failed to find vmnet-helper at %q", paths)
+	return "", &Error{Kind: reason.NotFoundVmnetHelper, Err: err}
+}
+
+// helperSearchPaths returns vmnet-helper paths to search, in priority order.
+// Prefer brew install paths on macOS 26+ since Homebrew is the recommended install method.
+func helperSearchPaths(macOSVer semver.Version) []string {
 	var paths []string
 	if macOSVer.Major >= 26 {
 		brewPrefix := detect.BrewPrefix()
@@ -444,17 +460,7 @@ func findHelper(macOSVer semver.Version) (string, error) {
 		)
 	}
 	paths = append(paths, legacyInstallPath)
-	for _, path := range paths {
-		if _, err := os.Stat(path); err != nil {
-			if !errors.Is(err, os.ErrNotExist) {
-				return "", &Error{Kind: reason.HostPathStat, Err: err}
-			}
-			continue
-		}
-		return path, nil
-	}
-	err := fmt.Errorf("failed to find vmnet-helper at %q", paths)
-	return "", &Error{Kind: reason.NotFoundVmnetHelper, Err: err}
+	return paths
 }
 
 // helperNeedsSudo returns true if vmnet-helper needs sudo to run based on the

--- a/pkg/drivers/common/vmnet/vmnet_test.go
+++ b/pkg/drivers/common/vmnet/vmnet_test.go
@@ -21,11 +21,60 @@ package vmnet
 import (
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/blang/semver/v4"
 )
+
+func TestHelperSearchPaths(t *testing.T) {
+	var macOS26Paths []string
+	if runtime.GOARCH == "arm64" {
+		macOS26Paths = []string{
+			"/opt/homebrew/bin/vmnet-helper",
+			"/opt/homebrew/opt/vmnet-helper/libexec/vmnet-helper",
+			legacyInstallPath,
+		}
+	} else {
+		macOS26Paths = []string{
+			"/usr/local/bin/vmnet-helper",
+			"/usr/local/opt/vmnet-helper/libexec/vmnet-helper",
+			legacyInstallPath,
+		}
+	}
+
+	tests := []struct {
+		name     string
+		macOSVer semver.Version
+		want     []string
+	}{
+		{
+			name:     "macOS 15 legacy only",
+			macOSVer: semver.MustParse("15.0.0"),
+			want:     []string{legacyInstallPath},
+		},
+		{
+			name:     "macOS 26 brew",
+			macOSVer: semver.MustParse("26.0.0"),
+			want:     macOS26Paths,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := helperSearchPaths(tt.macOSVer)
+			if len(got) != len(tt.want) {
+				t.Fatalf("helperSearchPaths() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("helperSearchPaths()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
 
 func TestMacOSVersion(t *testing.T) {
 	version, err := macOSVersion()

--- a/pkg/drivers/common/vmnet/vmnet_test.go
+++ b/pkg/drivers/common/vmnet/vmnet_test.go
@@ -23,6 +23,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/blang/semver/v4"
 )
 
 func TestMacOSVersion(t *testing.T) {
@@ -47,50 +49,50 @@ func TestHelperNeedsSudo(t *testing.T) {
 	tests := []struct {
 		name          string
 		helperVersion helperVersion
-		macOSVersion  string
+		macOSVer      semver.Version
 		want          bool
 	}{
 		{
 			name:          "old macOS new helper",
 			helperVersion: helperVersion{Version: "v0.9.0"},
-			macOSVersion:  "15.0",
+			macOSVer:      semver.MustParse("15.0.0"),
 			want:          true,
 		},
 		{
 			name:          "macOS 26 old helper",
 			helperVersion: helperVersion{Version: "v0.8.0"},
-			macOSVersion:  "26.0",
+			macOSVer:      semver.MustParse("26.0.0"),
 			want:          true,
 		},
 		{
 			name:          "macOS 26 new helper",
 			helperVersion: helperVersion{Version: "v0.9.0"},
-			macOSVersion:  "26.0",
+			macOSVer:      semver.MustParse("26.0.0"),
 			want:          false,
 		},
 		{
 			name:          "macOS 26 newer helper",
 			helperVersion: helperVersion{Version: "v1.0.0"},
-			macOSVersion:  "26.0",
+			macOSVer:      semver.MustParse("26.0.0"),
 			want:          false,
 		},
 		{
 			name:          "macOS 27 new helper",
 			helperVersion: helperVersion{Version: "v0.9.0"},
-			macOSVersion:  "27.0",
+			macOSVer:      semver.MustParse("27.0.0"),
 			want:          false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := helperNeedsSudo(tt.helperVersion, tt.macOSVersion)
+			got, err := helperNeedsSudo(tt.helperVersion, tt.macOSVer)
 			if err != nil {
 				t.Fatalf("helperNeedsSudo() failed: %v", err)
 			}
 			if got != tt.want {
 				t.Errorf("helperNeedsSudo(%v, %s) = %v, want %v",
-					tt.helperVersion.Version, tt.macOSVersion, got, tt.want)
+					tt.helperVersion.Version, tt.macOSVer, got, tt.want)
 			}
 		})
 	}

--- a/pkg/minikube/detect/detect.go
+++ b/pkg/minikube/detect/detect.go
@@ -201,6 +201,25 @@ func MacOS13Plus() bool {
 	return major >= 13
 }
 
+// BrewPrefix returns the default Homebrew installation prefix for the current OS
+// and architecture. See https://docs.brew.sh/Installation
+//
+// Returns an empty string on unsupported platforms (e.g. Windows) where Homebrew
+// has no standard prefix.
+func BrewPrefix() string {
+	switch runtime.GOOS {
+	case "darwin":
+		if runtime.GOARCH == "arm64" {
+			return "/opt/homebrew"
+		}
+		return "/usr/local"
+	case "linux":
+		return "/home/linuxbrew/.linuxbrew"
+	default:
+		return ""
+	}
+}
+
 // NestedVM returns true if the current machine is running a nested VM (like in MacOs in Github Action)
 // this func tries its best but not guaranteed to be 100% accurate, and if not sure will return false (default behaviour).
 func NestedVM() bool {


### PR DESCRIPTION
Fix brew path on Intel Macs and support brew bin path for vmnet-helper v1.0.0.

- Fix brew install path on Intel Macs: the brew path was hardcoded to
  /opt/homebrew which is only correct on Apple Silicon. Add
  detect.BrewPrefix() returning the correct Homebrew prefix for the
  current architecture.

- Search brew install path only on macOS 26+: Homebrew is the
  recommended install method only on macOS 26 and later. On older macOS
  versions only the legacy install path is searched.

- Support vmnet-helper brew install in bin: vmnet-helper >= 1.0 will
  install to the brew bin directory instead of libexec. Search the new
  bin path first, falling back to the current libexec path for older
  versions.

Fixes #23038
Fixes #22915