### PR TITLE
iso: Add build progress status

### DIFF
--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -21,6 +21,14 @@
 
 set -x -o pipefail
 
+source ./hack/jenkins/github.sh
+
+set_status() {
+  retry_github_status "${ghprbActualCommit}" "ISO PR Build Push" "pending" "${access_token}" "${BUILD_URL}" "$1"
+}
+
+set_status "Cleaning up build machine"
+
 # Clean build artifacts first - if available space is very low, anything else may fail.
 # Preserves ccache in $HOME/.buildroot-ccache.
 echo "Cleaning out directory"
@@ -31,6 +39,8 @@ echo "Stale workspace copies:"
 find "$(dirname "${WORKSPACE}")" -maxdepth 1 -name "$(basename "${WORKSPACE}")@*" | sed 's/^/  /'
 echo ""
 rm -rf "${WORKSPACE}"@* || true
+
+set_status "Preparing build machine"
 
 # Make sure gh is installed and configured
 ./hack/jenkins/installers/check_install_gh.sh
@@ -101,6 +111,8 @@ EOF
     gh pr comment "${ghprbPullId}" --body "$body"
     exit 1
 fi
+
+set_status "Building ISO"
 
 if ! make release-iso 2>&1 | tee iso-logs.txt; then
     # Exit of `make` (PIPESTATUS[0]); fallback to 1 if unavailable

--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -21,6 +21,17 @@
 
 set -x -o pipefail
 
+# Clean build artifacts first - if available space is very low, anything else may fail.
+# Preserves ccache in $HOME/.buildroot-ccache.
+echo "Cleaning out directory"
+rm -rf out
+
+# Clean Jenkins deferred wipeout leftovers and stale workspaces that may still occupy disk.
+echo "Stale workspace copies:"
+find "$(dirname "${WORKSPACE}")" -maxdepth 1 -name "$(basename "${WORKSPACE}")@*" | sed 's/^/  /'
+echo ""
+rm -rf "${WORKSPACE}"@* || true
+
 # Make sure gh is installed and configured
 ./hack/jenkins/installers/check_install_gh.sh
 
@@ -71,6 +82,24 @@ else
 	release=true
 	export ISO_VERSION
 	export ISO_BUCKET
+fi
+
+# Check available space after all installs - fail early if insufficient
+echo "Disk space before ISO build:"
+df -h .
+
+available_gb=$(df --output=avail . | tail -1 | awk '{printf "%.0f", $1/1024/1024}')
+echo "Available disk space: ${available_gb}GB"
+if [ "$available_gb" -lt 50 ]; then
+    echo "ERROR: Not enough disk space for ISO build. Available: ${available_gb}GB, required: at least 50GB"
+    body=$(cat << EOF
+Hi ${ghprbPullAuthorLoginMention}, building a new ISO failed for Commit ${ghprbActualCommit}
+Not enough disk space on build machine (${available_gb}GB available, need 50GB).
+Please contact the maintainers to clean up the ISO build node.
+EOF
+)
+    gh pr comment "${ghprbPullId}" --body "$body"
+    exit 1
 fi
 
 if ! make release-iso 2>&1 | tee iso-logs.txt; then

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -49,42 +49,7 @@ readonly TIMEOUT=${1:-120m}
 
 public_log_url="https://storage.googleapis.com/minikube-builds/logs/${MINIKUBE_LOCATION}/${ROOT_JOB_ID}/${JOB_NAME}.html"
 
-# retry_github_status provides reliable github status updates
-function retry_github_status() {
-  local commit=$1
-  local context=$2
-  local state=$3
-  local token=$4
-  local target=$5
-  local desc=$6
-
-   # Retry in case we hit our GitHub API quota or fail other ways.
-  local attempt=0
-  local timeout=2
-  local code=-1
-
-  echo "set GitHub status $context to $desc"
-
-  while [[ "${attempt}" -lt 8 ]]; do
-    local out=$(mktemp)
-    code=$(curl -o "${out}" -s --write-out "%{http_code}" -L -u minikube-bot:${token} \
-      "https://api.github.com/repos/kubernetes/minikube/statuses/${commit}" \
-      -H "Content-Type: application/json" \
-      -X POST \
-      -d "{\"state\": \"${state}\", \"description\": \"Jenkins: ${desc}\", \"target_url\": \"${target}\", \"context\": \"${context}\"}" || echo 999)
-
-    # 2xx HTTP codes
-    if [[ "${code}" =~ ^2 ]]; then
-      break
-    fi
-
-    cat "${out}" && rm -f "${out}"
-    echo "HTTP code ${code}! Retrying in ${timeout} .."
-    sleep "${timeout}"
-    attempt=$(( attempt + 1 ))
-    timeout=$(( timeout * 5 ))
-  done
-}
+source "$(dirname "${BASH_SOURCE[0]}")/github.sh"
 
 if [ "$(uname)" = "Darwin" ]; then
   if [ "$ARCH" = "arm64" ]; then

--- a/hack/jenkins/github.sh
+++ b/hack/jenkins/github.sh
@@ -1,0 +1,51 @@
+# Copyright 2026 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GitHub API helpers for Jenkins jobs.
+
+# retry_github_status provides reliable github status updates
+function retry_github_status() {
+  local commit=$1
+  local context=$2
+  local state=$3
+  local token=$4
+  local target=$5
+  local desc=$6
+
+  local attempt=0
+  local timeout=2
+  local code=-1
+
+  echo "set GitHub status $context to $desc"
+
+  while [[ "${attempt}" -lt 8 ]]; do
+    local out=$(mktemp)
+    code=$(curl -o "${out}" -s --write-out "%{http_code}" -L -u "minikube-bot:${token}" \
+      "https://api.github.com/repos/kubernetes/minikube/statuses/${commit}" \
+      -H "Content-Type: application/json" \
+      -X POST \
+      -d "{\"state\": \"${state}\", \"description\": \"Jenkins: ${desc}\", \"target_url\": \"${target}\", \"context\": \"${context}\"}" || echo 999)
+
+    if [[ "${code}" =~ ^2 ]]; then
+      rm -f "${out}"
+      break
+    fi
+
+    cat "${out}" && rm -f "${out}"
+    echo "HTTP code ${code}! Retrying in ${timeout} .."
+    sleep "${timeout}"
+    attempt=$(( attempt + 1 ))
+    timeout=$(( timeout * 5 ))
+  done
+}


### PR DESCRIPTION
Extract retry_github_status from common.sh into github.sh so it can be reused without pulling in test-job dependencies. Both common.sh and build_iso.sh source it.

Add status updates to build_iso.sh so the PR check description shows build progress:

    ISO PR Build Push — pending — "Cleaning up build machine"
    ISO PR Build Push — pending — "Preparing build machine"
    ISO PR Build Push — pending — "Building ISO"
    ISO PR Build Push — success — (set by Jenkins plugin)

Previously the status showed only "Build started for merge commit" until the job finished, with no visibility into which stage was running or where it got stuck.