### PR TITLE
vfkit: Auto-select vmnet-shared network when available

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -551,17 +551,29 @@ func validateVfkitNetwork(n string, options *run.CommandOptions) string {
 	case "nat":
 		// always available
 	case "vmnet-shared":
-		// "vment-shared" provides access between machines, with lower performance compared to "nat".
+		// "vmnet-shared" provides access between machines, with lower performance compared to "nat".
 		if err := vmnet.ValidateHelper(options); err != nil {
-			if vmnetErr, ok := err.(*vmnet.Error); ok {
-				exit.Message(vmnetErr.Kind, "failed to validate {{.network}} network: {{.reason}}", out.V{"network": n, "reason": err})
-			} else {
+			if vmnetErr, ok := err.(*vmnet.Error); !ok {
 				exit.Message(reason.Usage, "failed to validate {{.network}} network: {{.reason}}", out.V{"network": n, "reason": err})
+			} else {
+				exit.Message(vmnetErr.Kind, "failed to validate {{.network}} network: {{.reason}}", out.V{"network": n, "reason": err})
 			}
 		}
 	case "":
-		// Default to nat since it is always available and provides the best performance.
-		n = "nat"
+		// Use vmnet-helper if installed, fallback to nat otherwise.
+		if err := vmnet.ValidateHelper(options); err != nil {
+			if vmnetErr, ok := err.(*vmnet.Error); !ok {
+				exit.Message(reason.Usage, "failed to validate vmnet-shared network: {{.reason}}", out.V{"reason": err})
+			} else if !vmnetErr.IsNotFound() {
+				exit.Message(vmnetErr.Kind, "failed to validate vmnet-shared network: {{.reason}}", out.V{"reason": err})
+			}
+			// vmnet-helper is not installed.
+			n = "nat"
+		} else {
+			// vmnet-helper is installed and validated.
+			n = "vmnet-shared"
+		}
+		out.Styled(style.Internet, "Automatically selected the {{.network}} network", out.V{"network": n})
 	default:
 		exit.Message(reason.Usage, "--network with vfkit must be 'nat' or 'vmnet-shared'")
 	}

--- a/pkg/drivers/common/vmnet/vmnet_error.go
+++ b/pkg/drivers/common/vmnet/vmnet_error.go
@@ -26,3 +26,7 @@ type Error struct {
 func (e Error) Error() string {
 	return e.Err.Error()
 }
+
+func (e Error) IsNotFound() bool {
+	return e.Kind.ID == reason.NotFoundVmnetHelper.ID
+}


### PR DESCRIPTION
Change the default network for vfkit when --network is not specified. Previously, vfkit always defaulted to "nat". Now it calls ValidateHelper() to determine the default:

- vmnet-helper is installed and usable: select "vmnet-shared" to enable features like multi-node clusters and access between clusters. Multi-node clusters and access between clusters work.

- vmnet-helper is not installed: fall back to "nat", keeping previous behavior.

When selecting the network automatically we log new message, matching qemu driver behavior:

    🌐  Automatically selected the vmnet-shared network

If vmnet-helper validation fails we exit with an error. The user can fix the installation or use --network=nat to bypass vmnet-helper.

Possible validation errors:

- macOS < 26: sudo is required but requires a password prompt and the user cancelled the password prompt. This case will be eliminated when macOS 28 is released and minikube requires macOS >= 26.
- macOS >= 26: sudo is not required but running vmnet-helper --version fails (very unlikely).

Behavior for --network=nat and --network=vmnet-shared is unchanged.

## Example run - vmnet-shared selected automatically

```console
% out/minikube start
😄  minikube v1.38.1 on Darwin 26.4.1 (arm64)
✨  Automatically selected the vfkit driver. Other choices: qemu2, ssh, podman (experimental), krunkit (experimental)
❗  Starting v1.39.0, minikube will default to "containerd" container runtime. See #21973 for more info.
🌐  Automatically selected the vmnet-shared network
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🔥  Creating vfkit VM (CPUs=2, Memory=6144MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.36.1 on Docker 28.5.2 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```

## Example run - multi-node cluster works out of the box

```console
% out/minikube start --nodes 2
😄  minikube v1.38.1 on Darwin 26.4.1 (arm64)
✨  Automatically selected the vfkit driver. Other choices: qemu2, ssh, podman (experimental), krunkit (experimental)
❗  Starting v1.39.0, minikube will default to "containerd" container runtime. See #21973 for more info.
🌐  Automatically selected the vmnet-shared network
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🔥  Creating vfkit VM (CPUs=2, Memory=4050MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.36.1 on Docker 28.5.2 ...
🔗  Configuring CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner

👍  Starting "minikube-m02" worker node in "minikube" cluster
🔥  Creating vfkit VM (CPUs=2, Memory=4050MB, Disk=20000MB) ...
🌐  Found network options:
    ▪ NO_PROXY=192.168.64.167
🐳  Preparing Kubernetes v1.36.1 on Docker 28.5.2 ...
    ▪ env NO_PROXY=192.168.64.167
🔎  Verifying Kubernetes components...
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```

---
Fixes #22513
