### PR TITLE
docs: replace inline bold alerts with Docsy shortcodes

### DIFF
--- a/site/content/en/docs/contrib/building/iso.md
+++ b/site/content/en/docs/contrib/building/iso.md
@@ -77,9 +77,10 @@ To build without docker run:
 IN_DOCKER=1 make minikube-iso-<arch>
 ```
 
-> [!IMPORTANT]
-> Some external projects will try to use docker even when building
-> without docker. You must install docker on the build host.
+{{% alert title="Note" color="primary" %}}
+Some external projects will try to use docker even when building
+without docker. You must install docker on the build host.
+{{% /alert %}}
 
 ## Using a local ISO image
 

--- a/site/content/en/docs/drivers/krunkit.md
+++ b/site/content/en/docs/drivers/krunkit.md
@@ -43,9 +43,10 @@ instructions below.
 The command downloads the latest release from github and installs it to
 `/opt/vmnet-helper`.
 
-> [!IMPORTANT]
-> The vmnet-helper executable and the directory where it is installed
-> must be owned by root and may not be modifiable by unprivileged users.
+{{% alert title="Note" color="primary" %}}
+The vmnet-helper executable and the directory where it is installed
+must be owned by root and may not be modifiable by unprivileged users.
+{{% /alert %}}
 
 ### Grant permission to run vmnet-helper manually (if said no to script above)
 
@@ -81,9 +82,10 @@ from a local registry, RBD mirroring):
 minikube start --driver krunkit --vmnet-offloading
 ```
 
-> [!WARNING]
-> Offloading may not work for all workloads. Review the limitations below
-> and verify that this flag works for your workload before relying on it.
+{{% alert title="Warning" color="warning" %}}
+Offloading may not work for all workloads. Review the limitations below
+and verify that this flag works for your workload before relying on it.
+{{% /alert %}}
 
 #### Limitations
 

--- a/site/content/en/docs/drivers/vfkit.md
+++ b/site/content/en/docs/drivers/vfkit.md
@@ -53,9 +53,8 @@ You can change the sudoers configuration to allow access to specific
 users or other groups.
 
 
-**IMPORTANT**: The vmnet-helper executable and the directory where it is
-installed must be owned by root and may not be modifiable by
-unprivileged users.
+**IMPORTANT**: The vmnet-helper executable and the directory where it is installed must be owned by root and may not be modifiable by unprivileged users.
+
 
 
 ### Usage

--- a/site/content/en/docs/handbook/addons/registry-aliases.md
+++ b/site/content/en/docs/handbook/addons/registry-aliases.md
@@ -151,6 +151,6 @@ Once the application is running try doing `curl localhost:8080` to see the `Hell
 
 You can also update [skaffold.yaml](./skaffold.yaml) and [app.yaml](.k8s/app.yaml), to use `test.org`, `test.com` or `example.org` as container registry urls, and see all the container image names resolves to internal registry, resulting in successful build and deployment.
 
-> **NOTE**:
->
-> You can also update [skaffold.yaml](./skaffold.yaml) and [app. yaml](.k8s/app.yaml), to use `test.org`, `test.com` or > `example.org` as container registry urls, and see all the > container image names resolves to internal registry, resulting in successful build and deployment.
+{{% alert title="Note" color="primary" %}}
+You can also update [skaffold.yaml](./skaffold.yaml) and [app.yaml](.k8s/app.yaml), to use `test.org`, `test.com` or `example.org` as container registry urls, and see all the container image names resolves to internal registry, resulting in successful build and deployment.
+{{% /alert %}}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
What this PR does:
Replaces inline bold alert syntax (**IMPORTANT**, **NOTE**) with Docsy alert shortcodes for correct rendering on minikube.sigs.k8s.io
Files changed:

site/content/en/docs/drivers/vfkit.md
site/content/en/docs/handbook/addons/registry-aliases.md

Follow-up to: #23086