### PR TITLE
Skip unrelated workflows for site-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
       - "Makefile"
       - "!deploy/kicbase/**"
       - "!deploy/iso/**"
+      - "!site/**"
 env:
   GOPROXY: https://proxy.golang.org
   GO_VERSION: '1.26.2'

--- a/.github/workflows/go-housekeeping.yml
+++ b/.github/workflows/go-housekeeping.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'site/**'
 env:
   GOPROXY: https://proxy.golang.org
   GO_VERSION: '1.26.2'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,12 @@ name: Lint
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - 'site/**'
   push:
     branches: [ master ]
+    paths-ignore:
+      - 'site/**'
 
 # Limit one unit test job running per PR/Branch
 concurrency:


### PR DESCRIPTION
Workflows unrelated to site content (lint, build, go-housekeeping) were running on PRs and pushes that only modify files under site/. This wastes CI resources and can block simple doc fixes with flaky test failures (see kubernetes/minikube#22655).

Add paths-ignore or path negation for site/ to these workflows. Other test workflows (unit-test, functional_test, smoke-test) already had this exclusion.
