### PR TITLE
start: simplify getMDNS() control flow

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -643,10 +643,7 @@ func getDNSServers(cmd *cobra.Command, driverName string) []netip.Addr {
 // systemd-resolved is not applicable.
 func getMDNS(cmd *cobra.Command, driverName string) bool {
 	enabled := viper.GetBool(mdns)
-	if !enabled {
-		return false
-	}
-	if !driver.IsVM(driverName) || driver.IsSSH(driverName) {
+	if enabled && (!driver.IsVM(driverName) || driver.IsSSH(driverName)) {
 		if cmd.Flags().Changed(mdns) {
 			out.WarningT("--mdns flag is only valid with VM drivers, it will be ignored")
 		}


### PR DESCRIPTION
Combine the two early returns in `getMDNS()` into a single conditional that reads: "if enabled but unsupported driver, warn and reject." This reveals the intent better than separate guard clauses.

Follow-up cleanup from #22964 per review feedback.

cc @nirs 

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->