### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/cmd/minikube/cmd/config/defaults_test.go
+++ b/cmd/minikube/cmd/config/defaults_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"slices"
 	"testing"
 
 	"k8s.io/minikube/pkg/minikube/out"
@@ -49,10 +50,8 @@ func TestGetDefaults(t *testing.T) {
 			if tc.shouldErr {
 				return
 			}
-			for _, d := range defaults {
-				if d == tc.expectedContents {
-					return
-				}
+			if slices.Contains(defaults, tc.expectedContents) {
+				return
 			}
 			t.Fatalf("defaults didn't contain expected default. Actual: %v\nExpected: %v\n", defaults, tc.expectedContents)
 		})

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -177,11 +178,8 @@ func kicbaseImages(ctx context.Context, ociBin string) ([]string, error) {
 
 	var result []string
 	for _, img := range allImages {
-		for _, kicImg := range kicImagesRepo {
-			if kicImg == strings.Split(img, ":")[0] {
-				result = append(result, img)
-				break
-			}
+		if slices.Contains(kicImagesRepo, strings.Split(img, ":")[0]) {
+			result = append(result, img)
 		}
 	}
 	return result, nil

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -98,14 +99,7 @@ var RootCmd = &cobra.Command{
 func Execute() {
 	// Check whether this is a windows binary (.exe) running inisde WSL.
 	if runtime.GOOS == "windows" && detect.IsMicrosoftWSL() {
-		var found = false
-		for _, a := range os.Args {
-			if a == "--force" {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(os.Args, "--force") {
 			exit.Message(reason.WrongBinaryWSL, "You are trying to run a windows .exe binary inside WSL. For better integration please use a Linux binary instead (Download at https://minikube.sigs.k8s.io/docs/start/.). Otherwise if you still want to do this, you can do it using --force")
 		}
 	}

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -1126,14 +1127,7 @@ func checkExtraDiskOptions(cmd *cobra.Command, driverName string) {
 	supportedDrivers := []string{driver.HyperKit, driver.KVM2, driver.QEMU2, driver.VFKit, driver.Krunkit}
 
 	if cmd.Flags().Changed(extraDisks) {
-		supported := false
-		for _, d := range supportedDrivers {
-			if driverName == d {
-				supported = true
-				break
-			}
-		}
-		if !supported {
+		if !slices.Contains(supportedDrivers, driverName) {
 			out.WarningT("Specifying extra disks is currently only supported for the following drivers: {{.supported_drivers}}. If you can contribute to add this feature, please create a PR.", out.V{"supported_drivers": supportedDrivers})
 		}
 	}

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -254,14 +255,7 @@ func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
 					}
 				} else {
 					// proxy must in config
-					found := false
-					for _, v := range config.DockerEnv {
-						if v == proxyEnv {
-							found = true
-							break
-						}
-					}
-					if !found {
+					if !slices.Contains(config.DockerEnv, proxyEnv) {
 						t.Fatalf("Value %s expected in dockerEnv but not occurred", test.proxy)
 					}
 				}

--- a/pkg/minikube/audit/audit.go
+++ b/pkg/minikube/audit/audit.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"slices"
 	"strings"
 	"time"
 
@@ -151,12 +152,7 @@ func shouldLog() bool {
 	// commands that should not be logged.
 	no := []string{"status", "version", "logs", "generate-docs", "profile"}
 	a := pflag.Arg(0)
-	for _, c := range no {
-		if a == c {
-			return false
-		}
-	}
-	return true
+	return !slices.Contains(no, a)
 }
 
 // isDeletePurge return true if command is delete with purge flag.

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -110,12 +110,7 @@ func DisplaySupportedDrivers() string {
 
 // Supported returns if the driver is supported on this host.
 func Supported(name string) bool {
-	for _, d := range SupportedDrivers() {
-		if name == d {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(SupportedDrivers(), name)
 }
 
 // MachineType returns appropriate machine name for the driver
@@ -410,12 +405,7 @@ func Status(name string, options *run.CommandOptions) registry.DriverState {
 // IsAlias checks if an alias belongs to provided driver by name.
 func IsAlias(name, alias string) bool {
 	d := registry.Driver(name)
-	for _, da := range d.Alias {
-		if da == alias {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(d.Alias, alias)
 }
 
 // SetLibvirtURI sets the URI to perform libvirt health checks against

--- a/pkg/minikube/logs/logs_test.go
+++ b/pkg/minikube/logs/logs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package logs
 
 import (
+	"slices"
 	"testing"
 
 	"k8s.io/minikube/pkg/minikube/config"
@@ -77,14 +78,7 @@ func TestEnabledAddonPods(t *testing.T) {
 	got := enabledAddonPods(cfg)
 	expectedPods := []string{"kubernetes-dashboard", "gcp-auth", "controller_ingress", "storage-provisioner"}
 	for _, expectedPod := range expectedPods {
-		found := false
-		for _, pod := range got {
-			if expectedPod == pod {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(got, expectedPod) {
 			t.Errorf("%q was not found; got = %s", expectedPod, got)
 		}
 	}

--- a/pkg/minikube/machine/cache_binaries.go
+++ b/pkg/minikube/machine/cache_binaries.go
@@ -19,6 +19,7 @@ package machine
 import (
 	"fmt"
 	"runtime"
+	"slices"
 
 	"golang.org/x/sync/errgroup"
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
@@ -30,12 +31,7 @@ func isExcluded(binary string, excludedBinaries []string) bool {
 	if excludedBinaries == nil {
 		return false
 	}
-	for _, excludedBinary := range excludedBinaries {
-		if binary == excludedBinary {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(excludedBinaries, binary)
 }
 
 // CacheBinariesForBootstrapper will cache binaries for a bootstrapper

--- a/pkg/minikube/machine/cluster_test.go
+++ b/pkg/minikube/machine/cluster_test.go
@@ -19,6 +19,7 @@ package machine
 import (
 	"flag"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -305,14 +306,7 @@ func TestStartHostConfig(t *testing.T) {
 	// performing a strict exact-index match because other variables (like proxy variables
 	// e.g., NO_PROXY) may be automatically injected into EngineOptions.Env by minikube.
 	for _, expected := range cfg.DockerEnv {
-		found := false
-		for _, actual := range h.HostOptions.EngineOptions.Env {
-			if actual == expected {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(h.HostOptions.EngineOptions.Env, expected) {
 			t.Fatalf("Docker env variable %q was not set! got %+v", expected, h.HostOptions.EngineOptions.Env)
 		}
 	}

--- a/pkg/minikube/proxy/proxy.go
+++ b/pkg/minikube/proxy/proxy.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 
 	"errors"
@@ -131,12 +132,7 @@ func checkEnv(ip string, env string) bool {
 
 // isValidEnv checks if the env for proxy settings
 func isValidEnv(env string) bool {
-	for _, e := range EnvVars {
-		if e == env {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(EnvVars, env)
 }
 
 // UpdateTransport takes a k8s client *rest.config and returns a config without a proxy.

--- a/pkg/minikube/reason/k8s.go
+++ b/pkg/minikube/reason/k8s.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package reason
 
-import "github.com/blang/semver/v4"
+import (
+	"slices"
+
+	"github.com/blang/semver/v4"
+)
 
 // K8sIssue represents a known issue with a particular version of Kubernetes
 type K8sIssue struct {
@@ -58,10 +62,8 @@ var k8sIssues = []K8sIssue{
 // ProblematicK8sVersion checks for the supplied Kubernetes version and checks if there's a known issue with it.
 func ProblematicK8sVersion(v semver.Version) *K8sIssue {
 	for _, issue := range k8sIssues {
-		for _, va := range issue.VersionsAffected {
-			if va == v.String() {
-				return &issue
-			}
+		if slices.Contains(issue.VersionsAffected, v.String()) {
+			return &issue
 		}
 	}
 	return nil

--- a/pkg/minikube/reason/match.go
+++ b/pkg/minikube/reason/match.go
@@ -18,6 +18,7 @@ package reason
 
 import (
 	"regexp"
+	"slices"
 
 	"k8s.io/klog/v2"
 )
@@ -71,10 +72,8 @@ func MatchKnownIssue(r Kind, err error, goos string) *Kind {
 
 		// Does this match require an OS matchup?
 		if len(ki.GOOS) > 0 {
-			for _, o := range ki.GOOS {
-				if o == goos {
-					return &ki.Kind
-				}
+			if slices.Contains(ki.GOOS, goos) {
+				return &ki.Kind
 			}
 		}
 		if genericMatch == nil {


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->


There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.