### PR TITLE
buildroot: Updated to latest LTS version

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,7 +30,6 @@ linters:
         - "-ST1005"
         # Omit embedded fields from selector expression
         - "-QF1008"
-        
     revive:
       enable-all-rules: true
       rules:
@@ -89,6 +88,14 @@ linters:
         - name: unused-receiver
           disabled: true
         - name: add-constant
+          disabled: true
+        ###### Redundant with other linters.
+        - name: error-strings
+          disabled: true # staticcheck ST1005 handles this and catches more cases
+        ###### Opinionated style rules - permanently disabled.
+        - name: if-return
+          disabled: true
+        - name: unsecure-url-scheme
           disabled: true
         ###### To be determined, this is a rule with differences.
         - name: import-alias-naming
@@ -156,6 +163,8 @@ linters:
       # we generally dont wanna touch or lint the Third_party code, it is basically like a fork for code that we can not import.
       # but have to copy/paste
       - third_party
+      # Deprecated driver, no one can test changes.
+      - pkg/drivers/parallels/
       # Skip test files
       - '(.+)_test\.go'
     rules:
@@ -187,6 +196,10 @@ linters:
       # Ignore package-naming rule in pkg/drivers/common/ because renaming it would create massive code churn and refactoring.
       - path: 'pkg/drivers/common/'
         text: "package-naming:"
+        linter: revive
+      # Existing bare returns in route_darwin.go - fix later.
+      - path: 'pkg/minikube/tunnel/route_darwin.go'
+        text: "bare-return:"
         linter: revive
 formatters:
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -197,6 +197,10 @@ linters:
       - path: 'pkg/drivers/common/'
         text: "package-naming:"
         linter: revive
+      # pkg/libmachine/log shadows the standard library "log" package, but renaming it would touch the entire codebase.
+      - path: 'pkg/libmachine/log/'
+        text: "package-naming:"
+        linter: revive
       # Existing bare returns in route_darwin.go - fix later.
       - path: 'pkg/minikube/tunnel/route_darwin.go'
         text: "bare-return:"

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ export GOTOOLCHAIN := go$(GO_VERSION)
 GO_K8S_VERSION_PREFIX ?= v1.36.0
 
 INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)
-BUILDROOT_BRANCH ?= 2025.02
+BUILDROOT_BRANCH ?= 2025.02.14
 GOLANG_OPTIONS = GOWORK=off GO_VERSION=$(GO_VERSION)
 BUILDROOT_OPTIONS = BR2_EXTERNAL=../../deploy/iso/minikube-iso $(GOLANG_OPTIONS)
 REGISTRY ?= gcr.io/k8s-minikube

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ KIC_VERSION ?= $(shell grep -E "Version =" pkg/drivers/kic/types.go | cut -d \" 
 HUGO_VERSION ?= $(shell grep -E "HUGO_VERSION = \"" netlify.toml | cut -d \" -f2)
 
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
-ISO_VERSION ?= "v1.38.0"-1778539887-22974
+ISO_VERSION ?= "v1.38.0"-1779921764-23057
 
 # Dashes are valid in semver, but not Linux packaging. Use ~ to delimit alpha/beta
 DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))

--- a/pkg/libmachine/log/fmt_machine_logger.go
+++ b/pkg/libmachine/log/fmt_machine_logger.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package log //nolint:revive
+package log
 
 import (
 	"fmt"

--- a/pkg/libmachine/log/fmt_machine_logger_test.go
+++ b/pkg/libmachine/log/fmt_machine_logger_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package log //nolint:revive
+package log
 
 import (
 	"bufio"

--- a/pkg/libmachine/log/history_recorder_test.go
+++ b/pkg/libmachine/log/history_recorder_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package log //nolint:revive
+package log
 
 import (
 	"testing"

--- a/pkg/libmachine/log/log.go
+++ b/pkg/libmachine/log/log.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package log //nolint:revive
+package log
 
 import (
 	"io"

--- a/pkg/libmachine/log/machine_logger.go
+++ b/pkg/libmachine/log/machine_logger.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package log //nolint:revive
+package log
 
 import "io"
 

--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -41,7 +41,7 @@ const fileScheme = "file"
 // DefaultISOURLs returns a list of ISO URL's to consult by default, in priority order
 func DefaultISOURLs() []string {
 	v := version.GetISOVersion()
-	isoBucket := "minikube-builds/iso/22974"
+	isoBucket := "minikube-builds/iso/23057"
 
 	return []string{
 		fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s-%s.iso", isoBucket, v, runtime.GOARCH),


### PR DESCRIPTION
Keeping minimal change to check if we can build an ISO with latest version. If everything is good the next step will be to update the kernel to latest 6.6.x version.

https://lore.kernel.org/buildroot/buildroot-2025.02.14-announce-1779278521@buildroot.org/T/#u

Based on #23058 to avoid the lint errors.
