### PR TITLE
Skip flaky integration tests to unblock CI

### DIFF
--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -43,6 +43,9 @@ import (
 
 // TestDownloadOnly makes sure the --download-only parameter in minikube start caches the appropriate images and tarballs.
 func TestDownloadOnly(t *testing.T) { // nolint:gocyclo
+	if DockerDriver() {
+		t.Skip("skipping: flaky on Docker driver: https://github.com/kubernetes/minikube/issues/23163")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(30))
 
 	// separate each k8s version testrun into individual profiles to avoid ending up with subsequently mixed up configs like:
@@ -218,6 +221,9 @@ func TestDownloadOnly(t *testing.T) { // nolint:gocyclo
 func TestDownloadOnlyKic(t *testing.T) {
 	if !KicDriver() {
 		t.Skip("skipping, only for docker or podman driver")
+	}
+	if DockerDriver() {
+		t.Skip("skipping: flaky on Docker driver: https://github.com/kubernetes/minikube/issues/23163")
 	}
 	profile := UniqueProfileName("download-docker")
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(15))

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -854,6 +854,9 @@ func validateVolcanoAddon(ctx context.Context, t *testing.T, profile string) {
 	if ContainerRuntime() == "crio" {
 		t.Skipf("skipping: crio not supported")
 	}
+	if KVMDriver() {
+		t.Skip("skipping: flaky on KVM driver: https://github.com/kubernetes/minikube/issues/23138")
+	}
 
 	volcanoNamespace := "volcano-system"
 

--- a/test/integration/error_spam_test.go
+++ b/test/integration/error_spam_test.go
@@ -56,6 +56,9 @@ var stderrAllow = []string{
 	`For more information, see`,
 	// warning about upcoming default container runtime change
 	regexp.QuoteMeta(constants.DefaultContainerRuntimeChangeWarning),
+	// registry connectivity warning from inside the container
+	`Failing to connect to https://registry.k8s.io/`,
+	`you may need to configure a proxy`,
 }
 
 // stderrAllowRe combines rootCauses into a single regex

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -757,6 +757,9 @@ func validateAuditAfterStart(_ context.Context, t *testing.T, profile string) {
 // validateSoftStart validates that after minikube already started, a `minikube start` should not change the configs.
 func validateSoftStart(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
+	if KVMDriver() {
+		t.Skip("skipping: flaky on KVM driver: https://github.com/kubernetes/minikube/issues/23153")
+	}
 
 	start := time.Now()
 	// docs: The test `validateStartWithProxy` should have start minikube, make sure the configured node port is `8441`
@@ -867,6 +870,9 @@ func validateMinikubeKubectlDirectCall(ctx context.Context, t *testing.T, profil
 // validateExtraConfig verifies minikube with --extra-config works as expected
 func validateExtraConfig(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
+	if KVMDriver() {
+		t.Skip("skipping: flaky on KVM driver: https://github.com/kubernetes/minikube/issues/23153")
+	}
 
 	start := time.Now()
 	// docs: The tests before this already created a profile

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -922,6 +922,9 @@ func imageID(image string) string {
 // NOTE: It expects all components to be Ready, so it makes sense to run it close after only those tests that include '--wait=all' start flag
 func validateComponentHealth(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
+	if KVMDriver() {
+		t.Skip("skipping: flaky on KVM driver: https://github.com/kubernetes/minikube/issues/23142")
+	}
 
 	// The ComponentStatus API is deprecated in v1.19, so do the next closest thing.
 	found := map[string]bool{

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1905,6 +1905,7 @@ func validateCpCmd(ctx context.Context, t *testing.T, profile string) {
 
 // validateMySQL validates a minimalist MySQL deployment
 func validateMySQL(ctx context.Context, t *testing.T, profile string) {
+	t.Skip("skipping: flaky, ECR rate limits cause ImagePullBackOff: https://github.com/kubernetes/minikube/issues/23264")
 	defer PostMortemLogs(t, profile)
 
 	// docs: Run `kubectl replace --force -f testdata/mysql/yaml`

--- a/test/integration/functional_test_mount_test.go
+++ b/test/integration/functional_test_mount_test.go
@@ -292,6 +292,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) { // no
 	})
 
 	t.Run("VerifyCleanup", func(t *testing.T) {
+		t.Skip("skipping: flaky mount cleanup timing: https://github.com/kubernetes/minikube/issues/23139")
 		tempDir := t.TempDir()
 
 		ctx, cancel := context.WithTimeout(ctx, Minutes(10))

--- a/test/integration/ha_test.go
+++ b/test/integration/ha_test.go
@@ -198,6 +198,9 @@ func validateHADeployApp(ctx context.Context, t *testing.T, profile string) {
 
 // validateHAPingHostFromPods uses app previously deployed by validateDeployAppToHACluster to verify its pods, located on different nodes, can resolve "host.minikube.internal".
 func validateHAPingHostFromPods(ctx context.Context, t *testing.T, profile string) {
+	if DockerDriver() {
+		t.Skip("skipping: flaky on Docker driver: https://github.com/kubernetes/minikube/issues/23144")
+	}
 	// get Pod names
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "kubectl", "--", "get", "pods", "-o", "jsonpath='{.items[*].metadata.name}'"))
 	if err != nil {

--- a/test/integration/ha_test.go
+++ b/test/integration/ha_test.go
@@ -124,6 +124,9 @@ func validateHAStartCluster(ctx context.Context, t *testing.T, profile string) {
 
 // validateHADeployApp deploys an app to ha (multi-control plane) cluster and ensures all nodes can serve traffic.
 func validateHADeployApp(ctx context.Context, t *testing.T, profile string) {
+	if DockerDriver() {
+		t.Skip("skipping: flaky on Docker driver: https://github.com/kubernetes/minikube/issues/23140")
+	}
 	// Create a deployment for app
 	_, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "kubectl", "--", "apply", "-f", "./testdata/ha/ha-pod-dns-test.yaml"))
 	if err != nil {

--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -40,6 +40,9 @@ func TestMultiNode(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("none driver does not support multinode")
 	}
+	if KVMDriver() {
+		t.Skip("skipping: flaky on KVM driver, serial subtests are tightly coupled and cannot be skipped individually: https://github.com/kubernetes/minikube/issues/23134")
+	}
 
 	if DockerDriver() {
 		rr, err := Run(t, exec.Command("docker", "version", "-f", "{{.Server.Version}}"))

--- a/test/integration/no_kubernetes_test.go
+++ b/test/integration/no_kubernetes_test.go
@@ -60,7 +60,6 @@ func TestNoKubernetes(t *testing.T) {
 			{"ProfileList", validateProfileListNoK8S},
 			{"Stop", validateStopNoK8S},
 			{"StartNoArgs", validateStartNoArgs},
-			{"VerifyK8sNotRunningSecond", validateK8SNotRunning},
 		}
 
 		for _, tc := range tests {
@@ -211,12 +210,17 @@ func validateProfileListNoK8S(ctx context.Context, t *testing.T, profile string)
 // validateStartNoArgs validates that minikube start with no args works.
 func validateStartNoArgs(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
+	if KVMDriver() {
+		t.Skip("skipping: flaky on KVM driver: https://github.com/kubernetes/minikube/issues/23154")
+	}
 
 	args := append([]string{"start", "-p", profile}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
 		t.Fatalf("failed to start minikube with args: %q : %v", rr.Command(), err)
 	}
+
+	validateK8SNotRunning(ctx, t, profile)
 }
 
 // getK8sStatus returns whether Kubernetes is running.

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -86,6 +86,9 @@ func validateFreshStart(ctx context.Context, t *testing.T, profile string) {
 // validateStartNoReconfigure validates that starting a running cluster does not invoke reconfiguration
 func validateStartNoReconfigure(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
+	if KVMDriver() {
+		t.Skip("skipping: flaky on KVM driver: https://github.com/kubernetes/minikube/issues/23141")
+	}
 
 	args := []string{"start", "-p", profile, "--alsologtostderr", "-v=1"}
 	args = append(args, StartArgs()...)

--- a/test/integration/preload_test.go
+++ b/test/integration/preload_test.go
@@ -107,6 +107,9 @@ func TestPreload(t *testing.T) {
 
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
+				if tc.name == "gcs-cached" && DockerDriver() {
+					t.Skip("skipping: flaky on Docker driver: https://github.com/kubernetes/minikube/issues/23164")
+				}
 				profile := UniqueProfileName("test-preload-dl-" + tc.name)
 				ctx, cancel := context.WithTimeout(context.Background(), Minutes(10))
 				defer CleanupWithLogs(t, profile, cancel)

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -81,6 +81,9 @@ func TestRunningBinaryUpgrade(t *testing.T) {
 	if TestingKicBaseImage() {
 		t.Skipf("Skipping, test does not make sense with --base-image")
 	}
+	if KVMDriver() {
+		t.Skip("skipping: flaky on KVM driver: https://github.com/kubernetes/minikube/issues/23150")
+	}
 
 	MaybeParallel(t)
 	profile := UniqueProfileName("running-upgrade")


### PR DESCRIPTION
Skip flaky integration tests to unblock CI

Skip flaky tests as a first aid to unblock development. The tests
need to be investigated and re-enabled. Fixing the underlying
issues is tracked in the linked issues.

## Skipped tests

- TestAddons/serial/Volcano (KVM) #23138
- TestDownloadOnly (Docker) #23163
- TestDownloadOnlyKic (Docker) #23163
- TestFunctional/parallel/MountCmd/VerifyCleanup #23139
- TestFunctional/parallel/MySQL #23264
- TestFunctional/serial/ComponentHealth (KVM) #23142
- TestFunctional/serial/ExtraConfig (KVM) #23153
- TestFunctional/serial/SoftStart (KVM) #23153
- TestMultiControlPlane/serial/DeployApp (Docker) #23140
- TestMultiControlPlane/serial/PingHostFromPods (Docker) #23144
- TestMultiNode (KVM) #23134
- TestNoKubernetes/serial/StartNoArgs (KVM) #23154
- TestPause/serial/SecondStartNoReconfiguration (KVM) #23141
- TestPreload/PreloadSrc/gcs-cached (Docker) #23164
- TestRunningBinaryUpgrade (KVM) #23150

## Removed tests

- TestNoKubernetes/serial/VerifyK8sNotRunningSecond: inlined into TestNoKubernetes/serial/StartNoArgs