### PR TITLE
docs: replace GitHub-style alerts with Docsy shortcodes

### DIFF
--- a/site/content/en/docs/contrib/building/iso.md
+++ b/site/content/en/docs/contrib/building/iso.md
@@ -77,9 +77,10 @@ To build without docker run:
 IN_DOCKER=1 make minikube-iso-<arch>
 ```
 
-> [!IMPORTANT]
-> Some external projects will try to use docker even when building
-> without docker. You must install docker on the build host.
+{{% alert title="Note" color="primary" %}}
+Some external projects will try to use docker even when building
+without docker. You must install docker on the build host.
+{{% /alert %}}
 
 ## Using a local ISO image
 

--- a/site/content/en/docs/drivers/krunkit.md
+++ b/site/content/en/docs/drivers/krunkit.md
@@ -43,9 +43,10 @@ instructions below.
 The command downloads the latest release from github and installs it to
 `/opt/vmnet-helper`.
 
-> [!IMPORTANT]
-> The vmnet-helper executable and the directory where it is installed
-> must be owned by root and may not be modifiable by unprivileged users.
+{{% alert title="Note" color="primary" %}}
+The vmnet-helper executable and the directory where it is installed
+must be owned by root and may not be modifiable by unprivileged users.
+{{% /alert %}}
 
 ### Grant permission to run vmnet-helper manually (if said no to script above)
 
@@ -81,9 +82,10 @@ from a local registry, RBD mirroring):
 minikube start --driver krunkit --vmnet-offloading
 ```
 
-> [!WARNING]
-> Offloading may not work for all workloads. Review the limitations below
-> and verify that this flag works for your workload before relying on it.
+{{% alert title="Warning" color="warning" %}}
+Offloading may not work for all workloads. Review the limitations below
+and verify that this flag works for your workload before relying on it.
+{{% /alert %}}
 
 #### Limitations
 


### PR DESCRIPTION
What this PR does:
Replaces GitHub-style alert syntax (> [!WARNING], > [!IMPORTANT]) with Docsy shortcodes that render correctly on minikube.sigs.k8s.io
Files changed:

site/content/en/docs/contrib/building/iso.md
site/content/en/docs/drivers/krunkit.md

Fixes: #23070