### PR TITLE
infra: download preloads from github as default and gcs as failover

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -213,7 +213,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(staticIP, "", "Set a static IP for the minikube cluster, the IP must be: private, IPv4, and the last octet must be between 2 and 254, for example 192.168.200.200 (Docker and Podman drivers only)")
 	startCmd.Flags().StringP(gpus, "g", "", "Allow pods to use your GPUs. Options include: [all,nvidia,amd] (Docker driver with Docker container-runtime only)")
 	startCmd.Flags().Duration(autoPauseInterval, time.Minute*1, "Duration of inactivity before the minikube VM is paused (default 1m0s)")
-	startCmd.Flags().String(preloadSrc, "auto", "Which source to download the preload from (valid options: gcs, github, auto). Defaults to auto (try both).")
+	startCmd.Flags().String(preloadSrc, "auto", "Which source to download the preload from (valid options: gcs, github, auto). Defaults to auto (try github first, then gcs as failover).")
 }
 
 // initKubernetesFlags inits the commandline flags for Kubernetes related options

--- a/pkg/minikube/download/download_test.go
+++ b/pkg/minikube/download/download_test.go
@@ -202,7 +202,8 @@ func testPreloadExistsCaching(t *testing.T) {
 	checkCache = func(_ string) (fs.FileInfo, error) {
 		return nil, errors.New("cache not found")
 	}
-	doesPreloadExist := false
+	doesPreloadExistGCS := false
+	doesPreloadExistGH := false
 	gcsCheckCalls := 0
 	ghCheckCalls := 0
 	savedGCSCheck := checkRemotePreloadExistsGCS
@@ -210,11 +211,11 @@ func testPreloadExistsCaching(t *testing.T) {
 	preloadStates = make(map[string]map[string]preloadState)
 	checkRemotePreloadExistsGCS = func(_, _ string) bool {
 		gcsCheckCalls++
-		return doesPreloadExist
+		return doesPreloadExistGCS
 	}
 	checkRemotePreloadExistsGitHub = func(_, _ string) bool {
 		ghCheckCalls++
-		return false
+		return doesPreloadExistGH
 	}
 	t.Cleanup(func() {
 		checkRemotePreloadExistsGCS = savedGCSCheck
@@ -232,17 +233,28 @@ func testPreloadExistsCaching(t *testing.T) {
 	if existence || gcsCheckCalls != 0 || ghCheckCalls != 0 {
 		t.Errorf("Expected preload not to exist and no checks to be performed. Existence: %v, GCS Calls: %d, GH Calls: %d", existence, gcsCheckCalls, ghCheckCalls)
 	}
-	doesPreloadExist = true
+	doesPreloadExistGCS = true
+	doesPreloadExistGH = false
 	gcsCheckCalls = 0
 	ghCheckCalls = 0
 	existence = PreloadExists("v2", "c1", "docker", true)
-	if !existence || gcsCheckCalls != 1 || ghCheckCalls != 0 {
-		t.Errorf("Expected preload to exist via GCS. Existence: %v, GCS Calls: %d, GH Calls: %d", existence, gcsCheckCalls, ghCheckCalls)
+	if !existence || gcsCheckCalls != 1 || ghCheckCalls != 1 {
+		t.Errorf("Expected preload to exist via GCS failover. Existence: %v, GCS Calls: %d, GH Calls: %d", existence, gcsCheckCalls, ghCheckCalls)
 	}
+	doesPreloadExistGCS = false
+	doesPreloadExistGH = true
+	gcsCheckCalls = 0
+	ghCheckCalls = 0
+	existence = PreloadExists("v3", "c1", "docker", true)
+	if !existence || gcsCheckCalls != 0 || ghCheckCalls != 1 {
+		t.Errorf("Expected preload to exist via GitHub without GCS check. Existence: %v, GCS Calls: %d, GH Calls: %d", existence, gcsCheckCalls, ghCheckCalls)
+	}
+	doesPreloadExistGCS = true
+	doesPreloadExistGH = false
 	gcsCheckCalls = 0
 	ghCheckCalls = 0
 	existence = PreloadExists("v2", "c2", "docker", true)
-	if !existence || gcsCheckCalls != 1 || ghCheckCalls != 0 {
+	if !existence || gcsCheckCalls != 1 || ghCheckCalls != 1 {
 		t.Errorf("Expected preload to exist via GCS for new runtime. Existence: %v, GCS Calls: %d, GH Calls: %d", existence, gcsCheckCalls, ghCheckCalls)
 	}
 	gcsCheckCalls = 0

--- a/pkg/minikube/download/download_test.go
+++ b/pkg/minikube/download/download_test.go
@@ -194,8 +194,8 @@ func testImageToCache(t *testing.T) {
 // the local cache is absent and remote existence checks are required.
 // In summary, this test enforces that:
 // - PreloadExists performs remote checks only on cache misses.
-// - Negative and positive results are cached per (k8sVersion, containerVersion, runtime) key.
-// - GitHub is only consulted when GCS reports the preload as not existing.
+// - Negative and positive results are cached per (k8sVersion, containerRuntime) key.
+// - GCS is only consulted when GitHub reports the preload as not existing.
 // - Global state is correctly restored after the test.
 func testPreloadExistsCaching(t *testing.T) {
 	setupTestMiniHome(t)

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -216,13 +216,13 @@ func PreloadExists(k8sVersion, containerRuntime, driverName string, forcePreload
 			return true
 		}
 	default:
-		// auto or unknown - try both
-		if PreloadExistsGCS(k8sVersion, containerRuntime) {
-			setPreloadState(k8sVersion, containerRuntime, preloadState{exists: true, source: preloadSourceGCS})
-			return true
-		}
+		// auto or unknown - try both (GitHub first, GCS as failover)
 		if PreloadExistsGH(k8sVersion, containerRuntime) {
 			setPreloadState(k8sVersion, containerRuntime, preloadState{exists: true, source: preloadSourceGitHub})
+			return true
+		}
+		if PreloadExistsGCS(k8sVersion, containerRuntime) {
+			setPreloadState(k8sVersion, containerRuntime, preloadState{exists: true, source: preloadSourceGCS})
 			return true
 		}
 	}


### PR DESCRIPTION
part of https://github.com/kubernetes/minikube/issues/20887
closes https://github.com/kubernetes/minikube/issues/23088
