### PR TITLE
ci: add step-level timeouts to functional_test workflow

### DIFF
--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -49,17 +49,22 @@ jobs:
     name: ${{ matrix.name }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        timeout-minutes: 1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        timeout-minutes: 2
         with:
           go-version: ${{env.GO_VERSION}}
           cache: true      
       - name: Download Dependencies
+        timeout-minutes: 1
         run: go mod download
       - name: Build minikube and e2e test binaries
+        timeout-minutes: 7
         run: |
           make ${{ matrix.make-targets }}
           cp -r test/integration/testdata ./out
       - name: Upload Test Binaries
+        timeout-minutes: 1
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: binaries-${{ matrix.arch }}
@@ -143,16 +148,21 @@ jobs:
     steps:
       - id: info-block
         uses: medyagh/info-block@f5c042624acf8ce21bed4b0de77962e0a56ad88e # v1
+        timeout-minutes: 1
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        timeout-minutes: 1
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        timeout-minutes: 2
         with:
           go-version: ${{env.GO_VERSION}}
           cache: true      
       - name: Install gopogh
+        timeout-minutes: 1
         uses: ./.github/actions/install-gopogh
       - name: Set up cgroup v2 delegation (rootless)
         if: ${{ matrix.rootless }}
+        timeout-minutes: 1
         run: |
           sudo mkdir -p /etc/systemd/system/user@.service.d
           cat <<EOF | sudo tee /etc/systemd/system/user@.service.d/delegate.conf
@@ -162,6 +172,7 @@ jobs:
           sudo systemctl daemon-reload
       - name: Set up Rootless Docker (rootless)
         if: ${{ matrix.rootless }}
+        timeout-minutes: 3
         run: |
           sudo apt-get remove moby-engine-*
           curl https://get.docker.com | sudo sh
@@ -169,13 +180,16 @@ jobs:
           docker context use rootless
       - name: Update brew package index (macos)
         if: contains(matrix.os, 'macos')
+        timeout-minutes: 1
         run: brew update
       - name: Update apt-get package index (ubuntu)
         if: runner.os == 'Linux' && (matrix.driver == 'podman' || matrix.driver == 'none')
+        timeout-minutes: 2
         run: sudo apt-get update -qq
       - name: Install cri_dockerd (baremetal only)
         shell: bash
         if: matrix.driver == 'none' && matrix.cruntime == 'docker'
+        timeout-minutes: 1
         run: |
           CRI_DOCKERD_VERSION="v0.4.3"
           ARCH="${{ matrix.arch }}"
@@ -189,6 +203,7 @@ jobs:
       - name: Install crictl (baremetal only)
         shell: bash
         if: matrix.driver == 'none'
+        timeout-minutes: 1
         run: |
           CRICTL_VERSION="v1.35.0"
           ARCH="${{ matrix.arch }}"
@@ -199,15 +214,18 @@ jobs:
       - name: Install conntrack & socat (baremetal only)
         shell: bash
         if: matrix.driver == 'none'
+        timeout-minutes: 1
         run: sudo apt-get -qq -y install conntrack
       # socat is required for kubectl port forward which is used in some tests
       - name: Install socat (baremetal only)
         shell: bash
         if: matrix.driver == 'none'
+        timeout-minutes: 1
         run: sudo apt-get -qq -y install socat        
       - name: Install container networking plugins (baremetal only)
         shell: bash
         if: matrix.driver == 'none'
+        timeout-minutes: 1
         run: |
           CNI_PLUGIN_VERSION="v1.9.1"
           ARCH="${{ matrix.arch }}"
@@ -218,6 +236,7 @@ jobs:
           sudo tar -xf "$CNI_PLUGIN_TAR" -C "$CNI_PLUGIN_INSTALL_DIR"
           rm "$CNI_PLUGIN_TAR"
       - name: Install docker-cli
+        timeout-minutes: 1
         run: |
           set -x
           if [[ "$RUNNER_OS" == "macOS" ]]; then
@@ -244,6 +263,7 @@ jobs:
       - name: Install podman
         if: matrix.driver == 'podman'
         shell: bash
+        timeout-minutes: 1
         run: |
           sudo apt -q update
           sudo apt install -q -y podman
@@ -259,28 +279,34 @@ jobs:
           echo "=== podman ps ==="
           podman ps || true
       - name: Install kubectl
+        timeout-minutes: 1
         uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
       - name: Install qemu and socket_vmnet (macos)
         if: contains(matrix.os, 'macos') && matrix.driver == 'qemu'
+        timeout-minutes: 1
         run: |
           brew install qemu socket_vmnet
           HOMEBREW=$(which brew) && sudo ${HOMEBREW} services start socket_vmnet
       - name: Install vfkit and vmnet_helper (macos)
         if: matrix.driver == 'vfkit'
+        timeout-minutes: 1
         run: |
           brew install vfkit
           curl -fsSL https://github.com/minikube-machine/vmnet-helper/releases/latest/download/install.sh | sudo VMNET_INTERACTIVE=0 bash
       - name: Download Test Binaries
+        timeout-minutes: 1
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: binaries-${{ matrix.arch }}
       - name: Disable AppArmor for MySQL
         if: runner.os == 'Linux'
+        timeout-minutes: 1
         run: |
           sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
           sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
       - name: Install containerd (baremetal only)
         if: matrix.driver == 'none' && matrix.cruntime == 'containerd'
+        timeout-minutes: 1
         run: |
           sudo apt-get update
           sudo apt-get install -y containerd
@@ -292,6 +318,7 @@ jobs:
         id: run_test
         continue-on-error: true
         shell: bash
+        timeout-minutes: 18
         run: |
           set -x
           mkdir -p report
@@ -299,7 +326,8 @@ jobs:
           chmod a+x ./minikube-*
           ./minikube-$(go env GOOS)-$(go env GOARCH) delete --all --purge
           START_TIME=$(date -u +%s)
-          ./e2e-$(go env GOOS)-$(go env GOARCH) -minikube-start-args=" --driver=${{ matrix.driver }} ${{ matrix.extra-start-args }} -v=6 --alsologtostderr"  -test.run TestFunctional -test.timeout=${{ matrix.test-timeout }} -test.v -binary=./minikube-$(go env GOOS)-$(go env GOARCH) 2>&1 | tee ./report/testout.txt
+          # -test.timeout=0 disables the go test timeout; the step timeout-minutes above enforces the actual deadline
+          ./e2e-$(go env GOOS)-$(go env GOARCH) -minikube-start-args=" --driver=${{ matrix.driver }} ${{ matrix.extra-start-args }} -v=6 --alsologtostderr"  -test.run TestFunctional -test.timeout=0 -test.v -binary=./minikube-$(go env GOOS)-$(go env GOARCH) 2>&1 | tee ./report/testout.txt
           END_TIME=$(date -u +%s)
           TIME_ELAPSED=$(($END_TIME-$START_TIME))
           min=$((${TIME_ELAPSED}/60))
@@ -309,10 +337,12 @@ jobs:
           echo "TIME_ELAPSED=${TIME_ELAPSED}" >> $GITHUB_ENV
       - name: Convert Test Output to JSON
         if: always()
+        timeout-minutes: 1
         shell: bash
         run: go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
       - name: Generate Gopogh HTML Report
         uses: ./.github/actions/generate-report
+        timeout-minutes: 1
         if: always()
         with:
           json_report_path: './report/testout.json'


### PR DESCRIPTION
Added step-level timeouts to functional_test.yml to prevent CI runs 
from getting stuck for hours (e.g. the 6-hour apt-get hang).

Timeouts are based on stats from 241 runs (last 30 days) using the recommended timeout from workflow-stats tool (p95*3):

| Step | N | Min | Avg | P50 | P90 | P95 | Max | Timeout |
|---|--:|--:|--:|--:|--:|--:|--:|--:|
| Run Functional Test | 1387 | 2m47s | 4m13s | 4m07s | 5m23s | 5m48s | 10m43s | 18m00s |
| Build minikube and e2e test binaries | 296 | 1m07s | 1m40s | 1m38s | 2m08s | 2m11s | 2m21s | 7m00s |
| Set up Rootless Docker (rootless) | 133 | 42s | 48s | 47s | 54s | 56s | 1m26s | 3m00s |
| Run actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c | 1683 | 7s | 20s | 21s | 26s | 29s | 1m01s | 2m00s |
| Update apt-get package index (ubuntu) | 704 | 5s | 11s | 10s | 19s | 23s | 48s | 2m00s |
| Upload Test Binaries | 296 | 8s | 10s | 10s | 13s | 13s | 14s | 1m00s |
| Run actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 | 24 | 3s | 9s | 4s | 24s | 46s | 1m08s | 3m00s |
| Install podman | 139 | 5s | 8s | 8s | 11s | 12s | 23s | 1m00s |
| Install containerd (baremetal only) | 283 | 5s | 7s | 7s | 9s | 10s | 25s | 1m00s |
| Install conntrack & socat (baremetal only) | 565 | 3s | 6s | 6s | 11s | 15s | 24s | 1m00s |
| Download Test Binaries | 1387 | 2s | 4s | 4s | 8s | 9s | 40s | 1m00s |
| Run actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd | 1659 | 2s | 3s | 3s | 4s | 5s | 1m06s | 1m00s |
| Install docker-cli | 1387 | 0s | 3s | 3s | 8s | 11s | 23s | 1m00s |
| Download Dependencies | 296 | 0s | 3s | 2s | 10s | 12s | 28s | 1m00s |
| Install socat (baremetal only) | 565 | 2s | 3s | 3s | 5s | 6s | 10s | 1m00s |
| Set up job | 1683 | 0s | 2s | 2s | 3s | 4s | 9s | 1m00s |
| Run medyagh/info-block@f5c042624acf8ce21bed4b0de77962e0a56ad88e | 1387 | 1s | 1s | 2s | 2s | 3s | 7s | 1m00s |
| Generate Gopogh HTML Report | 1387 | 0s | 1s | 2s | 2s | 2s | 3s | 1m00s |
| Install container networking plugins (baremetal only) | 565 | 0s | 1s | 1s | 2s | 2s | 3s | 1m00s |
| Install cri_dockerd (baremetal only) | 282 | 0s | 0s | 1s | 1s | 2s | 2s | 1m00s |
| Install kubectl | 1387 | 0s | 0s | 1s | 1s | 1s | 2m50s | 1m00s |
| Install gopogh | 1387 | 0s | 0s | 1s | 1s | 1s | 2s | 1m00s |
| Install crictl (baremetal only) | 565 | 0s | 0s | 1s | 1s | 1s | 2s | 1m00s |
| Convert Test Output to JSON | 1387 | 0s | 0s | 0s | 1s | 1s | 5s | 1m00s |
| Post Run actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c | 1683 | 0s | 0s | 0s | 1s | 1s | 15s | 1m00s |
| Set up cgroup v2 delegation (rootless) | 133 | 0s | 0s | 0s | 1s | 1s | 1s | 1m00s |
| Post Run actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd | 1659 | 0s | 0s | 0s | 1s | 1s | 1s | 1m00s |
| Post Run actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 | 24 | 0s | 0s | 0s | 1s | 1s | 1s | 1m00s |
| Disable AppArmor for MySQL | 1387 | 0s | 0s | 0s | 0s | 1s | 1s | 1m00s |
| Complete job | 1683 | 0s | 0s | 0s | 0s | 0s | 1s | 1m00s |

Part of #23041