### PR TITLE
iso: Fix ISO build script reliability and error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ KIC_VERSION ?= $(shell grep -E "Version =" pkg/drivers/kic/types.go | cut -d \" 
 HUGO_VERSION ?= $(shell grep -E "HUGO_VERSION = \"" netlify.toml | cut -d \" -f2)
 
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
-ISO_VERSION ?= v1.38.0-1782213340-23211
+ISO_VERSION ?= v1.38.0-1782507637-23218
 
 # Dashes are valid in semver, but not Linux packaging. Use ~ to delimit alpha/beta
 DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ KIC_VERSION ?= $(shell grep -E "Version =" pkg/drivers/kic/types.go | cut -d \" 
 HUGO_VERSION ?= $(shell grep -E "HUGO_VERSION = \"" netlify.toml | cut -d \" -f2)
 
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
-ISO_VERSION ?= "v1.38.0"-1782213340-23211
+ISO_VERSION ?= v1.38.0-1782213340-23211
 
 # Dashes are valid in semver, but not Linux packaging. Use ~ to delimit alpha/beta
 DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))

--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -70,14 +70,25 @@ if dpkg --compare-versions "$CMAKE_VERSION" lt "3.20"; then
 fi
 
 # Let's make sure we have the newest ISO reference
+
+# ISO tags are of the form VERSION-TIMESTAMP-PR, so this grep finds that TIMESTAMP in the middle.
+# If it doesn't exist, it will just return VERSION, which is covered in the if statement below.
+# Example: "v1.38.0-1782213340-23211" -> 1782213340
+# NOTE: tr -d '"' is needed because Makefile-head (from master) may still have quoted values.
+# This can be simplified once master no longer uses quotes around ISO_VERSION.
 curl -L https://github.com/kubernetes/minikube/raw/master/Makefile --output Makefile-head
-# ISO tags are of the form VERSION-TIMESTAMP-PR, so this grep finds that TIMESTAMP in the middle
-# if it doesn't exist, it will just return VERSION, which is covered in the if statement below
-HEAD_ISO_TIMESTAMP=$(grep -E "ISO_VERSION \?= " Makefile-head | cut -d \" -f 2 | cut -d "-" -f 2)
-CURRENT_ISO_TS=$(grep -E "ISO_VERSION \?= " Makefile | cut -d \" -f 2 | cut -d "-" -f 2)
-if [[ $HEAD_ISO_TIMESTAMP != v* ]]; then
-	diff=$((CURRENT_ISO_TS-HEAD_ISO_TIMESTAMP))
-	if [[ $CURRENT_ISO_TS == v* ]] || [ $diff -lt 0 ]; then
+head_iso_timestamp=$(grep -E "ISO_VERSION \?= " Makefile-head | cut -d " " -f 3 | tr -d '"' | cut -d "-" -f 2)
+
+# NOTE: The PR's Makefile may also have quoted values if the PR was created before this fix.
+# Example: ISO_VERSION ?= "v1.38.0-1782213340-23211" -> v1.38.0-1782213340-23211
+current_iso_value=$(grep -E "ISO_VERSION \?= " Makefile | cut -d " " -f 3 | tr -d '"')
+
+# Example: v1.38.0-1782213340-23211 -> 1782213340
+current_iso_timestamp=$(echo "$current_iso_value" | cut -d "-" -f 2)
+
+if [[ $head_iso_timestamp != v* ]]; then
+	diff=$((current_iso_timestamp-head_iso_timestamp))
+	if [[ $current_iso_timestamp == v* ]] || [ $diff -lt 0 ]; then
 		gh pr comment ${ghprbPullId} --body "Hi ${ghprbPullAuthorLoginMention}, your ISO info is out of date. Please rebase."
 		exit 1
 	fi
@@ -86,9 +97,10 @@ rm Makefile-head
 
 if [[ -z $ISO_VERSION ]]; then
 	release=false
-	IV=$(grep -E "ISO_VERSION \?=" Makefile | cut -d " " -f 3 | cut -d "-" -f 1)
+	# Example: v1.38.0-1782213340-23211 -> v1.38.0
+	current_iso_version=$(echo "$current_iso_value" | cut -d "-" -f 1)
 	now=$(date +%s)
-	export ISO_VERSION=$IV-$now-$ghprbPullId
+	export ISO_VERSION=$current_iso_version-$now-$ghprbPullId
 	export ISO_BUCKET=minikube-builds/iso/$ghprbPullId
 else
 	release=true

--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -21,6 +21,29 @@
 
 set -x -o pipefail
 
+# Clean build artifacts first - if available space is very low, anything else may fail.
+echo "Cleaning out directory"
+rm -rf out
+
+# Clean stale Go caches that accumulate over time and can consume tens of GB.
+# The ISO build uses buildroot and does not need the host Go cache.
+# Clean it to prevent unbounded growth - only make generate-docs uses host Go.
+echo "Cleaning Go caches"
+go clean -cache -modcache || true
+chmod -R u+w "${GOPATH}/src" || true
+rm -rf "${GOPATH}/src" || true
+
+# Clean Jenkins deferred wipeout leftovers and stale workspaces that may still occupy disk.
+# Matches both @* (Jenkins deferred wipeout) and _ws-cleanup_* (WS-CLEANUP plugin) leftovers.
+echo "Stale workspace copies:"
+find "$(dirname "${WORKSPACE}")" -maxdepth 1 -name "$(basename "${WORKSPACE}")_*" -o -name "$(basename "${WORKSPACE}")@*" | sed 's/^/  /'
+echo ""
+chmod -R u+w "${WORKSPACE}"@* "${WORKSPACE}"_* || true
+rm -rf "${WORKSPACE}"@* "${WORKSPACE}"_* || true
+
+# Trim systemd journal to 1GB - no reason to keep gigabytes of logs on a build machine.
+sudo journalctl --vacuum-size=1G || true
+
 # Make sure gh is installed and configured
 ./hack/jenkins/installers/check_install_gh.sh
 
@@ -71,6 +94,30 @@ else
 	release=true
 	export ISO_VERSION
 	export ISO_BUCKET
+fi
+
+# Check available space after all installs - fail early if insufficient
+echo "Disk space before ISO build:"
+df -h .
+
+required_gb=100
+available_gb=$(df --output=avail . | tail -1 | awk '{printf "%.0f", $1/1024/1024}')
+echo "Available disk space: ${available_gb}GB"
+if [ "$available_gb" -lt "$required_gb" ]; then
+    echo "ERROR: Not enough disk space for ISO build. Available: ${available_gb}GB, required: at least ${required_gb}GB"
+    ./hack/jenkins/investigate_disk_usage.sh || true
+    body=$(cat << EOF
+Hi ${ghprbPullAuthorLoginMention}, building a new ISO failed for Commit ${ghprbActualCommit}
+Not enough disk space on build machine (${available_gb}GB available, need ${required_gb}GB).
+
+See the logs at:
+https://storage.cloud.google.com/minikube-builds/logs/${ghprbPullId}/${ghprbActualCommit::7}/iso_build.txt
+
+Please contact the maintainers to clean up the ISO build node.
+EOF
+)
+    gh pr comment "${ghprbPullId}" --body "$body"
+    exit 1
 fi
 
 if ! make release-iso 2>&1 | tee iso-logs.txt; then

--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -153,16 +153,31 @@ if [ "$release" = false ]; then
 
 	git add Makefile pkg/minikube/download/iso.go site/content/en/docs/commands/start.md
 	git commit -m "Updating ISO to ${ISO_VERSION}"
-	git push ${ghprbPullAuthorLogin} HEAD:${ghprbSourceBranch}
+	if git push ${ghprbPullAuthorLogin} HEAD:${ghprbSourceBranch}; then
+		message=$(cat <<EOF
+Hi ${ghprbPullAuthorLoginMention}, we have updated your PR with the reference to newly built ISO.
+Pull the changes locally if you want to test with them or update your PR further.
 
-	message="Hi ${ghprbPullAuthorLoginMention}, we have updated your PR with the reference to newly built ISO. Pull the changes locally if you want to test with them or update your PR further."
-	if [ $? -gt 0 ]; then
-		message="Hi ${ghprbPullAuthorLoginMention}, we failed to push the reference to the ISO to your PR. Please run the following command and push manually.
+Build logs (for reference):
+https://storage.cloud.google.com/minikube-builds/logs/${ghprbPullId}/${ghprbActualCommit::7}/iso_build.txt
+EOF
+)
+	else
+		message=$(cat <<EOF
+Hi ${ghprbPullAuthorLoginMention}, we built a new ISO but failed to push the update to your PR.
+Please run the following commands and push manually:
 
-		sed -i 's/ISO_VERSION ?= .*/ISO_VERSION ?= ${ISO_VERSION}/' Makefile; sed -i 's|isoBucket := .*|isoBucket := "${ISO_BUCKET}"|' pkg/minikube/download/iso.go; make generate-docs;
-		"
+\`\`\`
+sed -i 's/ISO_VERSION ?= .*/ISO_VERSION ?= ${ISO_VERSION}/' Makefile
+sed -i 's|isoBucket := .*|isoBucket := "${ISO_BUCKET}"|' pkg/minikube/download/iso.go
+make generate-docs
+\`\`\`
+
+See the build logs for more details:
+https://storage.cloud.google.com/minikube-builds/logs/${ghprbPullId}/${ghprbActualCommit::7}/iso_build.txt
+EOF
+)
 	fi
-	
 	gh pr comment ${ghprbPullId} --body "${message}"
 else
 	# Release!

--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -141,11 +141,14 @@ git config user.name "minikube-bot"
 git config user.email "20374350+minikube-bot@users.noreply.github.com"
 
 if [ "$release" = false ]; then
-	# Update the user's PR with newly build ISO
+	# Update the user's PR with the newly built ISO.
+	# We use `gh pr checkout` because it sets up the fork remote over HTTPS
+	# using the gh auth token, which allows pushing to fork PRs when "Allow
+	# edits from maintainers" is enabled. SSH-based push cannot work since
+	# the bot does not have SSH access to contributors' forks.
 
-	git remote add ${ghprbPullAuthorLogin} git@github.com:${ghprbPullAuthorLogin}/minikube.git
-	git fetch ${ghprbPullAuthorLogin}
-	git checkout -b ${ghprbPullAuthorLogin}-${ghprbSourceBranch} ${ghprbPullAuthorLogin}/${ghprbSourceBranch}
+	gh auth setup-git
+	gh pr checkout ${ghprbPullId}
 
 	sed -i "s/ISO_VERSION ?= .*/ISO_VERSION ?= ${ISO_VERSION}/" Makefile
 	sed -i "s|isoBucket := .*|isoBucket := \"${ISO_BUCKET}\"|" pkg/minikube/download/iso.go
@@ -153,7 +156,7 @@ if [ "$release" = false ]; then
 
 	git add Makefile pkg/minikube/download/iso.go site/content/en/docs/commands/start.md
 	git commit -m "Updating ISO to ${ISO_VERSION}"
-	if git push ${ghprbPullAuthorLogin} HEAD:${ghprbSourceBranch}; then
+	if git push; then
 		message=$(cat <<EOF
 Hi ${ghprbPullAuthorLoginMention}, we have updated your PR with the reference to newly built ISO.
 Pull the changes locally if you want to test with them or update your PR further.

--- a/hack/jenkins/investigate_disk_usage.sh
+++ b/hack/jenkins/investigate_disk_usage.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright 2026 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Investigate disk usage on build nodes.
+# Shows top 5 entries by size, recursively drilling into directories.
+# Usage: ./hack/jenkins/investigate_disk_usage.sh [root_path] [max_depth]
+
+set -o pipefail
+shopt -s dotglob
+
+root="${1:-/}"
+max_depth="${2:-3}"
+
+investigate() {
+    local dir="${1%/}"
+    local depth="$2"
+
+    local top5
+    top5=$(sudo du -sm "${dir}"/* 2>/dev/null | sort -rn | head -5 || true)
+
+    echo "--- ${dir}/* ---"
+    echo "$top5"
+    echo ""
+
+    [ "$depth" -ge "$max_depth" ] && return
+
+    for entry in $(echo "$top5" | awk '{print $2}'); do
+        [ -d "${entry}" ] || continue
+        investigate "${entry}" $((depth + 1))
+    done
+}
+
+echo "=== Disk usage investigation: ${root} ==="
+echo ""
+df -h "${root}"
+echo ""
+
+investigate "${root}" 1
+
+echo "=== End disk usage investigation ==="

--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -41,7 +41,7 @@ const fileScheme = "file"
 // DefaultISOURLs returns a list of ISO URL's to consult by default, in priority order
 func DefaultISOURLs() []string {
 	v := version.GetISOVersion()
-	isoBucket := "minikube-builds/iso/23211"
+	isoBucket := "minikube-builds/iso/23218"
 
 	return []string{
 		fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s-%s.iso", isoBucket, v, runtime.GOARCH),


### PR DESCRIPTION
The ISO build script had multiple issues causing build failures, silent errors,
broken workflows for fork PRs, and CLA check failures. This PR addresses all
of them.

## Changes

### 1. Clean up build nodes and check disk space before ISO build

The ISO build was failing with `xorriso: FAILURE: Image size exceeds free space`
because build nodes accumulate stale data over time (Go caches, old workspaces,
journal logs). Clean them at the start and fail early with a helpful PR comment
if disk space is still insufficient.

### 2. Fix push failure detection and improve error comment

The `$?` check after `git push` was broken — the intervening variable assignment
always resets it to 0, so push failures were never detected. The job was marked
as failed with no comment posted, forcing users to construct the build log URL
manually. Use `if ! git push` and post a formatted comment with manual
instructions and a log link.

### 3. Fix adding ISO commit to contributor fork PRs

The script used SSH to push to the PR author's fork, which cannot work for
external contributors (the bot has no SSH access to their repos). Switch to
`gh pr checkout` + `gh auth setup-git` which uses HTTPS with the bot's token,
allowing push to fork branches when "Allow edits from maintainers" is enabled.

### 4. Remove spurious quotes from ISO_VERSION in Makefile

The ISO_VERSION value was wrapped in quotes (`"v1.38.0"`). In Make, quotes are
literal characters, so the value included them. This caused two bugs:

1. The constructed ISO_VERSION for PR builds had embedded quotes:
   `"v1.38.0"-timestamp-PR` instead of `v1.38.0-timestamp-PR`.

2. The staleness check that detects when a PR's ISO is older than master was
   completely broken — the timestamp was outside the quotes and never extracted.
   The "ISO info is out of date. Please rebase." message was never triggered.

Remove the quotes, simplify the parsing, and use descriptive variable names.