### PR TITLE
Watch dhcpd_leases changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/docker/go-connections v0.7.0
 	github.com/docker/go-units v0.5.0
 	github.com/elazarl/goproxy v1.8.2
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gofrs/flock v0.13.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.7
@@ -142,7 +143,6 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/fgprof v0.9.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fvbommel/sortorder v1.1.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect

--- a/pkg/drivers/common/dhcp/lease.go
+++ b/pkg/drivers/common/dhcp/lease.go
@@ -34,8 +34,9 @@ const (
 	// leasesPath is the path to dhcpd leases file
 	leasesPath = "/var/db/dhcpd_leases"
 
-	// pollInterval is how long to wait between attempts in WaitForLease.
-	pollInterval = 2 * time.Second
+	// pollInterval is how long the caller should wait before retrying when the
+	// leases file is missing.
+	pollInterval = 1 * time.Second
 )
 
 // Entry holds a parsed DHCP lease entry.
@@ -71,18 +72,48 @@ func WaitForLease(mac string, timeout time.Duration) (string, error) {
 	log.Infof("Waiting for DHCP lease for %s (timeout %s)", mac, timeout)
 
 	start := time.Now()
-	deadline := start.Add(timeout)
-	for i := 0; ; i++ {
-		log.Debugf("Searching for %s in %s (attempt %d) ...", mac, leasesPath, i)
-		ip, err := ipAddressFromFile(macAddress, leasesPath)
-		if err == nil {
-			log.Infof("Found DHCP lease for %s: %s in %.3f seconds", mac, ip, time.Since(start).Seconds())
-			return ip, nil
+	lastWaitingLog := start
+	waiting := false
+
+	w, err := newWatcher(timeout)
+	if err != nil {
+		return "", err
+	}
+	defer w.Close()
+
+	for {
+		ev, err := w.watch()
+		if err != nil {
+			return "", fmt.Errorf("watching DHCP lease for %s: %w", mac, err)
 		}
-		if time.Now().After(deadline) {
-			return "", err
+		switch ev {
+		case fileMissing:
+			if !waiting {
+				log.Infof("Leases file removed, waiting until %s is created ...", leasesPath)
+				lastWaitingLog = time.Now()
+				waiting = true
+			} else if time.Since(lastWaitingLog) >= time.Minute {
+				log.Infof("Still waiting until %s is created ...", leasesPath)
+				lastWaitingLog = time.Now()
+			}
+			time.Sleep(pollInterval)
+		case fileCreated, fileChanged, periodicCheck:
+			switch ev {
+			case fileCreated:
+				log.Infof("Leases file created, searching for %s in %s", mac, leasesPath)
+				waiting = false
+			case fileChanged:
+				log.Debugf("Leases file changed, searching for %s in %s", mac, leasesPath)
+			case periodicCheck:
+				log.Debugf("Periodic check, searching for %s in %s", mac, leasesPath)
+			}
+			if ip, err := ipAddressFromFile(macAddress, leasesPath); err == nil {
+				log.Infof("Found DHCP lease for %s: %s in %.3f seconds", mac, ip, time.Since(start).Seconds())
+				return ip, nil
+			}
+		case deadlineExceeded:
+			return "", fmt.Errorf("timeout waiting for DHCP lease for %s after %s", mac, timeout)
 		}
-		time.Sleep(pollInterval)
 	}
 }
 

--- a/pkg/drivers/common/dhcp/watcher.go
+++ b/pkg/drivers/common/dhcp/watcher.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dhcp
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+const (
+	// checkInterval is how often we check as a fallback when listening for notifications.
+	checkInterval = 10 * time.Second
+)
+
+type event int
+
+const (
+	fileCreated event = iota
+	fileChanged
+	fileMissing
+	periodicCheck
+	deadlineExceeded
+)
+
+// watcher monitors the DHCP leases file for changes via fsnotify, with a
+// periodic fallback check every checkInterval. When the file does not exist,
+// watch() returns fileMissing immediately and the caller is responsible for
+// waiting before retrying.
+//
+// We watch the file directly rather than its parent directory (/var/db) because
+// macOS SIP protects some entries under /var/db, causing fsnotify's Add() to
+// fail with "operation not permitted" when it tries to lstat protected entries.
+//
+// Watching a file directly has one complication: programs that update the file
+// atomically (write tmp + rename) cause kqueue to lose the watch on the
+// original inode. We handle this by re-watching via startListening() whenever a
+// Remove or Rename event is received.
+//
+// The periodic fallback check is an extra safety mechanism in case fsnotify
+// events are buggy or silently lost.
+type watcher struct {
+	fsw       *fsnotify.Watcher
+	deadline  *time.Timer
+	ticker    *time.Ticker
+	listening bool
+}
+
+func newWatcher(d time.Duration) (*watcher, error) {
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create file watcher: %w", err)
+	}
+	ticker := time.NewTicker(checkInterval)
+	ticker.Stop()
+	return &watcher{
+		fsw:      fsw,
+		deadline: time.NewTimer(d),
+		ticker:   ticker,
+	}, nil
+}
+
+func (w *watcher) Close() {
+	w.ticker.Stop()
+	w.deadline.Stop()
+	w.fsw.Close()
+}
+
+// startListening tries to watch the leases file for notifications.
+func (w *watcher) startListening() error {
+	if err := w.fsw.Add(leasesPath); err != nil {
+		if w.listening {
+			w.ticker.Stop()
+			w.listening = false
+		}
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to watch %s: %w", leasesPath, err)
+		}
+		return nil
+	}
+	w.listening = true
+	w.ticker.Reset(checkInterval)
+	return nil
+}
+
+// watch returns the next event. When the file is missing, it returns
+// fileMissing immediately — the caller should sleep before calling again.
+// When the file exists, it blocks until a change is detected.
+func (w *watcher) watch() (event, error) {
+	if !w.listening {
+		select {
+		case <-w.deadline.C:
+			return deadlineExceeded, nil
+		default:
+		}
+		if err := w.startListening(); err != nil {
+			return 0, err
+		}
+		if w.listening {
+			return fileCreated, nil
+		}
+		return fileMissing, nil
+	}
+
+	for {
+		select {
+		case ev, ok := <-w.fsw.Events:
+			if !ok {
+				return 0, errors.New("watcher events channel closed")
+			}
+			if ev.Has(fsnotify.Remove | fsnotify.Rename) {
+				// Atomic writes replace the file via remove or rename,
+				// dropping the kqueue watch. Re-watch the new inode.
+				// See https://github.com/fsnotify/fsnotify/issues/372
+				if err := w.startListening(); err != nil {
+					return 0, err
+				}
+				if w.listening {
+					return fileChanged, nil
+				}
+				return fileMissing, nil
+			}
+			if ev.Has(fsnotify.Create | fsnotify.Write) {
+				// In practice dhcpd updates the leases file atomically
+				// (write tmp + rename), so we typically see Rename above.
+				// Write is kept as a fallback; if we read mid-write,
+				// IPAddressForMAC simply won't find the MAC and we'll
+				// retry on the next event or periodic check.
+				return fileChanged, nil
+			}
+			// Ignore Chmod and other unrelated events (e.g. Spotlight indexing).
+		case err, ok := <-w.fsw.Errors:
+			if !ok {
+				return 0, errors.New("watcher errors channel closed")
+			}
+			return 0, fmt.Errorf("watcher error: %w", err)
+		case <-w.ticker.C:
+			return periodicCheck, nil
+		case <-w.deadline.C:
+			return deadlineExceeded, nil
+		}
+	}
+}


### PR DESCRIPTION
Replace polling when waiting for a DHCP lease with fsnotify-based file
watching. Parse the leases file only when it changes, log only on events.

## Motivation

The old code polled `/var/db/dhcpd_leases` every 2 seconds while waiting for a
lease:

1. **Noisy logs** — logs every 2 seconds, every noisy in the CI
2. **Wasted work** — re-parsed the entire file even when nothing changed
3. **Still slow** — a new lease could go undetected for up to 2 seconds

## How it works

### watcher

The watcher monitors `/var/db/dhcpd_leases` via fsnotify. It has no logging and
no polling loop — it just returns events to the caller.

Each call to `watch()` either returns immediately or blocks:

- **File missing**: tries to start watching. If the file doesn't exist, returns
  `fileMissing` immediately. The caller decides how long to wait before retrying.
- **File exists**: blocks on fsnotify events, a periodic fallback ticker (10s),
  or the deadline timer.

Events:

- `fileMissing` — file does not exist, or was removed during watching (returned immediately, non-blocking)
- `fileCreated` — file appeared, watching started
- `fileChanged` — fsnotify detected a change (including atomic writes via rename/remove)
- `periodicCheck` — 10s fallback in case fsnotify events are missed
- `deadlineExceeded` — timeout

### WaitForLease

`WaitForLease` drives the loop, handles all logging, and searches the leases
file only when the watcher reports a change.

On `fileMissing`: logs "waiting until file is created" once, then a "still
waiting" heartbeat every minute. Sleeps 1s before retrying.

On `fileCreated` / `fileChanged` / `periodicCheck`: searches the leases file
for the MAC address.

## Flows

### First boot, file exists (local)

The leases file exists with entries from other VMs, but our lease isn't there yet.

1. `fileCreated` → search leases file → no match
2. `fileChanged` → search leases file → found (dhcpd wrote the lease)

### First boot, file missing (CI)

The leases file doesn't exist yet — common on CI runners.

1. `fileMissing` → log "Leases file removed, waiting until … is created"
2. `fileMissing` × N → silent (log "Still waiting …" every minute)
3. `fileCreated` → search leases file → found

### Second boot

The leases file exists and our lease is already in it.

1. `fileCreated` → search leases file → found immediately

## Example logs

### First boot (CI) — file missing ~100s

File doesn't exist for 117 seconds — only 2 status lines during the wait
instead of "Searching for …" every 2 seconds.

```
I0601 21:58:49.682947   33845 main.go:144] libmachine: Nested VM detected, increasing timeout from 2m0s to 6m0s
I0601 21:58:49.682970   33845 main.go:144] libmachine: Waiting for DHCP lease for e6:f6:65:cb:17:82 (timeout 6m0s)
I0601 21:58:49.683129   33845 main.go:144] libmachine: Leases file removed, waiting until /var/db/dhcpd_leases is created ...
I0601 21:59:49.803267   33845 main.go:144] libmachine: Still waiting until /var/db/dhcpd_leases is created ...
I0601 22:00:46.881589   33845 main.go:144] libmachine: Leases file created, searching for e6:f6:65:cb:17:82 in /var/db/dhcpd_leases
I0601 22:00:46.881723   33845 main.go:144] libmachine: Found DHCP lease for e6:f6:65:cb:17:82: 192.168.65.2 in 117.140 seconds```

## Example logs - second boot (CI)

Lease already in the file from the first boot — found immediately.

```
I0601 22:01:45.849152   38317 main.go:144] libmachine: Nested VM detected, increasing timeout from 2m0s to 6m0s
I0601 22:01:45.849168   38317 main.go:144] libmachine: Waiting for DHCP lease for e6:f6:65:cb:17:82 (timeout 6m0s)
I0601 22:01:45.849344   38317 main.go:144] libmachine: Leases file created, searching for e6:f6:65:cb:17:82 in /var/db/dhcpd_leases
I0601 22:01:45.849425   38317 main.go:144] libmachine: Found DHCP lease for e6:f6:65:cb:17:82: 192.168.65.2 in 0.000 seconds```

## Example logs - first start (local)

File exists with ~200 entries but our lease isn't there yet — we search once,
start watching, and find it ~1.3s later on the first `fileChanged` instead of
polling every 2 seconds.

```
I0531 23:59:41.611070   37847 main.go:144] libmachine: Waiting for DHCP lease for 5a:6b:43:02:61:96 (timeout 2m0s)
I0531 23:59:41.611182   37847 main.go:144] libmachine: Leases file created, searching for 5a:6b:43:02:61:96 in /var/db/dhcpd_leases
[snipped ~200 lease entries]
I0531 23:59:42.913415   37847 main.go:144] libmachine: Leases file changed, searching for 5a:6b:43:02:61:96 in /var/db/dhcpd_leases
I0531 23:59:42.913803   37847 main.go:144] libmachine: dhcp entry: {Name:minikube IPAddress:192.168.65.27 HWAddress:5a:6b:43:02:61:96 ID:1,5a:6b:43:2:61:96 Lease:0x6a1ca396}
I0531 23:59:42.913811   37847 main.go:144] libmachine: Found DHCP lease for 5a:6b:43:02:61:96: 192.168.65.27 in 1.302 seconds
```

## Example logs - second start (local)

Lease already in the file — found on the initial check, no watcher needed.

```
I0601 00:17:18.063291   38043 main.go:144] libmachine: Waiting for DHCP lease for 5a:6b:43:02:61:96 (timeout 2m0s)
I0601 00:17:18.063389   38043 main.go:144] libmachine: Leases file created, searching for 5a:6b:43:02:61:96 in /var/db/dhcpd_leases
I0601 00:17:18.063905   38043 main.go:144] libmachine: dhcp entry: {Name:minikube IPAddress:192.168.65.27 HWAddress:5a:6b:43:02:61:96 ID:1,5a:6b:43:2:61:96 Lease:0x6a1ca529}
I0601 00:17:18.063911   38043 main.go:144] libmachine: Found DHCP lease for 5a:6b:43:02:61:96: 192.168.65.27 in 0.001 seconds
```

---
Based on #23084 