### PR TITLE
Add Octopus AI code review workflow

### DIFF
--- a/.github/workflows/octopus.yml
+++ b/.github/workflows/octopus.yml
@@ -1,0 +1,13 @@
+name: "octopus-review"
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  review:
+    if: github.repository == 'kubernetes/minikube'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: octopusreview/action@c7156c0dc465c20e8b06da84b92b64f9ae8c7c36 # v1


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs [Octopus](https://octopus-review.ai/open-source), a free, open-source AI code review tool, on pull requests. Octopus indexes the codebase and posts context-aware inline review comments with severity levels. It is **free and unlimited for public OSI-licensed repositories, with no API key required**.

This is a follow-up to #23143 (opened by @nirs, then closed because Octopus could not post reviews — `GITHUB_TOKEN` is read-only on pull requests from forks).

## What changed since #23143

The earlier attempt used the `pull_request` event, where GitHub restricts `GITHUB_TOKEN` to read-only for fork PRs, so the action could not post comments and failed silently. This PR resolves that:

- Uses **`pull_request_target`**, which gives the token the `pull-requests: write` access needed to post reviews on fork PRs.
- This is safe here because the Octopus action **only reads the PR diff through the GitHub API — it never checks out or runs PR code**, so no untrusted fork code executes in the privileged context. (The action also now emits a clear log message instead of failing silently if it ever lacks write access.)
- The action is pinned to a full commit SHA.
- Guarded with `if: github.repository == 'kubernetes/minikube'` so it does not run on forks of this repo.

## Notes

- Only the workflow file is added; the flaky-test skips from #23143 are intentionally left out so this PR stays focused.
- Docs, including the fork-PR security rationale: https://octopus-review.ai/docs/github-action#fork-pull-requests
- Source: https://github.com/octopusreview/octopus

Happy to adjust the trigger, permissions, or scoping to match maintainer preferences.