### PR TITLE
Add configurable DNS servers for VM drivers

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -172,6 +172,11 @@ var settings = []Setting{
 		name: config.MaxAuditEntries,
 		set:  SetInt,
 	},
+	{
+		name:        config.DNSServers,
+		set:         SetStringSlice,
+		validations: []setFn{IsValidIPAddressSlice},
+	},
 }
 
 // ConfigCmd represents the config command

--- a/cmd/minikube/cmd/config/set_test.go
+++ b/cmd/minikube/cmd/config/set_test.go
@@ -33,35 +33,53 @@ func TestNotFound(t *testing.T) {
 
 func TestSetNotAllowed(t *testing.T) {
 	createTestConfig(t)
-	err := Set("driver", "123456")
-	if err == nil || err.Error() != "run validations for \"driver\" with value of \"123456\": [driver \"123456\" is not supported]" {
-		t.Fatalf("Set did not return error for unallowed value: %+v", err)
-	}
-	err = Set("memory", "10a")
-	if err == nil || err.Error() != "run validations for \"memory\" with value of \"10a\": [invalid memory size: invalid suffix: 'a']" {
-		t.Fatalf("Set did not return error for unallowed value: %+v", err)
-	}
+	t.Run("driver", func(t *testing.T) {
+		err := Set("driver", "123456")
+		if err == nil || err.Error() != "run validations for \"driver\" with value of \"123456\": [driver \"123456\" is not supported]" {
+			t.Fatalf("Set did not return error for unallowed value: %+v", err)
+		}
+	})
+	t.Run("memory", func(t *testing.T) {
+		err := Set("memory", "10a")
+		if err == nil || err.Error() != "run validations for \"memory\" with value of \"10a\": [invalid memory size: invalid suffix: 'a']" {
+			t.Fatalf("Set did not return error for unallowed value: %+v", err)
+		}
+	})
+	t.Run("dns-servers", func(t *testing.T) {
+		err := Set("dns-servers", ",1.2.3.4")
+		if err == nil {
+			t.Fatalf("Set did not return error for invalid dns-servers value")
+		}
+	})
 }
 
 func TestSetOK(t *testing.T) {
 	createTestConfig(t)
-	err := Set("driver", "ssh")
-	defer func() {
-		err = Unset("driver")
+	t.Run("driver", func(t *testing.T) {
+		err := Set("driver", "ssh")
+		defer func() {
+			err = Unset("driver")
+			if err != nil {
+				t.Errorf("failed to unset driver: %+v", err)
+			}
+		}()
 		if err != nil {
-			t.Errorf("failed to unset driver: %+v", err)
+			t.Fatalf("Set returned error for valid property value: %+v", err)
 		}
-	}()
-	if err != nil {
-		t.Fatalf("Set returned error for valid property value: %+v", err)
-	}
-	val, err := Get("driver")
-	if err != nil {
-		t.Fatalf("Get returned error for valid property: %+v", err)
-	}
-	if val != "ssh" {
-		t.Fatalf("Get returned %s, expected \"ssh\"", val)
-	}
+		val, err := Get("driver")
+		if err != nil {
+			t.Fatalf("Get returned error for valid property: %+v", err)
+		}
+		if val != "ssh" {
+			t.Fatalf("Get returned %s, expected \"ssh\"", val)
+		}
+	})
+	t.Run("dns-servers", func(t *testing.T) {
+		err := Set("dns-servers", "8.8.8.8,1.1.1.1")
+		if err != nil {
+			t.Fatalf("Set returned error for valid dns-servers value: %+v", err)
+		}
+	})
 }
 
 func createTestConfig(t *testing.T) {

--- a/cmd/minikube/cmd/config/util.go
+++ b/cmd/minikube/cmd/config/util.go
@@ -94,6 +94,12 @@ func SetBool(m config.MinikubeConfig, name string, val string) error {
 	return nil
 }
 
+// SetStringSlice sets a []string value from a comma-separated string
+func SetStringSlice(m config.MinikubeConfig, name string, val string) error {
+	m[name] = strings.Split(val, ",")
+	return nil
+}
+
 // ErrValidateProfile Error to validate profile
 type ErrValidateProfile struct {
 	Name string

--- a/cmd/minikube/cmd/config/util_test.go
+++ b/cmd/minikube/cmd/config/util_test.go
@@ -82,6 +82,37 @@ func TestSetBool(t *testing.T) {
 	}
 }
 
+func TestSetStringSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{"single", "8.8.8.8", []string{"8.8.8.8"}},
+		{"multiple", "8.8.8.8,1.1.1.1", []string{"8.8.8.8", "1.1.1.1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := make(config.MinikubeConfig)
+			if err := SetStringSlice(m, "dns-servers", tt.input); err != nil {
+				t.Fatalf("SetStringSlice(%q) error: %v", tt.input, err)
+			}
+			val, ok := m["dns-servers"].([]string)
+			if !ok {
+				t.Fatalf("Type not set to []string")
+			}
+			if len(val) != len(tt.expected) {
+				t.Fatalf("got %v, want %v", val, tt.expected)
+			}
+			for i := range val {
+				if val[i] != tt.expected[i] {
+					t.Fatalf("got %v, want %v", val, tt.expected)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateProfile(t *testing.T) {
 	testCases := []string{"82374328742_2974224498", "validate_test"}
 	for _, name := range testCases {

--- a/cmd/minikube/cmd/config/validations.go
+++ b/cmd/minikube/cmd/config/validations.go
@@ -19,6 +19,7 @@ package config
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"net/url"
 	"os"
 	"strconv"
@@ -152,6 +153,16 @@ func IsValidRuntime(_, runtime string) error {
 	_, err := cruntime.New(cruntime.Config{Type: runtime})
 	if err != nil {
 		return fmt.Errorf("invalid runtime: %v", err)
+	}
+	return nil
+}
+
+// IsValidIPAddressSlice checks that a comma-separated value contains only valid IP addresses (IPv4 or IPv6)
+func IsValidIPAddressSlice(name, val string) error {
+	for s := range strings.SplitSeq(val, ",") {
+		if _, err := netip.ParseAddr(s); err != nil {
+			return fmt.Errorf("%s: %q is not a valid IP address", name, s)
+		}
 	}
 	return nil
 }

--- a/cmd/minikube/cmd/config/validations_test.go
+++ b/cmd/minikube/cmd/config/validations_test.go
@@ -179,3 +179,90 @@ func TestIsValidMemory(t *testing.T) {
 
 	runValidations(t, tests, "memory", IsValidMemory)
 }
+
+func TestIsValidIPAddressSlice(t *testing.T) {
+	var tests = []validationTest{
+		{
+			value:     "8.8.8.8",
+			shouldErr: false,
+		},
+		{
+			value:     "8.8.8.8,1.1.1.1",
+			shouldErr: false,
+		},
+		{
+			value:     "192.168.1.1",
+			shouldErr: false,
+		},
+		{
+			value:     "10.0.0.1,172.16.0.1,8.8.4.4",
+			shouldErr: false,
+		},
+		{
+			value:     "::1",
+			shouldErr: false,
+		},
+		{
+			value:     "2001:4860:4860::8888",
+			shouldErr: false,
+		},
+		{
+			value:     "8.8.8.8,2001:4860:4860::8844",
+			shouldErr: false,
+		},
+		{
+			value:     "::ffff:8.8.8.8",
+			shouldErr: false,
+		},
+		{
+			value:     "",
+			shouldErr: true,
+		},
+		{
+			value:     "   ",
+			shouldErr: true,
+		},
+		{
+			value:     " 8.8.8.8",
+			shouldErr: true,
+		},
+		{
+			value:     "8.8.8.8 ",
+			shouldErr: true,
+		},
+		{
+			value:     "8.8.8.8, 1.1.1.1",
+			shouldErr: true,
+		},
+		{
+			value:     "not-an-ip",
+			shouldErr: true,
+		},
+		{
+			value:     "8.8.8.8,not-valid",
+			shouldErr: true,
+		},
+		{
+			value:     ",8.8.8.8",
+			shouldErr: true,
+		},
+		{
+			value:     "8.8.8.8,",
+			shouldErr: true,
+		},
+		{
+			value:     "8.8.8.8,,1.1.1.1",
+			shouldErr: true,
+		},
+		{
+			value:     "999.999.999.999",
+			shouldErr: true,
+		},
+		{
+			value:     "8.8.8",
+			shouldErr: true,
+		},
+	}
+
+	runValidations(t, tests, "dns-servers", IsValidIPAddressSlice)
+}

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"net/netip"
+
 	"github.com/blang/semver/v4"
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/spf13/cobra"
@@ -148,6 +150,7 @@ const (
 	preloadSrc              = "preload-source"
 	rosetta                 = "rosetta"
 	vmnetOffloading         = "vmnet-offloading"
+	dnsServers              = config.DNSServers
 )
 
 var (
@@ -311,6 +314,9 @@ func initNetworkingFlags() {
 	startCmd.Flags().String(sshSSHUser, defaultSSHUser, "SSH user (ssh driver only)")
 	startCmd.Flags().String(sshSSHKey, "", "SSH key (ssh driver only)")
 	startCmd.Flags().Int(sshSSHPort, defaultSSHPort, "SSH port (ssh driver only)")
+
+	// dns
+	startCmd.Flags().StringSlice(dnsServers, nil, "Static DNS server IP addresses for the VM (VM drivers only)")
 
 	// socket vmnet
 	startCmd.Flags().String(socketVMnetClientPath, "", "Path to the socket vmnet client binary (QEMU driver only)")
@@ -588,6 +594,35 @@ func getVmnetOffloading(driverName string) bool {
 	return enabled
 }
 
+// getDNSServers returns the configured DNS servers for VM drivers.
+// For non-VM drivers the value is ignored since DNS configuration via
+// systemd-resolved is not applicable.
+func getDNSServers(cmd *cobra.Command, driverName string) []netip.Addr {
+	servers := viper.GetStringSlice(dnsServers)
+	if len(servers) == 0 {
+		return nil
+	}
+	addrs := make([]netip.Addr, 0, len(servers))
+	for _, s := range servers {
+		addr, err := netip.ParseAddr(s)
+		if err != nil {
+			exit.Message(reason.Usage, "dns-servers: '{{.value}}' is not a valid IP address", out.V{"value": s})
+		}
+		addrs = append(addrs, addr)
+	}
+	// We handle only VMs managed by minikube.
+	if !driver.IsVM(driverName) || driver.IsSSH(driverName) {
+		// Only warn when the flag was explicitly passed. Config values are
+		// silently ignored for non-VM drivers to avoid noisy warnings when
+		// the user has both VM and container-based clusters.
+		if cmd.Flags().Changed(dnsServers) {
+			out.WarningT("--dns-servers flag is only valid with VM drivers, it will be ignored")
+		}
+		return nil
+	}
+	return addrs
+}
+
 // generateNewConfigFromFlags generate a config.ClusterConfig based on flags
 func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime string, drvName string, options *run.CommandOptions) config.ClusterConfig {
 	var cc config.ClusterConfig
@@ -694,6 +729,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 		AutoPauseInterval:  viper.GetDuration(autoPauseInterval),
 		Rosetta:            getRosetta(drvName),
 		VmnetOffloading:    getVmnetOffloading(drvName),
+		DNSServers:         getDNSServers(cmd, drvName),
 	}
 	cc.VerifyComponents = interpretWaitFlag(*cmd)
 

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -59,6 +59,8 @@ const (
 	EmbedCerts = "EmbedCerts"
 	// MaxAuditEntries is the maximum number of audit entries to retain
 	MaxAuditEntries = "MaxAuditEntries"
+	// DNSServers is the key for static DNS server addresses for VM drivers
+	DNSServers = "dns-servers"
 )
 
 var (

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"net"
+	"net/netip"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -111,6 +112,7 @@ type ClusterConfig struct {
 	AutoPauseInterval       time.Duration // Specifies interval of time to wait before checking if cluster should be paused
 	Rosetta                 bool          // Only used by vfkit driver
 	VmnetOffloading         bool          // Only used by krunkit driver
+	DNSServers              []netip.Addr  // Static DNS servers for the VM (VM drivers only)
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/node/dns.go
+++ b/pkg/minikube/node/dns.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"fmt"
+	"net/netip"
+	"os/exec"
+	"strings"
+
+	"k8s.io/klog/v2"
+	"k8s.io/minikube/pkg/minikube/command"
+	"k8s.io/minikube/pkg/minikube/out"
+)
+
+// configureDNS configures static DNS servers on the VM, overriding DHCP-provided
+// DNS settings. This fixes DNS resolution on managed Macs where network extensions
+// block DNS traffic from the VM bridge to the host resolver.
+//
+// We configure systemd-resolved with two settings:
+//
+//  1. DNS servers (resolvectl dns eth0 8.8.8.8 1.1.1.1):
+//     Sets DNS servers that are reachable from the VM, bypassing the
+//     host's broken DNS path.
+//
+//  2. Routing domain (resolvectl domain eth0 "~."):
+//     The "~." syntax tells systemd-resolved to route ALL DNS queries through
+//     eth0's DNS servers. The "~" prefix marks it as a routing domain (not a
+//     search domain), and "." matches the root domain (everything). Without
+//     this, systemd-resolved might still try other interfaces' DNS servers.
+func configureDNS(runner command.Runner, servers []netip.Addr) {
+	if len(servers) == 0 {
+		return
+	}
+
+	values := make([]string, len(servers))
+	for i, addr := range servers {
+		values[i] = addr.String()
+	}
+	dnsServers := strings.Join(values, " ")
+
+	script := fmt.Sprintf(`
+resolvectl dns eth0 %s
+resolvectl domain eth0 "~."
+resolvectl flush-caches
+`, dnsServers)
+
+	cmd := exec.Command("sudo", "bash", "-o", "errexit", "-c", script)
+	if _, err := runner.RunCmd(cmd); err != nil {
+		klog.Warningf("Failed to configure static DNS servers: %v", err)
+		out.WarningT("Failed to configure static DNS servers")
+		return
+	}
+
+	klog.Infof("Configured static DNS servers: %s", dnsServers)
+}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -676,6 +676,8 @@ func startMachine(cfg *config.ClusterConfig, node *config.Node, delOnFail bool, 
 		return runner, preExists, m, hostInfo, fmt.Errorf("Failed to get command runner: %w", err)
 	}
 
+	configureDNS(runner, cfg.DNSServers)
+
 	ip, err := validateNetwork(hostInfo, runner, cfg.KubernetesConfig.ImageRepository)
 	if err != nil {
 		return runner, preExists, m, hostInfo, fmt.Errorf("Failed to validate network: %w", err)


### PR DESCRIPTION
Add support for configuring static DNS servers on VM drivers via the
`--dns-servers` start flag and the persistent `dns-servers` config setting. When
set, minikube configures systemd-resolved on the VM at start via `resolvectl`.

The setting only applies to VM drivers. For container-based drivers it is
ignored, with a warning if the flag is passed explicitly.

This is intentionally a **minimal fix** for the v1.39 release. It does **not**
include automatic detection or auto-configuration of DNS servers (as proposed in
#22646). A follow-up issue will track that work.

## Motivation

The primary use case is managed Macs where corporate network extensions block
DNS traffic from the VM bridge to the host resolver. See #22646 for a detailed
description of the problem. Static DNS servers can also be useful in other
environments where the host-provided DNS is unavailable or unsuitable for the
VM.

## How it works

By default, VM drivers use the host as the DNS server (the bridge IP):

```console
$ minikube start
...

$ minikube ssh -- resolvectl status eth0
Link 2 (eth0)
    Current Scopes: DNS LLMNR/IPv4
         Protocols: +DefaultRoute +LLMNR -mDNS DNSOverTLS=opportunistic DNSSEC=no/unsupported
Current DNS Server: 192.168.64.1
       DNS Servers: 192.168.64.1
```

With `--dns-servers 8.8.8.8,1.1.1.1`, minikube reconfigures systemd-resolved to
use the specified servers and route all queries through them:

```console
$ minikube start --dns-servers 8.8.8.8,1.1.1.1
...

$ minikube ssh -- resolvectl status eth0
Link 2 (eth0)
    Current Scopes: DNS LLMNR/IPv4
         Protocols: +DefaultRoute +LLMNR -mDNS DNSOverTLS=opportunistic DNSSEC=no/unsupported
Current DNS Server: 8.8.8.8
       DNS Servers: 8.8.8.8 1.1.1.1
        DNS Domain: ~.
```

The `~.` routing domain tells systemd-resolved to send all DNS queries through
eth0's servers rather than falling back to other interfaces.

## Usage

### Per-cluster configuration

The configuration is persisted in the profile configuration and applied when nodes are started.

```console
minikube start --driver vfkit --network vmnet-shared --dns-servers 8.8.8.8,1.1.1.1
minikube stop
minikube start
```

### Persistent default

If we set the config all new VM-based clusters will use the config by default.

```console
minikube config set dns-servers 8.8.8.8,1.1.1.1
minikube start --driver vfkit --network vmnet-shared --profile p1
minikube start --driver krunkit --network vmnet-shared --profile p2
```

### New warnings

When starting a container-based cluster with this option we warn:

```console
% minikube start --driver podman --dns-servers 8.8.8.8,1.1.1.1
😄  minikube v1.38.1 on Darwin 26.5 (arm64)
✨  Using the podman (experimental) driver based on user configuration
❗  Starting v1.39.0, minikube will default to "containerd" container runtime. See #21973 for more info.
❗  --dns-servers flag is only valid with VM drivers, it will be ignored
...
```

---
Fixes #22646