### PR TITLE
ci: add step-level timeouts to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        timeout-minutes: 1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        timeout-minutes: 1
         with:
           go-version: ${{env.GO_VERSION}}
       - name: Download Dependencies
+        timeout-minutes: 1
         run: go mod download
       - name: Build Binaries
+        timeout-minutes: 32
         run: |
           make cross
           make e2e-cross
@@ -40,6 +44,7 @@ jobs:
           echo "end of debug stuff"
           echo $(which jq)
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        timeout-minutes: 3
         with:
           name: minikube_binaries
           path: out
@@ -47,16 +52,21 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        timeout-minutes: 1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        timeout-minutes: 1
         with:
           go-version: ${{env.GO_VERSION}}
       - name: Install libvirt
+        timeout-minutes: 2
         run: |
           sudo apt-get update
           sudo apt-get install -y libvirt-dev
       - name: Download Dependencies
+        timeout-minutes: 1
         run: go mod download
       - name: Lint
+        timeout-minutes: 13
         env:
           TESTSUITE: lintall
         run: make test
@@ -65,16 +75,21 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        timeout-minutes: 1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        timeout-minutes: 1
         with:
           go-version: ${{env.GO_VERSION}}
       - name: Install libvirt
+        timeout-minutes: 2
         run: |
           sudo apt-get update
           sudo apt-get install -y libvirt-dev
       - name: Download Dependencies
+        timeout-minutes: 1
         run: go mod download
       - name: Unit Test
+        timeout-minutes: 9
         env:
           TESTSUITE: unittest
         run: make test


### PR DESCRIPTION
A part of #23041 fix.

This PR adds timeout-minutes to every step in .github/workflows/build.yml.

The timeout values below are based on real run data from the last 30 days (43 runs). Collected via `nirs`'s workflow-stats tool (PR #23042).

Timeout column = `p95 × 3`, rounded up to whole minutes, floor 1 minute

### Stats used (last 30 days, 43 runs)

| Step | N | Min | Avg | P50 | P90 | P95 | Max | Timeout |
|---|--:|--:|--:|--:|--:|--:|--:|--:|
| Build Binaries | 42 | 6m11s | 9m43s | 9m59s | 10m17s | 10m22s | 10m24s | 32m00s |
| Lint | 39 | 2m37s | 3m35s | 3m44s | 3m59s | 4m07s | 4m07s | 13m00s |
| Unit Test | 42 | 1m51s | 2m42s | 2m48s | 2m54s | 2m55s | 2m57s | 9m00s |
| Upload Test Binaries (upload-artifact) | 42 | 29s | 43s | 44s | 48s | 48s | 49s | 3m00s |
| Install libvirt | 81 | 11s | 18s | 15s | 28s | 35s | 58s | 2m00s |
| Download Dependencies | 123 | 7s | 10s | 9s | 14s | 16s | 40s | 1m00s |
| setup-go | 123 | 7s | 9s | 9s | 13s | 14s | 21s | 1m00s |
| checkout | 117 | 3s | 4s | 4s | 4s | 5s | 28s | 1m00s |

### Notes
- `Build Binaries` = 32m is large but follows the tool's suggestion (p95 10m22s × 3). Would love to get some feedback on this!
- No job-level timeout, which is easier to maintain since we already have timeouts for each step.
