### PR TITLE
drivers: Use deterministic MAC addresses

### DIFF
--- a/pkg/drivers/common/mac/mac.go
+++ b/pkg/drivers/common/mac/mac.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mac generates deterministic MAC addresses from VM names.
+package mac
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// FromName returns a locally administered unicast MAC address derived from
+// the given name. The same name always produces the same MAC address.
+// https://en.wikipedia.org/wiki/MAC_address#Universal_vs._local_(U/L_bit)
+func FromName(name string) string {
+	fullName := fmt.Sprintf("minikube-mac-%s", name)
+	b := sha256.Sum256([]byte(fullName))
+	// | 2 sets the locally-administered bit.
+	// & 0xfe clears the multicast bit (unicast only).
+	b[0] = (b[0] | 2) & 0xfe
+	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", b[0], b[1], b[2], b[3], b[4], b[5])
+}

--- a/pkg/drivers/common/mac/mac_test.go
+++ b/pkg/drivers/common/mac/mac_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mac
+
+import (
+	"net"
+	"testing"
+)
+
+func TestFromName(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{"minikube"},
+		{"my-cluster"},
+		{"test-profile-123"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr := FromName(tt.name)
+
+			hw, err := net.ParseMAC(addr)
+			if err != nil {
+				t.Fatalf("invalid MAC address %q: %v", addr, err)
+			}
+
+			// Must be locally administered (bit 1 of first byte set)
+			if hw[0]&2 == 0 {
+				t.Errorf("MAC %s is not locally administered", addr)
+			}
+
+			// Must be unicast (bit 0 of first byte clear)
+			if hw[0]&1 != 0 {
+				t.Errorf("MAC %s is not unicast", addr)
+			}
+
+			// Must be deterministic
+			if addr2 := FromName(tt.name); addr != addr2 {
+				t.Errorf("not deterministic: %s != %s", addr, addr2)
+			}
+		})
+	}
+
+	// Different names must produce different MACs
+	if FromName("cluster-a") == FromName("cluster-b") {
+		t.Error("different names produced the same MAC")
+	}
+}

--- a/pkg/drivers/common/vmnet/vmnet.go
+++ b/pkg/drivers/common/vmnet/vmnet.go
@@ -60,8 +60,9 @@ type Helper struct {
 	// The pidfile and log are stored here.
 	MachineDir string
 
-	// InterfaceID is a random UUID for the vmnet interface. Using the same UUID
-	// will obtain the same MAC address from vmnet.
+	// InterfaceID is an optional UUID for the vmnet interface. When set,
+	// vmnet-helper passes --interface-id to obtain a deterministic MAC address
+	// from vmnet.
 	InterfaceID string
 
 	// Offloading is required for krunkit, does not work with vfkit.
@@ -184,7 +185,11 @@ func (h *Helper) Start(socketPath string) error {
 		executable = helper.Path
 	}
 
-	args = append(args, "--socket", socketPath, "--interface-id", h.InterfaceID)
+	args = append(args, "--socket", socketPath)
+
+	if h.InterfaceID != "" {
+		args = append(args, "--interface-id", h.InterfaceID)
+	}
 
 	if h.Offloading {
 		args = append(args, "--enable-tso", "--enable-checksum-offload")
@@ -229,8 +234,10 @@ func (h *Helper) Start(socketPath string) error {
 		return fmt.Errorf("failed to decode vmnet interface info: %w", err)
 	}
 
-	log.Infof("Got mac address %q", info.MACAddress)
 	h.macAddress = info.MACAddress
+	if h.InterfaceID != "" {
+		log.Infof("Got mac address %q", info.MACAddress)
+	}
 
 	return nil
 }

--- a/pkg/drivers/krunkit/krunkit.go
+++ b/pkg/drivers/krunkit/krunkit.go
@@ -202,8 +202,6 @@ func (d *Driver) Start() error {
 		return err
 	}
 
-	d.MACAddress = d.VmnetHelper.GetMACAddress()
-
 	if err := d.startKrunkit(socketPath); err != nil {
 		return err
 	}

--- a/pkg/drivers/kvm/domain_definition_arm64.go
+++ b/pkg/drivers/kvm/domain_definition_arm64.go
@@ -60,10 +60,16 @@ const domainTmpl = `
     </controller>
     <interface type='network'>
       <source network='{{.PrivateNetwork}}'/>
+      {{- if .PrivateMAC}}
+      <mac address='{{.PrivateMAC}}'/>
+      {{- end}}
       <model type='virtio'/>
     </interface>
     <interface type='network'>
       <source network='{{.Network}}'/>
+      {{- if .MAC}}
+      <mac address='{{.MAC}}'/>
+      {{- end}}
       <model type='virtio'/>
     </interface>
     <serial type='pty'>

--- a/pkg/drivers/kvm/domain_definition_x86.go
+++ b/pkg/drivers/kvm/domain_definition_x86.go
@@ -57,10 +57,16 @@ const domainTmpl = `
     </disk>
     <interface type='network'>
       <source network='{{.PrivateNetwork}}'/>
+      {{- if .PrivateMAC}}
+      <mac address='{{.PrivateMAC}}'/>
+      {{- end}}
       <model type='virtio'/>
     </interface>
     <interface type='network'>
       <source network='{{.Network}}'/>
+      {{- if .MAC}}
+      <mac address='{{.MAC}}'/>
+      {{- end}}
       <model type='virtio'/>
     </interface>
     <serial type='pty'>

--- a/pkg/drivers/kvm/driver.go
+++ b/pkg/drivers/kvm/driver.go
@@ -58,12 +58,12 @@ type Driver struct {
 	// The location of the iso to boot from
 	ISO string
 
-	// The randomly generated MAC Address
-	// If empty, a random MAC will be generated.
+	// MAC address for the NIC attached to the default network.
+	// If empty, libvirt generates a random address.
 	MAC string
 
-	// The randomly generated MAC Address for the NIC attached to the private network
-	// If empty, a random MAC will be generated.
+	// MAC address for the NIC attached to the private network.
+	// If empty, libvirt generates a random address.
 	PrivateMAC string
 
 	// Whether to passthrough GPU devices from the host to the VM.

--- a/pkg/drivers/vfkit/vfkit.go
+++ b/pkg/drivers/vfkit/vfkit.go
@@ -247,8 +247,6 @@ func (d *Driver) Start() error {
 		if err := d.VmnetHelper.Start(socketPath); err != nil {
 			return err
 		}
-
-		d.MACAddress = d.VmnetHelper.GetMACAddress()
 	}
 
 	if err := d.startVfkit(socketPath); err != nil {

--- a/pkg/minikube/registry/drvs/krunkit/krunkit.go
+++ b/pkg/minikube/registry/drvs/krunkit/krunkit.go
@@ -25,9 +25,10 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/google/uuid"
+	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/libmachine/drivers"
 
+	"k8s.io/minikube/pkg/drivers/common/mac"
 	"k8s.io/minikube/pkg/drivers/common/virtiofs"
 	"k8s.io/minikube/pkg/drivers/common/vmnet"
 	"k8s.io/minikube/pkg/drivers/krunkit"
@@ -61,13 +62,8 @@ func init() {
 func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
 	machineName := config.MachineName(cfg, n)
 	storePath := localpath.MiniPath()
-
-	// We generate a random UUID (or use a user provided one). vment-helper will
-	// obtain a mac address from the vmnet framework using the UUID.
-	u := cfg.UUID
-	if u == "" {
-		u = uuid.NewString()
-	}
+	macAddr := mac.FromName(machineName)
+	klog.Infof("Using mac address %s", macAddr)
 
 	mounts, err := virtiofs.ValidateMountString(cfg.MountString)
 	if err != nil {
@@ -85,11 +81,11 @@ func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
 		Memory:         cfg.Memory,
 		CPU:            cfg.CPUs,
 		ExtraDisks:     cfg.ExtraDisks,
+		MACAddress:     macAddr,
 		VirtiofsMounts: mounts,
 		VmnetHelper: vmnet.Helper{
-			MachineDir:  filepath.Join(storePath, "machines", machineName),
-			InterfaceID: u,
-			Offloading:  cfg.VmnetOffloading,
+			MachineDir: filepath.Join(storePath, "machines", machineName),
+			Offloading: cfg.VmnetOffloading,
 		},
 	}, nil
 }

--- a/pkg/minikube/registry/drvs/kvm2/kvm2.go
+++ b/pkg/minikube/registry/drvs/kvm2/kvm2.go
@@ -31,8 +31,10 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/libmachine/drivers"
 
+	"k8s.io/minikube/pkg/drivers/common/mac"
 	"k8s.io/minikube/pkg/drivers/kvm"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/download"
@@ -66,6 +68,9 @@ func init() {
 
 func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 	name := config.MachineName(cc, n)
+	macAddr := mac.FromName(name)
+	privateMACAddr := mac.FromName(name + "-private")
+	klog.Infof("Using mac address %s, private mac address %s", macAddr, privateMACAddr)
 	return kvm.Driver{
 		BaseDriver: &drivers.BaseDriver{
 			MachineName: name,
@@ -80,6 +85,8 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		DiskSize:       cc.DiskSize,
 		DiskPath:       filepath.Join(localpath.MiniPath(), "machines", name, fmt.Sprintf("%s.rawdisk", name)),
 		ISO:            filepath.Join(localpath.MiniPath(), "machines", name, "boot2docker.iso"),
+		MAC:            macAddr,
+		PrivateMAC:     privateMACAddr,
 		GPU:            cc.KVMGPU,
 		Hidden:         cc.KVMHidden,
 		ConnectionURI:  cc.KVMQemuURI,

--- a/pkg/minikube/registry/drvs/qemu2/qemu2.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2.go
@@ -17,7 +17,6 @@ limitations under the License.
 package qemu2
 
 import (
-	"crypto/rand"
 	"fmt"
 	"os"
 	"os/exec"
@@ -27,6 +26,8 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/spf13/viper"
+	"k8s.io/klog/v2"
+	"k8s.io/minikube/pkg/drivers/common/mac"
 	"k8s.io/minikube/pkg/drivers/qemu"
 	"k8s.io/minikube/pkg/libmachine/drivers"
 
@@ -161,10 +162,8 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	mac, err := generateMACAddress()
-	if err != nil {
-		return nil, fmt.Errorf("generating MAC address: %v", err)
-	}
+	macAddr := mac.FromName(name)
+	klog.Infof("Using mac address %s", macAddr)
 
 	return qemu.Driver{
 		BaseDriver: &drivers.BaseDriver{
@@ -188,7 +187,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		Network:               cc.Network,
 		CacheMode:             "default",
 		IOMode:                "threads",
-		MACAddress:            mac,
+		MACAddress:            macAddr,
 		SocketVMNetPath:       cc.SocketVMnetPath,
 		SocketVMNetClientPath: cc.SocketVMnetClientPath,
 		ExtraDisks:            cc.ExtraDisks,
@@ -215,15 +214,4 @@ func status(_ *run.CommandOptions) registry.State {
 	}
 
 	return registry.State{Installed: true, Healthy: true, Running: true}
-}
-
-func generateMACAddress() (string, error) {
-	buf := make([]byte, 6)
-	if _, err := rand.Read(buf); err != nil {
-		return "", err
-	}
-	// Set local bit, ensure unicast address, socket_vmnet doesn't support multicast
-	buf[0] = (buf[0] | 2) & 0xfe
-	mac := fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", buf[0], buf[1], buf[2], buf[3], buf[4], buf[5])
-	return mac, nil
 }

--- a/pkg/minikube/registry/drvs/vfkit/vfkit.go
+++ b/pkg/minikube/registry/drvs/vfkit/vfkit.go
@@ -19,15 +19,15 @@ limitations under the License.
 package vfkit
 
 import (
-	"crypto/rand"
 	"fmt"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 
-	"github.com/google/uuid"
+	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/libmachine/drivers"
 
+	"k8s.io/minikube/pkg/drivers/common/mac"
 	"k8s.io/minikube/pkg/drivers/common/virtiofs"
 	"k8s.io/minikube/pkg/drivers/common/vmnet"
 	"k8s.io/minikube/pkg/drivers/vfkit"
@@ -63,30 +63,18 @@ func init() {
 }
 
 func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
-	var mac string
-	var helper *vmnet.Helper
-
 	machineName := config.MachineName(cfg, n)
 	storePath := localpath.MiniPath()
+	macAddr := mac.FromName(machineName)
+	klog.Infof("Using mac address %s", macAddr)
+
+	var helper *vmnet.Helper
 
 	switch cfg.Network {
 	case "nat", "":
-		// We generate a random mac address.
-		var err error
-		mac, err = generateMACAddress()
-		if err != nil {
-			return nil, fmt.Errorf("generating MAC address: %v", err)
-		}
 	case "vmnet-shared":
-		// We generate a random UUID (or use a user provided one). vment-helper
-		// will obtain a mac address from the vmnet framework using the UUID.
-		u := cfg.UUID
-		if u == "" {
-			u = uuid.NewString()
-		}
 		helper = &vmnet.Helper{
-			MachineDir:  filepath.Join(storePath, "machines", machineName),
-			InterfaceID: u,
+			MachineDir: filepath.Join(storePath, "machines", machineName),
 		}
 	default:
 		return nil, fmt.Errorf("unsupported network: %q", cfg.Network)
@@ -110,7 +98,7 @@ func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
 		ExtraDisks:     cfg.ExtraDisks,
 		VirtiofsMounts: mounts,
 		Network:        cfg.Network,
-		MACAddress:     mac,
+		MACAddress:     macAddr,
 		VmnetHelper:    helper,
 		Rosetta:        cfg.Rosetta,
 	}, nil
@@ -122,15 +110,4 @@ func status(_ *run.CommandOptions) registry.State {
 		return registry.State{Error: err, Fix: "Run 'brew install vfkit'", Doc: docURL}
 	}
 	return registry.State{Installed: true, Healthy: true, Running: true}
-}
-
-func generateMACAddress() (string, error) {
-	buf := make([]byte, 6)
-	if _, err := rand.Read(buf); err != nil {
-		return "", err
-	}
-	// Set local bit, ensure unicast address
-	buf[0] = (buf[0] | 2) & 0xfe
-	mac := fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", buf[0], buf[1], buf[2], buf[3], buf[4], buf[5])
-	return mac, nil
 }


### PR DESCRIPTION
When a minikube cluster is deleted and recreated with the same name, the VM gets a new random MAC address, causing the DHCP server to assign a different IP. This makes it harder to use static DNS configurations like /etc/hosts for accessing services in the cluster.

Generate a deterministic MAC address from the cluster name using SHA-256, ensuring the same cluster name always gets the same locally-administered unicast MAC address. The algorithm follows vmnet-helper's approach[1].

As a side benefit, when recreating a cluster the DHCP lease from the previous run is usually still available, so minikube finds the IP instantly without polling.

Driver changes:
- vfkit: use deterministic MAC for both NAT and vmnet-shared networks, removing UUID-based MAC generation from vmnet framework
- krunkit: same as vfkit, use deterministic MAC instead of vmnet UUID
- qemu2: replace random MAC generation with deterministic MAC
- kvm2: set MAC and PrivateMAC in libvirt domain XML, which previously let libvirt generate random addresses
- vmnet-helper: make --interface-id optional, only log vmnet MAC when interface-id is set

[1] https://github.com/nirs/vmnet-helper/blob/6076be89236965b0751605585062c09c7d622d09/testing/mac.py#L7

## Example usage

Starting default cluster:

```console
% minikube start --driver vfkit
😄  minikube v1.38.1 on Darwin 26.5.1 (arm64)
✨  Using the vfkit driver based on user configuration
❗  Starting v1.39.0, minikube will default to "containerd" container runtime. See #21973 for more info.
🌐  Automatically selected the vmnet-shared network
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🔥  Creating vfkit VM (CPUs=2, Memory=6144MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.36.1 on Docker 28.5.2 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```

We got IP address:

```console
% minikube ssh -- ip addr show eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 66:ce:a3:13:ca:73 brd ff:ff:ff:ff:ff:ff
    inet 192.168.64.3/24 metric 1024 brd 192.168.64.255 scope global dynamic eth0
       valid_lft 563sec preferred_lft 563sec
```

Delete the cluster:

```console
% minikube delete
🔥  Deleting "minikube" in vfkit ...
💀  Removed all traces of the "minikube" cluster.
```

Start default cluster again - with different driver:

```console
nir@space-gray minikube (consistent-mac-address)% minikube start --driver krunkit
😄  minikube v1.38.1 on Darwin 26.5.1 (arm64)
✨  Using the krunkit (experimental) driver based on user configuration
❗  Starting v1.39.0, minikube will default to "containerd" container runtime. See #21973 for more info.
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🔥  Creating krunkit VM (CPUs=2, Memory=6144MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.36.1 on Docker 28.5.2 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```

We got the same mac address and IP:

```console
% minikube ssh -- ip addr show eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 66:ce:a3:13:ca:73 brd ff:ff:ff:ff:ff:ff
    inet 192.168.64.3/24 metric 1024 brd 192.168.64.255 scope global dynamic eth0
       valid_lft 584sec preferred_lft 584sec
```

In the dhcpd_leases we can see that one lease was created:

```console
% cat /var/db/dhcpd_leases
{
	name=podman-krunkit
	ip_address=192.168.64.2
	hw_address=1,7a:65:90:f:bb:1c
	identifier=1,7a:65:90:f:bb:1c
	lease=0x6a31fd6b
}
{
	name=minikube
	ip_address=192.168.64.3
	hw_address=1,66:ce:a3:13:ca:73
	identifier=1,66:ce:a3:13:ca:73
	lease=0x6a31fb8d
}
```

Delete the cluster:

```console
nir@space-gray minikube (consistent-mac-address)% minikube delete
🙄  "minikube" profile does not exist, trying anyways.
💀  Removed all traces of the "minikube" cluster.
```
Start cluster with profile name:

```console
% minikube start --driver vfkit --profile cluster
😄  [cluster] minikube v1.38.1 on Darwin 26.5.1 (arm64)
✨  Using the vfkit driver based on user configuration
❗  Starting v1.39.0, minikube will default to "containerd" container runtime. See #21973 for more info.
🌐  Automatically selected the vmnet-shared network
👍  Starting "cluster" primary control-plane node in "cluster" cluster
🔥  Creating vfkit VM (CPUs=2, Memory=6144MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.36.1 on Docker 28.5.2 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "cluster" cluster and "default" namespace by default
```

We got a new mac address and IP:

```console
% minikube ssh --profile cluster -- ip addr show eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether de:3a:9c:f5:74:d5 brd ff:ff:ff:ff:ff:ff
    inet 192.168.64.4/24 metric 1024 brd 192.168.64.255 scope global dynamic eth0
       valid_lft 565sec preferred_lft 565sec
```

New lease was created:

```console
% cat /var/db/dhcpd_leases
{
	name=minikube
	ip_address=192.168.64.4
	hw_address=1,de:3a:9c:f5:74:d5
	identifier=1,de:3a:9c:f5:74:d5
	lease=0x6a31ff2a
}
{
	name=minikube
	ip_address=192.168.64.3
	hw_address=1,66:ce:a3:13:ca:73
	identifier=1,66:ce:a3:13:ca:73
	lease=0x6a31fb8d
}
{
	name=podman-krunkit
	ip_address=192.168.64.2
	hw_address=1,7a:65:90:f:bb:1c
	identifier=1,7a:65:90:f:bb:1c
	lease=0x6a31fe97
}
```

Delete the cluster:

```console
% minikube delete --profile cluster
🔥  Deleting "cluster" in vfkit ...
💀  Removed all traces of the "cluster" cluster.
```

Create new cluster with same profile name:

```console
% minikube start --driver vfkit --profile cluster
😄  [cluster] minikube v1.38.1 on Darwin 26.5.1 (arm64)
✨  Using the vfkit driver based on user configuration
❗  Starting v1.39.0, minikube will default to "containerd" container runtime. See #21973 for more info.
🌐  Automatically selected the vmnet-shared network
👍  Starting "cluster" primary control-plane node in "cluster" cluster
🔥  Creating vfkit VM (CPUs=2, Memory=6144MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.36.1 on Docker 28.5.2 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "cluster" cluster and "default" namespace by default
```

We got the same mac and IP:

```console
% minikube ssh --profile cluster -- ip addr show eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether de:3a:9c:f5:74:d5 brd ff:ff:ff:ff:ff:ff
    inet 192.168.64.4/24 metric 1024 brd 192.168.64.255 scope global dynamic eth0
       valid_lft 583sec preferred_lft 583sec
```

## Faster start with cached DHCP lease

When recreating a cluster, the DHCP lease from the previous run is
usually still in `/var/db/dhcpd_leases`. Since the MAC address is the
same, minikube finds the IP on the first attempt without polling,
and starts waiting for SSH immediately:

```console
I0617 05:04:29.632813   80094 main.go:144] libmachine: Waiting for DHCP lease for 66:ce:a3:13:ca:73 (timeout 2m0s)
I0617 05:04:29.632846   80094 main.go:144] libmachine: Searching for 66:ce:a3:13:ca:73 in /var/db/dhcpd_leases (attempt 0) ...
I0617 05:04:29.632943   80094 main.go:144] libmachine: Found DHCP lease for 66:ce:a3:13:ca:73: 192.168.64.3 in 0.000 seconds
I0617 05:04:29.632949   80094 main.go:144] libmachine: Waiting until SSH server "192.168.64.3:22" is accessible
I0617 05:04:29.632951   80094 main.go:144] libmachine: Dialing to SSH server "192.168.64.3:22"
I0617 05:04:31.497851   80094 main.go:144] libmachine: Failed to dial: dial tcp 192.168.64.3:22: connect: connection refused
I0617 05:04:31.497894   80094 main.go:144] libmachine: Dialing to SSH server "192.168.64.3:22"
I0617 05:04:31.553648   80094 main.go:144] libmachine: Failed to dial: dial tcp 192.168.64.3:22: connect: connection refused
I0617 05:04:32.554866   80094 main.go:144] libmachine: Dialing to SSH server "192.168.64.3:22"
I0617 05:04:32.556347   80094 main.go:144] libmachine: Reading from SSH server "192.168.64.3:22"
I0617 05:04:32.560725   80094 main.go:144] libmachine: SSH server "192.168.64.3:22" is accessible in 2.928 seconds
```