### PR TITLE
docs: replace GitHub alerts with Docsy shortcodes

### DIFF
--- a/site/content/en/docs/contrib/building/iso.md
+++ b/site/content/en/docs/contrib/building/iso.md
@@ -68,8 +68,7 @@ sudo apt-get install \
     wget \
 ```
 
-Install Go using these instructions:
-https://go.dev/doc/install
+Install Go using the [Go installation instructions](https://go.dev/doc/install).
 
 To build without docker run:
 
@@ -77,9 +76,10 @@ To build without docker run:
 IN_DOCKER=1 make minikube-iso-<arch>
 ```
 
-> [!IMPORTANT]
-> Some external projects will try to use docker even when building
-> without docker. You must install docker on the build host.
+{{% alert title="Note" color="primary" %}}
+Some external projects will try to use docker even when building
+without docker. You must install docker on the build host.
+{{% /alert %}}
 
 ## Using a local ISO image
 
@@ -133,4 +133,3 @@ We publish CI builds of minikube, built at every Pull Request. Builds are availa
 - <https://storage.googleapis.com/minikube-builds/PR_NUMBER/minikube-darwin-amd64>
 - <https://storage.googleapis.com/minikube-builds/PR_NUMBER/minikube-linux-amd64>
 - <https://storage.googleapis.com/minikube-builds/PR_NUMBER/minikube-windows-amd64.exe>
-

--- a/site/content/en/docs/drivers/krunkit.md
+++ b/site/content/en/docs/drivers/krunkit.md
@@ -43,12 +43,12 @@ instructions below.
 The command downloads the latest release from github and installs it to
 `/opt/vmnet-helper`.
 
-> [!IMPORTANT]
-> The vmnet-helper executable and the directory where it is installed
-> must be owned by root and may not be modifiable by unprivileged users.
+{{% alert title="Note" color="primary" %}}
+The vmnet-helper executable and the directory where it is installed
+must be owned by root and may not be modifiable by unprivileged users.
+{{% /alert %}}
 
 ### Grant permission to run vmnet-helper manually (if said no to script above)
-
 
 The vment-helper process must run as root to create a vmnet interface.
 To allow users in the `staff` group to run the vmnet helper without a
@@ -62,8 +62,6 @@ sudo install -m 0640 /opt/vmnet-helper/share/doc/vmnet-helper/sudoers.d/vmnet-he
 
 You can change the sudoers configuration to allow access to specific
 users or other groups.
-
-
 
 ### Usage
 
@@ -81,9 +79,10 @@ from a local registry, RBD mirroring):
 minikube start --driver krunkit --vmnet-offloading
 ```
 
-> [!WARNING]
-> Offloading may not work for all workloads. Review the limitations below
-> and verify that this flag works for your workload before relying on it.
+{{% alert title="Warning" color="warning" %}}
+Offloading may not work for all workloads. Review the limitations below
+and verify that this flag works for your workload before relying on it.
+{{% /alert %}}
 
 #### Limitations
 

--- a/site/content/en/docs/drivers/vfkit.md
+++ b/site/content/en/docs/drivers/vfkit.md
@@ -52,11 +52,11 @@ sudo install -m 0640 /opt/vmnet-helper/share/doc/vmnet-helper/sudoers.d/vmnet-he
 You can change the sudoers configuration to allow access to specific
 users or other groups.
 
-
-**IMPORTANT**: The vmnet-helper executable and the directory where it is
-installed must be owned by root and may not be modifiable by
+{{% alert title="Note" color="primary" %}}
+The vmnet-helper executable and the directory where it is installed
+must be owned by root and may not be modifiable by
 unprivileged users.
-
+{{% /alert %}}
 
 ### Usage
 
@@ -66,6 +66,7 @@ minikube start --driver vfkit --network vmnet-shared
 
 {{% /tab %}}
 {{% tab builtin %}}
+
 ### Usage
 
 ```shell


### PR DESCRIPTION
Fixes #23070

   Summary:
   - Replace GitHub-style `IMPORTANT` and `WARNING` callouts with Docsy alert shortcodes.
   - Update:
     - `site/content/en/docs/drivers/krunkit.md`
     - `site/content/en/docs/drivers/vfkit.md`
     - `site/content/en/docs/contrib/building/iso.md`

   Validation:
   - `make mdlint`
   - Direct `markdownlint` on the touched site docs
   - `git diff --check`
   - Confirmed no remaining GitHub-style `> [!... ]` alerts under `site/`

   Note:
   - A full local Hugo site build is currently blocked by an unrelated existing repo issue in `site/content/en/docs/drivers/hyperkit.md` (`readfile` shortcode missing), not by this change.
