### PR TITLE
ssh: prefer AES-GCM ciphers for external SSH client

### DIFF
--- a/pkg/libmachine/ssh/client.go
+++ b/pkg/libmachine/ssh/client.go
@@ -79,6 +79,8 @@ const (
 var (
 	baseSSHArgs = []string{
 		"-F", "/dev/null",
+		// Prefer hardware-accelerated AES-GCM over ChaCha20 (https://github.com/kubernetes/minikube/issues/23121)
+		"-o", "Ciphers=^aes128-gcm@openssh.com,aes256-gcm@openssh.com",
 		"-o", "ConnectionAttempts=3", // retry 3 times if SSH connection fails
 		"-o", "ConnectTimeout=10", // timeout after 10 seconds
 		"-o", "ControlMaster=no", // disable ssh multiplexing


### PR DESCRIPTION
Prepend aes128-gcm and aes256-gcm to the cipher list for the external SSH client (--native-ssh=false). On CPUs with hardware AES acceleration (all Apple Silicon, Intel Skylake+, AMD Zen+), this more than doubles SSH throughput vs the OpenSSH default:

    % hyperfine --warmup 1 \
        "dd if=/dev/zero bs=1M count=1024 2>/dev/null | out/minikube.before ssh --native-ssh=false -- 'cat > /dev/null'" \
        "dd if=/dev/zero bs=1M count=1024 2>/dev/null | out/minikube.after ssh --native-ssh=false -- 'cat > /dev/null'"
    Benchmark 1: dd if=/dev/zero bs=1M count=1024 2>/dev/null | out/minikube.before ssh --native-ssh=false -- 'cat > /dev/null'
      Time (mean ± σ):      3.430 s ±  0.008 s    [User: 2.863 s, System: 0.664 s]
      Range (min … max):    3.418 s …  3.443 s    10 runs

    Benchmark 2: dd if=/dev/zero bs=1M count=1024 2>/dev/null | out/minikube.after ssh --native-ssh=false -- 'cat > /dev/null'
      Time (mean ± σ):      1.554 s ±  0.012 s    [User: 0.302 s, System: 0.659 s]
      Range (min … max):    1.535 s …  1.570 s    10 runs

    Summary
      dd if=/dev/zero bs=1M count=1024 2>/dev/null | out/minikube.after ssh --native-ssh=false -- 'cat > /dev/null' ran
        2.21 ± 0.02 times faster than dd if=/dev/zero bs=1M count=1024 2>/dev/null | out/minikube.before ssh --native-ssh=false -- 'cat > /dev/null'

This measures raw SSH pipe throughput. In real-world use cases like image loading, the bottleneck is unpacking images and writing to disk on the guest, so the effective speedup will be much lower.

Fixes #23121