### PR TITLE
iso: mask nfsrahead udev rule to fix SIGBUS crash on aarch64

### DIFF
--- a/deploy/iso/minikube-iso/board/minikube/aarch64/rootfs-overlay/etc/udev/rules.d/99-nfsrahead.rules
+++ b/deploy/iso/minikube-iso/board/minikube/aarch64/rootfs-overlay/etc/udev/rules.d/99-nfsrahead.rules
@@ -1,0 +1,1 @@
+/dev/null

--- a/deploy/iso/minikube-iso/board/minikube/x86_64/rootfs-overlay/etc/udev/rules.d/99-nfsrahead.rules
+++ b/deploy/iso/minikube-iso/board/minikube/x86_64/rootfs-overlay/etc/udev/rules.d/99-nfsrahead.rules
@@ -1,0 +1,1 @@
+/dev/null


### PR DESCRIPTION
nfsrahead crashes with SIGBUS on aarch64 on every boot. The udev rule shipped by `nfs-utils` fires for all block devices but nfsrahead does not handle non-NFS devices gracefully and crashes in `__libc_free()` due to a misaligned pointer, a hard fault on aarch64, silent on x86_64.

Mask the rule in the rootfs overlay for both aarch64 and x86_64 by symlinking `99-nfsrahead.rules` to `/dev/null`. This suppresses the helper without removing nfs-utils which may still be needed for NFS PersistentVolumes (see issue discussion).

Fixes #23067

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
