### PR TITLE
site: bump node version from 20 to 24

### DIFF
--- a/hack/update/site_node_version/site_node_version.go
+++ b/hack/update/site_node_version/site_node_version.go
@@ -54,7 +54,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	version, err := latestNodeVersionByMajor(ctx, "v20")
+	version, err := latestNodeVersionByMajor(ctx, "v24")
 	if err != nil {
 		klog.Fatalf("Unable to get stable version: %v", err)
 	}

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@ command = "pwd && cd themes/docsy && npm install && git submodule update -f --in
 
 [build.environment]
 # node Active LTS
-NODE_VERSION = "20.20.2"
+NODE_VERSION = "24.16.0"
 # https://github.com/gohugoio/hugo/releases
 HUGO_VERSION = "v0.160.1"
 


### PR DESCRIPTION
closes https://github.com/kubernetes/minikube/issues/23008