### PR TITLE
fix: stream daemon images to disk to avoid OOM on image load

### DIFF
--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -129,6 +129,18 @@ func saveToTarFile(iname, rawDest string, overwrite bool) error {
 		return fmt.Errorf("nil reference for %s: %w", iname, err)
 	}
 
+	// Stream directly from the local daemon to disk, avoiding loading the full image into RAM. Falls through to the normal retrieval path if the image is not present in the daemon.
+	if useDaemon {
+		if err := streamImageFromDaemon(ref, dst); err == nil {
+			return nil
+		} else {
+			klog.Infof("failed to stream image %q from daemon: %v", ref, err)
+			if !useRemote {
+				return errCacheImageDoesntExist
+			}
+		}
+	}
+
 	img, cname, err := retrieveImage(ref, iname)
 	if err != nil {
 		klog.V(2).ErrorS(err, "an error while retrieving the image")

--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -135,6 +135,9 @@ func saveToTarFile(iname, rawDest string, overwrite bool) error {
 		if streamErr == nil {
 			return nil
 		}
+		// errNotInDaemon means the image is simply not local; fall through to the remote path.
+		// Any other error means the image was confirmed present but streaming failed (e.g. a
+		// disk full or rename error), so surface it rather than silently retrying via the remote registry.
 		klog.Infof("failed to stream image %q from daemon: %v", ref, streamErr)
 		if !errors.Is(streamErr, errNotInDaemon) {
 			// Real I/O failure after the image was confirmed present — surface it rather than

--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -129,15 +129,20 @@ func saveToTarFile(iname, rawDest string, overwrite bool) error {
 		return fmt.Errorf("nil reference for %s: %w", iname, err)
 	}
 
-	// Stream directly from the local daemon to disk, avoiding loading the full image into RAM. Falls through to the normal retrieval path if the image is not present in the daemon.
+	// Stream directly from the local daemon to disk, avoiding loading the full image into RAM. Falls through to the remote path only when the image is not found in the daemon.
 	if useDaemon {
-		if err := streamImageFromDaemon(ref, dst); err == nil {
+		streamErr := streamImageFromDaemon(ref, dst)
+		if streamErr == nil {
 			return nil
-		} else {
-			klog.Infof("failed to stream image %q from daemon: %v", ref, err)
-			if !useRemote {
-				return errCacheImageDoesntExist
-			}
+		}
+		klog.Infof("failed to stream image %q from daemon: %v", ref, streamErr)
+		if !errors.Is(streamErr, errNotInDaemon) {
+			// Real I/O failure after the image was confirmed present — surface it rather than
+			// pretending the image doesn't exist.
+			return streamErr
+		}
+		if !useRemote {
+			return errCacheImageDoesntExist
 		}
 	}
 

--- a/pkg/minikube/image/daemon_memory_test.go
+++ b/pkg/minikube/image/daemon_memory_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2024 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+)
+
+// TestSaveToTarFileMemory measures peak heap usage when saving a daemon image to cache.
+// Before the fix, this allocates roughly the full image size in RAM (buffered daemon read).
+// After the fix, allocations should be near zero (streaming directly to disk).
+//
+// Requires Docker daemon with redis:7 pulled locally:
+//
+//	docker pull redis:7
+func TestSaveToTarFileMemory(t *testing.T) {
+	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
+		if _, err2 := os.Stat(os.ExpandEnv("$HOME/.docker/run/docker.sock")); err2 != nil {
+			t.Skip("Docker daemon not available")
+		}
+	}
+
+	UseDaemon(true)
+	UseRemote(false)
+	t.Cleanup(func() {
+		UseDaemon(true)
+		UseRemote(true)
+	})
+
+	tmpDir := t.TempDir()
+	dst := filepath.Join(tmpDir, "redis_7")
+
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	if err := saveToTarFile("redis:7", dst, true); err != nil {
+		t.Fatalf("saveToTarFile: %v", err)
+	}
+
+	runtime.GC()
+	runtime.ReadMemStats(&after)
+
+	fi, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("output file missing: %v", err)
+	}
+
+	heapAllocMB := float64(after.TotalAlloc-before.TotalAlloc) / 1024 / 1024
+	fileSizeMB := float64(fi.Size()) / 1024 / 1024
+
+	t.Logf("Image size on disk:  %.1f MB", fileSizeMB)
+	t.Logf("Heap allocated:      %.1f MB", heapAllocMB)
+	t.Logf("Ratio (heap/disk):   %.2fx", heapAllocMB/fileSizeMB)
+
+	// After the fix the heap allocation should be a small fraction of the image size.
+	// Before the fix it will be >= image size (the entire image is buffered in []byte).
+	if heapAllocMB >= fileSizeMB*0.5 {
+		t.Errorf("EXCESSIVE MEMORY: allocated %.1f MB for a %.1f MB image — full image is being buffered in RAM (bug #17945)", heapAllocMB, fileSizeMB)
+	}
+}
+
+// TestStreamedTarIsValidDockerFormat verifies that the output of streamImageFromDaemon
+// (raw docker save output) is a valid Docker image tar that minikube's downstream
+// consumers — tarball.LoadManifest and transferAndLoadImage — can read correctly.
+// This matters because the temp-dir path skips go-containerregistry's tarball.Write
+// and writes docker save output directly.
+//
+// Requires Docker daemon with redis:7 pulled locally.
+func TestStreamedTarIsValidDockerFormat(t *testing.T) {
+	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
+		if _, err2 := os.Stat(os.ExpandEnv("$HOME/.docker/run/docker.sock")); err2 != nil {
+			t.Skip("Docker daemon not available")
+		}
+	}
+
+	UseDaemon(true)
+	UseRemote(false)
+	t.Cleanup(func() {
+		UseDaemon(true)
+		UseRemote(true)
+	})
+
+	tmpDir := t.TempDir()
+	dst := filepath.Join(tmpDir, "redis_7")
+
+	if err := saveToTarFile("redis:7", dst, true); err != nil {
+		t.Fatalf("saveToTarFile: %v", err)
+	}
+
+	manifest, err := tarball.LoadManifest(func() (io.ReadCloser, error) {
+		return os.Open(dst)
+	})
+	if err != nil {
+		t.Fatalf("output is not a valid Docker tar: %v", err)
+	}
+	if len(manifest) == 0 {
+		t.Fatal("manifest is empty")
+	}
+	if len(manifest[0].RepoTags) == 0 {
+		t.Fatal("manifest has no repo tags")
+	}
+	t.Logf("manifest repo tags: %v", manifest[0].RepoTags)
+}
+
+func BenchmarkSaveToTarFile_Daemon(b *testing.B) {
+	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
+		if _, err2 := os.Stat(os.ExpandEnv("$HOME/.docker/run/docker.sock")); err2 != nil {
+			b.Skip("Docker daemon not available")
+		}
+	}
+
+	UseDaemon(true)
+	UseRemote(false)
+	b.Cleanup(func() {
+		UseDaemon(true)
+		UseRemote(true)
+	})
+
+	for b.Loop() {
+		dst := filepath.Join(b.TempDir(), "redis_7")
+		if err := saveToTarFile("redis:7", dst, true); err != nil {
+			b.Fatalf("saveToTarFile: %v", err)
+		}
+	}
+}

--- a/pkg/minikube/image/daemon_memory_test.go
+++ b/pkg/minikube/image/daemon_memory_test.go
@@ -83,7 +83,7 @@ func TestSaveToTarFileMemory(t *testing.T) {
 	// After the fix the heap allocation should be a small fraction of the image size.
 	// Before the fix it will be >= image size (the entire image is buffered in []byte).
 	if heapAllocMB >= fileSizeMB*0.5 {
-		t.Errorf("EXCESSIVE MEMORY: allocated %.1f MB for a %.1f MB image — full image is being buffered in RAM (issue #17785)", heapAllocMB, fileSizeMB)
+		t.Errorf("EXCESSIVE MEMORY: allocated %.1f MB for a %.1f MB image — full image is being buffered in RAM (https://github.com/kubernetes/minikube/issues/17785)", heapAllocMB, fileSizeMB)
 	}
 }
 

--- a/pkg/minikube/image/daemon_memory_test.go
+++ b/pkg/minikube/image/daemon_memory_test.go
@@ -83,7 +83,7 @@ func TestSaveToTarFileMemory(t *testing.T) {
 	// After the fix the heap allocation should be a small fraction of the image size.
 	// Before the fix it will be >= image size (the entire image is buffered in []byte).
 	if heapAllocMB >= fileSizeMB*0.5 {
-		t.Errorf("EXCESSIVE MEMORY: allocated %.1f MB for a %.1f MB image — full image is being buffered in RAM (issues #17785/#17945)", heapAllocMB, fileSizeMB)
+		t.Errorf("EXCESSIVE MEMORY: allocated %.1f MB for a %.1f MB image — full image is being buffered in RAM (issue #17785)", heapAllocMB, fileSizeMB)
 	}
 }
 

--- a/pkg/minikube/image/daemon_memory_test.go
+++ b/pkg/minikube/image/daemon_memory_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Kubernetes Authors All rights reserved.
+Copyright 2026 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,12 +19,23 @@ package image
 import (
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
+
+// requireDockerImage skips the test if the named image is not present in the local daemon.
+// This handles all Docker configurations (regular, rootless, remote via $DOCKER_HOST) because
+// it delegates to the docker CLI which reads $DOCKER_HOST and other env vars.
+func requireDockerImage(t *testing.T, img string) {
+	t.Helper()
+	if err := exec.Command("docker", "inspect", "--type=image", img).Run(); err != nil {
+		t.Skipf("image %s not in local daemon (run: docker pull %s)", img, img)
+	}
+}
 
 // TestSaveToTarFileMemory measures peak heap usage when saving a daemon image to cache.
 // Before the fix, this allocates roughly the full image size in RAM (buffered daemon read).
@@ -34,11 +45,7 @@ import (
 //
 //	docker pull redis:7
 func TestSaveToTarFileMemory(t *testing.T) {
-	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
-		if _, err2 := os.Stat(os.ExpandEnv("$HOME/.docker/run/docker.sock")); err2 != nil {
-			t.Skip("Docker daemon not available")
-		}
-	}
+	requireDockerImage(t, "redis:7")
 
 	UseDaemon(true)
 	UseRemote(false)
@@ -76,7 +83,7 @@ func TestSaveToTarFileMemory(t *testing.T) {
 	// After the fix the heap allocation should be a small fraction of the image size.
 	// Before the fix it will be >= image size (the entire image is buffered in []byte).
 	if heapAllocMB >= fileSizeMB*0.5 {
-		t.Errorf("EXCESSIVE MEMORY: allocated %.1f MB for a %.1f MB image — full image is being buffered in RAM (bug #17945)", heapAllocMB, fileSizeMB)
+		t.Errorf("EXCESSIVE MEMORY: allocated %.1f MB for a %.1f MB image — full image is being buffered in RAM (issues #17785/#17945)", heapAllocMB, fileSizeMB)
 	}
 }
 
@@ -88,11 +95,7 @@ func TestSaveToTarFileMemory(t *testing.T) {
 //
 // Requires Docker daemon with redis:7 pulled locally.
 func TestStreamedTarIsValidDockerFormat(t *testing.T) {
-	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
-		if _, err2 := os.Stat(os.ExpandEnv("$HOME/.docker/run/docker.sock")); err2 != nil {
-			t.Skip("Docker daemon not available")
-		}
-	}
+	requireDockerImage(t, "redis:7")
 
 	UseDaemon(true)
 	UseRemote(false)
@@ -124,10 +127,8 @@ func TestStreamedTarIsValidDockerFormat(t *testing.T) {
 }
 
 func BenchmarkSaveToTarFile_Daemon(b *testing.B) {
-	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
-		if _, err2 := os.Stat(os.ExpandEnv("$HOME/.docker/run/docker.sock")); err2 != nil {
-			b.Skip("Docker daemon not available")
-		}
+	if err := exec.Command("docker", "inspect", "--type=image", "redis:7").Run(); err != nil {
+		b.Skipf("image redis:7 not in local daemon (run: docker pull redis:7)")
 	}
 
 	UseDaemon(true)

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -189,6 +189,52 @@ func retrieveDaemon(ref name.Reference) (v1.Image, error) {
 	return img, err
 }
 
+// streamImageFromDaemon saves a local Docker daemon image directly to dst by piping docker save output to disk, avoiding buffering the entire image in RAM.
+// Returns an error if the daemon is unavailable or the image does not exist locally.
+func streamImageFromDaemon(ref name.Reference, dst string) error {
+	cl, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	cl.NegotiateAPIVersion(ctx)
+
+	// Confirm the image exists before creating temp files.
+	if _, _, err := cl.ImageInspectWithRaw(ctx, ref.Name()); err != nil {
+		return err
+	}
+
+	rc, err := cl.ImageSave(ctx, []string{ref.Name()})
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	tmp, err := os.CreateTemp(filepath.Dir(dst), filepath.Base(dst)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if _, statErr := os.Stat(tmpName); statErr == nil {
+			os.Remove(tmpName)
+		}
+	}()
+
+	if _, err = io.Copy(tmp, rc); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+	if err = os.Rename(tmpName, dst); err != nil {
+		return err
+	}
+	klog.Infof("streamed %s from daemon to %s", ref.Name(), dst)
+	return nil
+}
+
 func retrieveRemote(ref name.Reference, p v1.Platform) (v1.Image, error) {
 	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(p))
 	if err == nil {

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -189,22 +189,33 @@ func retrieveDaemon(ref name.Reference) (v1.Image, error) {
 	return img, err
 }
 
+// errNotInDaemon is returned by streamImageFromDaemon when the image is not present in the
+// local daemon (or the daemon is unreachable). Callers use this to distinguish a missing image
+// from a real I/O failure that occurred after the image was confirmed present.
+var errNotInDaemon = errors.New("image not found in local daemon")
+
 // streamImageFromDaemon saves a local Docker daemon image directly to dst by piping docker save output to disk, avoiding buffering the entire image in RAM.
-// Returns an error if the daemon is unavailable or the image does not exist locally.
+// Returns errNotInDaemon if the image does not exist locally or the daemon is unavailable.
 func streamImageFromDaemon(ref name.Reference, dst string) error {
 	cl, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
-		return err
+		return errNotInDaemon
 	}
-	ctx := context.Background()
-	cl.NegotiateAPIVersion(ctx)
+	defer cl.Close()
 
-	// Confirm the image exists before creating temp files.
-	if _, _, err := cl.ImageInspectWithRaw(ctx, ref.Name()); err != nil {
-		return err
+	// Short timeout just for the inspect — matches the pattern in DigestByDockerLib.
+	// ImageSave gets its own background context since large images can take minutes.
+	inspectCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cl.NegotiateAPIVersion(inspectCtx)
+
+	// Confirm the image exists before creating temp files. Any failure here (not found,
+	// daemon unreachable) is treated as errNotInDaemon so callers can fall back to remote.
+	if _, err := cl.ImageInspect(inspectCtx, ref.Name()); err != nil {
+		return errNotInDaemon
 	}
 
-	rc, err := cl.ImageSave(ctx, []string{ref.Name()})
+	rc, err := cl.ImageSave(context.Background(), []string{ref.Name()})
 	if err != nil {
 		return err
 	}
@@ -223,6 +234,8 @@ func streamImageFromDaemon(ref name.Reference, dst string) error {
 
 	if _, err = io.Copy(tmp, rc); err != nil {
 		tmp.Close()
+		// Drain the daemon-side stream so it completes cleanly rather than being cancelled mid-flight.
+		_, _ = io.Copy(io.Discard, rc)
 		return err
 	}
 	if err = tmp.Close(); err != nil {

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -191,12 +191,17 @@ func CacheAndLoadImages(images []string, profiles []*config.Profile, overwrite b
 		return nil
 	}
 
-	// This is the most important thing
-	if err := image.SaveToDir(images, detect.ImageCacheDir(), overwrite); err != nil {
+	tmpDir, err := os.MkdirTemp("", "minikube-image-*")
+	if err != nil {
+		return fmt.Errorf("creating temp dir for images: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := image.SaveToDir(images, tmpDir, true); err != nil {
 		return fmt.Errorf("save to dir: %w", err)
 	}
 
-	return DoLoadImages(images, profiles, detect.ImageCacheDir(), overwrite, options)
+	return DoLoadImages(images, profiles, tmpDir, overwrite, options)
 }
 
 // DoLoadImages loads images to all profiles

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -191,17 +191,11 @@ func CacheAndLoadImages(images []string, profiles []*config.Profile, overwrite b
 		return nil
 	}
 
-	tmpDir, err := os.MkdirTemp("", "minikube-image-*")
-	if err != nil {
-		return fmt.Errorf("creating temp dir for images: %w", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	if err := image.SaveToDir(images, tmpDir, true); err != nil {
+	if err := image.SaveToDir(images, detect.ImageCacheDir(), overwrite); err != nil {
 		return fmt.Errorf("save to dir: %w", err)
 	}
 
-	return DoLoadImages(images, profiles, tmpDir, overwrite, options)
+	return DoLoadImages(images, profiles, detect.ImageCacheDir(), overwrite, options)
 }
 
 // DoLoadImages loads images to all profiles


### PR DESCRIPTION
minikube image load <image> was buffering the entire docker save output into a []byte via go-containerregistry's buffered daemon opener (buffered: true by default), causing peak heap usage of 6x or more the image size. A 3 GB image could consume 18+ GB of RAM, triggering OOM kills.

Added streamImageFromDaemon which pipes docker save directly to a temp file on disk via io.Copy and atomically renames it into the cache. saveToTarFile now takes this path first when useDaemon=true, falling through to the existing remote retrieval path only if the image is not found locally.

Measured on redis:7 (47 MB tar):
  before: 289.8 MB heap, 23.6 s
  after:    0.2 MB heap,  9.4 s

The workaround reported in the issue (docker save | minikube image load file.tar) worked for the same reason, this fix makes that the default behavior for the daemon path.

fixes #17785

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
