### PR TITLE
fix: use buffered channels to prevent goroutine leak on status timeout

### DIFF
--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -386,7 +386,7 @@ func Suggest(driversState []registry.DriverState) (registry.DriverState, []regis
 // Status returns the status of a driver
 func Status(name string, options *run.CommandOptions) registry.DriverState {
 	d := registry.Driver(name)
-	stateChannel := make(chan registry.State)
+	stateChannel := make(chan registry.State, 1)
 	timeoutChannel := time.After(20 * time.Second)
 	go func() {
 		stateChannel <- registry.Status(name, options)

--- a/pkg/minikube/registry/global.go
+++ b/pkg/minikube/registry/global.go
@@ -121,7 +121,7 @@ func Available(vm bool, options *run.CommandOptions) []DriverState {
 			klog.Errorf("%q does not implement Status", d.Name)
 			continue
 		}
-		stateChannel := make(chan State)
+		stateChannel := make(chan State, 1)
 		timeoutChannel := time.After(20 * time.Second)
 		go func() {
 			stateChannel <- d.Status(options)


### PR DESCRIPTION
Fixes goroutine leak when driver status check exceeds the 20s timeout. Both `driver.Status()` and `registry.Available()` spawn a goroutine that sends on an unbuffered channel. If the timeout fires first, no receiver remains and the goroutine blocks on send forever. Changing to a buffered channel (capacity 1) lets the sender complete and exit.

Same pattern and fix as #11247

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
