### PR TITLE
drivers: Start vm drivers in parallel

### DIFF
--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -129,27 +129,38 @@ func machineState(lvs libvirt.DomainState) state.State {
 }
 
 // GetIP returns an IP or hostname that this host is available at
+// Returns the stored address if available, otherwise queries libvirt.
 func (d *Driver) GetIP() (string, error) {
+	if d.IPAddress != "" {
+		return d.IPAddress, nil
+	}
+
 	s, err := d.GetState()
 	if err != nil {
 		return "", fmt.Errorf("getting domain state: %w", err)
 	}
 
 	if s != state.Running {
-		return "", errors.New("domain is not running")
+		return "", errors.New("IP address is not set and domain is not running")
 	}
 
-	conn, err := getConnection(d.ConnectionURI)
+	dom, conn, err := d.getDomain()
 	if err != nil {
-		return "", fmt.Errorf("failed opening libvirt connection: %w", err)
+		return "", fmt.Errorf("failed getting domain: %w", err)
 	}
 	defer func() {
-		if _, err := conn.Close(); err != nil {
-			log.Errorf("failed closing libvirt connection: %v", lvErr(err))
+		if err := closeDomain(dom, conn); err != nil {
+			log.Errorf("failed closing domain: %v", err)
 		}
 	}()
 
-	return ipFromXML(conn, d.MachineName, d.PrivateNetwork)
+	ip := d.lookupIP(dom)
+	if ip == "" {
+		return "", fmt.Errorf("IP address not found for domain %s", d.MachineName)
+	}
+
+	d.IPAddress = ip
+	return ip, nil
 }
 
 // GetSSHHostname returns hostname for use with ssh

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -240,8 +240,7 @@ func (d *Driver) Start() error {
 	}
 	log.Info("domain is now running")
 
-	log.Info("waiting for IP...")
-	if err := d.waitForStaticIP(conn, 90*time.Second); err != nil {
+	if err := d.waitForStaticIP(dom, conn, 90*time.Second); err != nil {
 		return fmt.Errorf("waiting for IP: %w", err)
 	}
 
@@ -275,34 +274,33 @@ func (d *Driver) waitForDomainState(targetState state.State, maxTime time.Durati
 }
 
 // waitForStaticIP waits for IP address of domain that has been created & starting and then makes that IP static.
-func (d *Driver) waitForStaticIP(conn *libvirt.Connect, maxTime time.Duration) error {
-	query := func() error {
-		sip, err := ipFromAPI(conn, d.MachineName, d.PrivateNetwork)
-		if err != nil {
-			return fmt.Errorf("getting domain IP, will retry: %w", err)
+// Polling is required since libvirt does not provide an event for DHCP lease changes.
+func (d *Driver) waitForStaticIP(dom *libvirt.Domain, conn *libvirt.Connect, maxTime time.Duration) error {
+	log.Infof("waiting for IP address for %s (timeout %v)", d.MachineName, maxTime)
+	start := time.Now()
+	deadline := start.Add(maxTime)
+	for attempt := 1; ; attempt++ {
+		log.Debugf("looking up IP address (attempt %d)", attempt)
+		ip := d.lookupIP(dom)
+		if ip != "" {
+			log.Infof("found IP address %s for %s in %.3f seconds", ip, d.MachineName, time.Since(start).Seconds())
+			d.reserveIP(conn, ip)
+			return nil
 		}
-
-		if sip == "" {
-			return errors.New("waiting for domain to come up")
+		if time.Now().After(deadline) {
+			return fmt.Errorf("domain %s didn't return IP after %v", d.MachineName, maxTime)
 		}
-
-		log.Infof("found domain IP: %s", sip)
-		d.IPAddress = sip
-
-		return nil
+		time.Sleep(2 * time.Second)
 	}
-	if err := retry.Local(query, maxTime); err != nil {
-		return fmt.Errorf("domain %s didn't return IP after %v", d.MachineName, maxTime)
-	}
+}
 
-	log.Info("reserving static IP address...")
-	if err := addStaticIP(conn, d.PrivateNetwork, d.MachineName, d.PrivateMAC, d.IPAddress); err != nil {
-		log.Warnf("failed reserving static IP address %s for domain %s, will continue anyway: %v", d.IPAddress, d.MachineName, err)
-	} else {
-		log.Infof("reserved static IP address %s for domain %s", d.IPAddress, d.MachineName)
+// reserveIP stores the IP in the driver and reserves it as a static DHCP lease.
+func (d *Driver) reserveIP(conn *libvirt.Connect, ip string) {
+	d.IPAddress = ip
+	log.Infof("found domain IP: %s", ip)
+	if err := addStaticIP(conn, d.PrivateNetwork, d.MachineName, d.PrivateMAC, ip); err != nil {
+		log.Warnf("failed reserving static IP address %s for domain %s, will continue anyway: %v", ip, d.MachineName, err)
 	}
-
-	return nil
 }
 
 // Create a host using the driver's config

--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -517,61 +517,25 @@ func dhcpLease(conn *libvirt.Connect, networkName, hostname, mac, ip string) (le
 	return nil, nil
 }
 
-// ipFromAPI returns current primary IP address of domain interface in network.
-func ipFromAPI(conn *libvirt.Connect, domain, networkName string) (string, error) {
-	mac, err := macFromXML(conn, domain, networkName)
-	if err != nil {
-		return "", fmt.Errorf("failed getting MAC address: %w", err)
-	}
-
-	ifaces, err := ifListFromAPI(conn, domain)
-	if err != nil {
-		return "", fmt.Errorf("failed getting network %s interfaces using API of domain %s: %w", networkName, domain, err)
-	}
-	for _, i := range ifaces {
-		if i.Hwaddr == mac {
-			if i.Addrs != nil {
-				log.Debugf("domain %s has current primary IP address %s and MAC address %s in network %s", domain, i.Addrs[0].Addr, mac, networkName)
-				return i.Addrs[0].Addr, nil
-			}
-			log.Debugf("domain %s with MAC address %s doesn't have current IP address in network %s: %+v", domain, mac, networkName, i)
-			return "", nil
-		}
-	}
-
-	log.Debugf("unable to find current IP address of domain %s in network %s (interfaces detected: %+v)", domain, networkName, ifaces)
-	return "", nil
-}
-
-// ifListFromAPI returns current domain interfaces.
-func ifListFromAPI(conn *libvirt.Connect, domain string) ([]libvirt.DomainInterface, error) {
-	dom, err := conn.LookupDomainByName(domain)
-	if err != nil {
-		return nil, fmt.Errorf("failed looking up domain %s: %w", domain, lvErr(err))
-	}
-	defer func() {
-		if dom == nil {
-			log.Warnf("nil domain, cannot free")
-		} else if err := dom.Free(); err != nil {
-			log.Errorf("failed freeing %s domain: %v", domain, lvErr(err))
-		}
-	}()
-
+// lookupIP returns the current IP address for the domain's private interface, or "" if not yet available.
+func (d *Driver) lookupIP(dom *libvirt.Domain) string {
 	ifs, err := dom.ListAllInterfaceAddresses(libvirt.DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE)
+	if err != nil {
+		log.Debugf("failed listing interface addresses (source=lease): %v", lvErr(err))
+	}
 	if len(ifs) == 0 {
+		ifs, err = dom.ListAllInterfaceAddresses(libvirt.DOMAIN_INTERFACE_ADDRESSES_SRC_ARP)
 		if err != nil {
-			log.Debugf("failed listing network interface addresses of domain %s (source=lease): %v", domain, lvErr(err))
-		} else {
-			log.Debugf("no network interface addresses found for domain %s (source=lease)", domain)
-		}
-		log.Debugf("trying to list again with source=arp")
-
-		if ifs, err = dom.ListAllInterfaceAddresses(libvirt.DOMAIN_INTERFACE_ADDRESSES_SRC_ARP); err != nil {
-			return nil, fmt.Errorf("failed listing network interface addresses of domain %s (source=arp): %w", domain, lvErr(err))
+			log.Debugf("failed listing interface addresses (source=arp): %v", lvErr(err))
 		}
 	}
 
-	return ifs, nil
+	for _, iface := range ifs {
+		if iface.Hwaddr == d.PrivateMAC && len(iface.Addrs) > 0 {
+			return iface.Addrs[0].Addr
+		}
+	}
+	return ""
 }
 
 // ipFromXML returns defined IP address of interface in network.

--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -538,26 +538,6 @@ func (d *Driver) lookupIP(dom *libvirt.Domain) string {
 	return ""
 }
 
-// ipFromXML returns defined IP address of interface in network.
-func ipFromXML(conn *libvirt.Connect, domain, networkName string) (string, error) {
-	mac, err := macFromXML(conn, domain, networkName)
-	if err != nil {
-		return "", fmt.Errorf("failed getting MAC address: %w", err)
-	}
-
-	lease, err := dhcpLease(conn, networkName, "", mac, "")
-	if err != nil {
-		return "", fmt.Errorf("failed looking up network %s for host DHCP lease {name: <any>, mac: %q, ip: <any>}: %w", networkName, mac, err)
-	}
-	if lease == nil {
-		log.Debugf("unable to find defined IP address of network %s interface with MAC address %s", networkName, mac)
-		return "", nil
-	}
-
-	log.Debugf("domain %s has defined IP address %s and MAC address %s in network %s", domain, lease.IPaddr, mac, networkName)
-	return lease.IPaddr, nil
-}
-
 // macFromXML returns defined MAC address of interface in network from domain XML.
 func macFromXML(conn *libvirt.Connect, domain, networkName string) (string, error) {
 	domIfs, err := ifListFromXML(conn, domain)

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -344,15 +344,17 @@ func postStartSetup(h *host.Host, mc config.ClusterConfig) error {
 // acquireMachinesLock protects against code that is not parallel-safe (libmachine, cert setup)
 func acquireMachinesLock(name string, drv string) (lock.Releaser, error) {
 	lockPath := filepath.Join(localpath.MiniPath(), "machines", drv)
-	// With KIC, it's safe to provision multiple hosts simultaneously
-	if driver.IsKIC(drv) {
+	// Drivers that support per-profile locking allow parallel creation of
+	// multiple profiles without serialization.
+	parallel := registry.Driver(drv).Parallel
+	if parallel {
 		lockPath = filepath.Join(localpath.MiniPath(), "machines", drv, name)
 	}
 	spec := lock.PathMutexSpec(lockPath)
 	// NOTE: Provisioning generally completes within 60 seconds
 	// however in parallel integration testing it might take longer
 	spec.Timeout = 13 * time.Minute
-	if driver.IsKIC(drv) {
+	if parallel {
 		spec.Timeout = 10 * time.Minute
 	}
 

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -55,6 +55,7 @@ func init() {
 		Status:   status,
 		Default:  true,
 		Priority: registry.HighlyPreferred,
+		Parallel: true,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}

--- a/pkg/minikube/registry/drvs/krunkit/krunkit.go
+++ b/pkg/minikube/registry/drvs/krunkit/krunkit.go
@@ -54,6 +54,7 @@ func init() {
 		Status:   status,
 		Default:  true,
 		Priority: registry.Experimental,
+		Parallel: true,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}

--- a/pkg/minikube/registry/drvs/kvm2/kvm2.go
+++ b/pkg/minikube/registry/drvs/kvm2/kvm2.go
@@ -61,6 +61,7 @@ func init() {
 		Status:   status,
 		Default:  true,
 		Priority: registry.Preferred,
+		Parallel: true,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -62,6 +62,7 @@ func init() {
 		Status:   status,
 		Default:  true,
 		Priority: priority,
+		Parallel: true,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}

--- a/pkg/minikube/registry/drvs/qemu2/qemu2.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2.go
@@ -57,6 +57,7 @@ func init() {
 		Status:   status,
 		Default:  true,
 		Priority: priority,
+		Parallel: true,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}

--- a/pkg/minikube/registry/drvs/vfkit/vfkit.go
+++ b/pkg/minikube/registry/drvs/vfkit/vfkit.go
@@ -57,6 +57,7 @@ func init() {
 		Status:   status,
 		Default:  true,
 		Priority: priority,
+		Parallel: true,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}

--- a/pkg/minikube/registry/registry.go
+++ b/pkg/minikube/registry/registry.go
@@ -111,6 +111,11 @@ type DriverDef struct {
 
 	// Priority returns the prioritization for selecting a driver by default.
 	Priority Priority
+
+	// Parallel is true for drivers that can start multiple profiles in
+	// parallel. When false (default) all profiles using this driver are
+	// serialized.
+	Parallel bool
 }
 
 // Empty returns true if the driver is nil


### PR DESCRIPTION
Currently acquireMachinesLock uses a single lock per driver, serializing all "minikube start" commands for profiles using the same driver. This was needed for VirtualBox (VBoxManage cannot handle concurrent calls) but is unnecessary for drivers where each profile creates an independent VM or container with no shared global state.

In drenv (RamenDR test framework) we create 3 minikube clusters in parallel using kvm2. Due to the shared lock, cluster creation is serialized for ~25 seconds per cluster:

```console
[hub] Cluster started in 41.09 seconds
[dr2] Cluster started in 64.46 seconds
[dr1] Cluster started in 89.48 seconds
```

All three clusters are requested at the same time, but the lock forces them to wait. The ~48 second spread between the first and last cluster is pure lock serialization overhead. The random lock acquisition order causes up to 50 seconds of runtime variance between runs (p95: 6m50s when both large clusters start first vs 7m40s when they start last).

Add a Parallel property to the driver registry. Drivers that set Parallel to true use a per-profile lock, allowing concurrent creation of multiple profiles. Drivers that do not set it (default false) keep the current serialized behavior.

Enable parallel start for kvm2, qemu2, vfkit, krunkit, docker, and podman. These drivers create fully independent VMs or containers and have no shared state that requires serialization. Other drivers (virtualbox, vmware, hyperv, hyperkit) are left serialized until someone tests them and confirms they are safe.

## vfkit test results

Tested with drenv, creating 6 small clusters in parallel. Testing shows that start time for 6 clusters decreased from 36.3 seconds to 22.7 seconds (1.61x faster).

| Metric | master | parallel-drivers | Change |
|--------|--------|--------|--------|
| Mean | 36.7 s | 22.7 s | 0.62x |
| Median | 36.7 s | 22.8 s | 0.62x |
| Min | 33.1 s | 20.6 s | 0.62x |
| Max | 41.6 s | 24.4 s | 0.59x |
| Std Dev | 1.7 s | 0.8 s | 0.47x |
| p95 | 39.5 s | 24.1 s | 0.61x |
| Passed | 100 | 100 | - |
| Failed | 0 | 0 | - |

### Before

```console
% grep started out/master/050.log
2026-06-07 00:25:17,973 INFO    [c1] Cluster started in 13.44 seconds
2026-06-07 00:25:22,599 INFO    [c4] Cluster started in 18.07 seconds
2026-06-07 00:25:25,972 INFO    [c6] Cluster started in 21.43 seconds
2026-06-07 00:25:33,481 INFO    [c5] Cluster started in 28.95 seconds
2026-06-07 00:25:38,059 INFO    [c3] Cluster started in 33.53 seconds
2026-06-07 00:25:42,184 INFO    [c2] Cluster started in 37.65 seconds
2026-06-07 00:25:43,665 INFO    [provider] Environment started in 39.19 seconds
```
### After

```console
% grep started out/parallel-drivers/050.log 
2026-06-06 23:29:32,178 INFO    [c5] Cluster started in 20.28 seconds
2026-06-06 23:29:32,406 INFO    [c3] Cluster started in 20.52 seconds
2026-06-06 23:29:32,640 INFO    [c2] Cluster started in 20.75 seconds
2026-06-06 23:29:32,808 INFO    [c6] Cluster started in 20.92 seconds
2026-06-06 23:29:33,146 INFO    [c1] Cluster started in 21.25 seconds
2026-06-06 23:29:33,295 INFO    [c4] Cluster started in 21.39 seconds
2026-06-06 23:29:34,711 INFO    [provider] Environment started in 22.87 seconds
```

## kvm test results

Tested with drenv, creating 6 small clusters in parallel. Testing shows that start time for 6 clusters decreased from 141.1 seconds to 63.3 seconds (2.2x faster). 

| Metric | master | parallel-drivers | Change |
|--------|--------|--------|--------|
| Mean | 141.1 s | 63.3 s | 0.45x |
| Median | 140.5 s | 62.9 s | 0.45x |
| Min | 131.6 s | 60.6 s | 0.46x |
| Max | 159.7 s | 69.7 s | 0.44x |
| Std Dev | 4.3 s | 2.2 s | 0.51x |
| p95 | 148.6 s | 68.0 s | 0.46x |
| Passed | 98 | 98 | - |
| Failed | 2 | 2 | - |

### Before

```console
$ grep started out/master/010.log 
2026-06-07 17:15:18,653 INFO    [c4] Cluster started in 36.85 seconds
2026-06-07 17:15:37,320 INFO    [c2] Cluster started in 55.51 seconds
2026-06-07 17:15:58,168 INFO    [c3] Cluster started in 76.36 seconds
2026-06-07 17:16:16,929 INFO    [c5] Cluster started in 95.12 seconds
2026-06-07 17:16:35,841 INFO    [c6] Cluster started in 114.03 seconds
2026-06-07 17:16:55,975 INFO    [c1] Cluster started in 134.16 seconds
2026-06-07 17:16:58,029 INFO    [provider] Environment started in 136.29 seconds
```

### After

```console
$ grep started out/parallel-drivers/010.log 
2026-06-07 09:00:02,909 INFO    [c3] Cluster started in 58.72 seconds
2026-06-07 09:00:02,942 INFO    [c6] Cluster started in 58.75 seconds
2026-06-07 09:00:03,005 INFO    [c4] Cluster started in 58.81 seconds
2026-06-07 09:00:03,425 INFO    [c1] Cluster started in 59.24 seconds
2026-06-07 09:00:03,492 INFO    [c5] Cluster started in 59.30 seconds
2026-06-07 09:00:04,661 INFO    [c2] Cluster started in 60.47 seconds
2026-06-07 09:00:07,576 INFO    [provider] Environment started in 63.46 seconds
```

## drenv stress test results

drenv stress test starting 3 minikube cluster using kvm driver and provisioning the cluster for DR testing. Tested with latest minikube release (1.38.1) and this PR.

The test show decreased start time from 426s to 406s (1.05x faster), and decreased variance from 16.9s to 10s (1.69x better).

| Metric | 1.38.1 | parallel-drivers | Change |
|--------|--------|--------|--------|
| Mean | 426.5 s | 406.7 s | 0.95x |
| Median | 432.0 s | 404.8 s | 0.94x |
| Min | 396.4 s | 392.5 s | 0.99x |
| Max | 463.3 s | 460.9 s | 0.99x |
| Std Dev | 16.9 s | 10.0 s | 0.59x |
| p95 | 454.1 s | 417.5 s | 0.92x |
| Passed | 99 | 97 | - |
| Failed | 1 | 3 | - |

Notes: all failures are known issues, not related to this change.

### Before - drenv addon times

With latest release cluster start order is random and it has big effect on addon deployment times.

<img width="2100" height="1680" alt="addons-trimmed" src="https://github.com/user-attachments/assets/5cff2b4c-3943-41e4-8dce-e0090a490899" />

### After - drenv addons times

With this change all clusters starts in parallel which make addons start time much more consistent and predictable.

<img width="2100" height="1680" alt="addons-trimmed" src="https://github.com/user-attachments/assets/9e0d0916-08e3-4f10-a06f-fdc5d075b362" />