### PR TITLE
ci: Use GitHub noreply email for minikube-bot commits

### DIFF
--- a/.github/workflows/dependabot-gomodtidy.yml
+++ b/.github/workflows/dependabot-gomodtidy.yml
@@ -34,7 +34,7 @@ jobs:
           make gomodtidy
           if [[ -n $(git status --porcelain) ]]; then
             git config --global user.name "minikube-bot"
-            git config --global user.email "minikube-bot@google.com"
+            git config --global user.email "20374350+minikube-bot@users.noreply.github.com"
             git add .
             git commit -m "update go.mod and go.sum"
             git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: Update auto-generated docs and translations
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: gendocs
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/go-housekeeping.yml
+++ b/.github/workflows/go-housekeeping.yml
@@ -59,8 +59,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: Update auto-generated docs and translations
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: gomodtidy
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Add leaderboard for ${{ github.ref_name }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: leaderboard
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/time-to-k8s.yml
+++ b/.github/workflows/time-to-k8s.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: add time-to-k8s benchmark for ${{ steps.timeToK8sBenchmark.outputs.version }}
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: addTimeToK8s${{ steps.timeToK8sBenchmark.outputs.version }}
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/.github/workflows/update-all.yml
+++ b/.github/workflows/update-all.yml
@@ -33,8 +33,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Kicbase/ISO: Update dependency versions'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: bump_iso_image_versions
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/.github/workflows/update-amd-gpu-device-plugin-version.yml
+++ b/.github/workflows/update-amd-gpu-device-plugin-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon amd-gpu-device-plugin: Update amd/k8s-device-plugin image from ${{ steps.bumpAmdDevicePlugin.outputs.OLD_VERSION }} to ${{ steps.bumpAmdDevicePlugin.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_amd_device_plugin_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-buildkit-version.yml
+++ b/.github/workflows/update-buildkit-version.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Kicbase/ISO: Update buildkit from ${{ steps.bumpBuildkit.outputs.OLD_VERSION }} to ${{ steps.bumpBuildkit.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_buildkit_version
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/.github/workflows/update-calico-version.yml
+++ b/.github/workflows/update-calico-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'CNI: Update calico from ${{ steps.bumpCalico.outputs.OLD_VERSION }} to ${{ steps.bumpCalico.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_calico_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-cilium-version.yml
+++ b/.github/workflows/update-cilium-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'CNI: Update cilium from ${{ steps.bumpCilium.outputs.OLD_VERSION }} to ${{ steps.bumpCilium.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_cilium_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-cloud-spanner-emulator-version.yml
+++ b/.github/workflows/update-cloud-spanner-emulator-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon cloud-spanner: Update cloud-spanner-emulator/emulator image from ${{ steps.bumpCloudSpannerEmulator.outputs.OLD_VERSION }} to ${{ steps.bumpCloudSpannerEmulator.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_cloud_spanner_emulator_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-cni-plugins-version.yml
+++ b/.github/workflows/update-cni-plugins-version.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Kicbase/ISO: Update cni-plugins from ${{ steps.bumpCNIPlugins.outputs.OLD_VERSION }} to ${{ steps.bumpCNIPlugins.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_cni_plugins_version
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/.github/workflows/update-containerd-version.yml
+++ b/.github/workflows/update-containerd-version.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Kicbase/ISO: Update containerd from ${{ steps.bumpContainerd.outputs.OLD_VERSION }} to ${{ steps.bumpContainerd.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_containerd_version
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/.github/workflows/update-cri-dockerd-version.yml
+++ b/.github/workflows/update-cri-dockerd-version.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Kicbase/ISO: Update cri-dockerd from ${{ steps.bumpCriDockerd.outputs.OLD_VERSION }} to ${{ steps.bumpCriDockerd.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_cri_dockerd_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-cri-o-version.yml
+++ b/.github/workflows/update-cri-o-version.yml
@@ -40,8 +40,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Kicbase/ISO: Update cri-o from ${{ steps.bumpCrio.outputs.OLD_VERSION }} to ${{ steps.bumpCrio.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_cri-o_version
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/.github/workflows/update-crictl-version.yml
+++ b/.github/workflows/update-crictl-version.yml
@@ -40,8 +40,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Kicbase/ISO: Update crictl from ${{ steps.bumpCrictl.outputs.OLD_VERSION }} to ${{ steps.bumpCrictl.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_crictl_version
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/.github/workflows/update-crun-version.yml
+++ b/.github/workflows/update-crun-version.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Kicbase/ISO: Update crun from ${{ steps.bumpCrun.outputs.OLD_VERSION }} to ${{ steps.bumpCrun.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_crun_version
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/.github/workflows/update-debian-version.yml
+++ b/.github/workflows/update-debian-version.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Kicbase: Bump debian:bookworm from ${{ steps.bumpBaseOsImage.outputs.OLD_VERSION }} to ${{ steps.bumpBaseOsImage.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_debian_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-docker-buildx-version.yml
+++ b/.github/workflows/update-docker-buildx-version.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'ISO: Update docker-buildx from ${{ steps.bumpDockerBuildx.outputs.OLD_VERSION }} to ${{ steps.bumpDockerBuildx.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_docker_buildx_version
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/.github/workflows/update-docker-version.yml
+++ b/.github/workflows/update-docker-version.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Kicbase/ISO: Update docker from ${{ steps.bumpDocker.outputs.OLD_VERSION }} to ${{ steps.bumpDocker.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_docker_version
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/.github/workflows/update-docsy-version.yml
+++ b/.github/workflows/update-docsy-version.yml
@@ -36,8 +36,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'site: Update docsy version to ${{ steps.bumpDocsy.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_docsy_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-flannel-version.yml
+++ b/.github/workflows/update-flannel-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'CNI: Update flannel from ${{ steps.bumpFlannel.outputs.OLD_VERSION }} to ${{ steps.bumpFlannel.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_flannel_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-gcp-auth-version.yml
+++ b/.github/workflows/update-gcp-auth-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon gcp-auth: Update k8s-minikube/gcp-auth-webhook image from ${{ steps.bumpGCPAuth.outputs.OLD_VERSION }} to ${{ steps.bumpGCPAuth.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_gcp_auth_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-gh-version.yml
+++ b/.github/workflows/update-gh-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'CI: Update gh from ${{ steps.bumpGh.outputs.OLD_VERSION }} to ${{ steps.bumpGh.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_gh_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-go-github-version.yml
+++ b/.github/workflows/update-go-github-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Update go-github from ${{ steps.bumpGoGithub.outputs.OLD_VERSION }} to ${{ steps.bumpGoGithub.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_go_github_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-golang-version.yml
+++ b/.github/workflows/update-golang-version.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Update go from ${{ steps.bumpGolang.outputs.OLD_VERSION }} to ${{ steps.bumpGolang.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_golang_version
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/.github/workflows/update-golint-version.yml
+++ b/.github/workflows/update-golint-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'CI: Update golint from ${{ steps.bumpGolint.outputs.OLD_VERSION }} to ${{ steps.bumpGolint.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_golint_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-gopogh-version.yml
+++ b/.github/workflows/update-gopogh-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'CI: Update gopogh from ${{ steps.bumpGopogh.outputs.OLD_VERSION }} to ${{ steps.bumpGopogh.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_gopogh_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-gotestsum-version.yml
+++ b/.github/workflows/update-gotestsum-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'CI: Update gotestsum from ${{ steps.bumpGotestsum.outputs.OLD_VERSION }} to ${{ steps.bumpGotestsum.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_gotestsum_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-headlamp-version.yml
+++ b/.github/workflows/update-headlamp-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon Headlamp: Update Headlamp image from ${{ steps.bumpHeadlamp.outputs.OLD_VERSION }} to ${{ steps.bumpHeadlamp.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_headlamp_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-hugo-version.yml
+++ b/.github/workflows/update-hugo-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Site: Update hugo from ${{ steps.bumpHugo.outputs.OLD_VERSION }} to ${{ steps.bumpHugo.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_hugo_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-ingress-version.yml
+++ b/.github/workflows/update-ingress-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon ingress: Update ingress-nginx/controller image from ${{ steps.bumpIngress.outputs.OLD_VERSION }} to ${{ steps.bumpIngress.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_ingress_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-inspektor-gadget-version.yml
+++ b/.github/workflows/update-inspektor-gadget-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon inspektor-gadget: Update inspektor-gadget image from ${{ steps.bumpInspektorGadget.outputs.OLD_VERSION }} to ${{ steps.bumpInspektorGadget.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_inspektor_gadget_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-iso-image-versions.yml
+++ b/.github/workflows/update-iso-image-versions.yml
@@ -123,8 +123,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Kicbase/ISO: Update dependency versions'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: bump_iso_image_versions
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/.github/workflows/update-istio-operator.yml
+++ b/.github/workflows/update-istio-operator.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon istio-provisioner: Update istio/operator image from ${{ steps.bumpIstioOperator.outputs.OLD_VERSION }} to ${{ steps.bumpIstioOperator.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_istio_operator_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-k8s-versions.yml
+++ b/.github/workflows/update-k8s-versions.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: bump default/newest kubernetes versions
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_k8s_versions
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-kindnetd-version.yml
+++ b/.github/workflows/update-kindnetd-version.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'CNI: Update kindnetd from ${{ steps.bumpKindnetd.outputs.OLD_VERSION }} to ${{ steps.bumpKindnetd.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_kindnetd_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-kong-ingress-controller-version.yml
+++ b/.github/workflows/update-kong-ingress-controller-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon kong: Update kong/kubernetes-ingress-controller image from ${{ steps.bumpKongIngressController.outputs.OLD_VERSION }} to ${{ steps.bumpKongIngressController.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_kong_ingress_controller_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-kong-version.yml
+++ b/.github/workflows/update-kong-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon kong: Update kong image from ${{ steps.bumpKong.outputs.OLD_VERSION }} to ${{ steps.bumpKong.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_kong_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-kube-vip-version.yml
+++ b/.github/workflows/update-kube-vip-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'HA (multi-control plane): Update kube-vip from ${{ steps.bumpKubeVip.outputs.OLD_VERSION }} to ${{ steps.bumpKubeVip.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_kube_vip_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-kubeadm-constants.yml
+++ b/.github/workflows/update-kubeadm-constants.yml
@@ -36,8 +36,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: update image constants for kubeadm images
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_kubeadm_constants
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-kubectl-version.yml
+++ b/.github/workflows/update-kubectl-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon kubevirt: Update bitnami/kubectl image from ${{ steps.bumpKubectl.outputs.OLD_VERSION }} to ${{ steps.bumpKubectl.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_kubectl_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-kubernetes-versions-list.yml
+++ b/.github/workflows/update-kubernetes-versions-list.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: update Kubernetes versions list
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_update_kubernetes_versions_list
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-kubevirt-version.yml
+++ b/.github/workflows/update-kubevirt-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon kubevirt: Update KubeVirt version from ${{ steps.bumpKubevirt.outputs.OLD_VERSION }} to ${{ steps.bumpKubevirt.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_kubevirt_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-metrics-server-version.yml
+++ b/.github/workflows/update-metrics-server-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon metrics-server: Update metrics-server/metrics-server image from ${{ steps.bumpMetricsServer.outputs.OLD_VERSION }} to ${{ steps.bumpMetricsServer.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_metrics_server_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-nerdctl-version.yml
+++ b/.github/workflows/update-nerdctl-version.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Kicbase/ISO: Update nerdctl from ${{ steps.bumpNerdctl.outputs.OLD_VERSION }} to ${{ steps.bumpNerdctl.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_nerdctl_version
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/.github/workflows/update-nerdctld-version.yml
+++ b/.github/workflows/update-nerdctld-version.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Kicbase: Update nerdctld from ${{ steps.bumpNerdctld.outputs.OLD_VERSION }} to ${{ steps.bumpNerdctld.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_nerdctld_version
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/.github/workflows/update-nvidia-device-plugin-version.yml
+++ b/.github/workflows/update-nvidia-device-plugin-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon nvidia-device-plugin: Update nvidia/k8s-device-plugin image from ${{ steps.bumpNvidiaDevicePlugin.outputs.OLD_VERSION }} to ${{ steps.bumpNvidiaDevicePlugin.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_nvidia_device_plugin_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-portainer-version.yml
+++ b/.github/workflows/update-portainer-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon portainer: Update portainer image from ${{ steps.bumpPortainer.outputs.OLD_VERSION }} to ${{ steps.bumpPortainer.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_portainer_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-registry-version.yml
+++ b/.github/workflows/update-registry-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon registry: Update registry image from ${{ steps.bumpRegistry.outputs.OLD_VERSION }} to ${{ steps.bumpRegistry.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_registry_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-runc-version.yml
+++ b/.github/workflows/update-runc-version.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Kicbase/ISO: Update runc from ${{ steps.bumpRunc.outputs.OLD_VERSION }} to ${{ steps.bumpRunc.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_runc_version
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/.github/workflows/update-site-node-version.yml
+++ b/.github/workflows/update-site-node-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'site: Update node from ${{ steps.bumpSiteNode.outputs.OLD_VERSION }} to ${{ steps.bumpSiteNode.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_site_node_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-volcano-version.yml
+++ b/.github/workflows/update-volcano-version.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon Volcano: Update volcano images from ${{ steps.bumpVolcano.outputs.OLD_VERSION }} to ${{ steps.bumpVolcano.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_volcano_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/update-yakd-version.yml
+++ b/.github/workflows/update-yakd-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: 'Addon yakd: Update manusa/yakd image from ${{ steps.bumpYakd.outputs.OLD_VERSION }} to ${{ steps.bumpYakd.outputs.NEW_VERSION }}'
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: auto_bump_yakd_version
           push-to-fork: minikube-bot/minikube
           base: master

--- a/.github/workflows/yearly-leaderboard.yml
+++ b/.github/workflows/yearly-leaderboard.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
           commit-message: Update yearly leaderboard
-          committer: minikube-bot <minikube-bot@google.com>
-          author: minikube-bot <minikube-bot@google.com>
+          committer: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
+          author: minikube-bot <20374350+minikube-bot@users.noreply.github.com>
           branch: yearly-leaderboard
           branch-suffix: short-commit-hash
           push-to-fork: minikube-bot/minikube

--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -91,7 +91,7 @@ EOF
 fi
 
 git config user.name "minikube-bot"
-git config user.email "minikube-bot@google.com"
+git config user.email "20374350+minikube-bot@users.noreply.github.com"
 
 if [ "$release" = false ]; then
 	# Update the user's PR with newly build ISO

--- a/hack/jenkins/kicbase_auto_build.sh
+++ b/hack/jenkins/kicbase_auto_build.sh
@@ -100,7 +100,7 @@ docker pull $GCR_IMG
 fullsha=$(docker inspect --format='{{index .RepoDigests 0}}' $GCR_IMG)
 sha=$(echo ${fullsha} | cut -d ":" -f 2)
 git config user.name "minikube-bot"
-git config user.email "minikube-bot@google.com"
+git config user.email "20374350+minikube-bot@users.noreply.github.com"
 
 
 if [ "$release" = false ]; then

--- a/hack/jenkins/release_update_releases_json.sh
+++ b/hack/jenkins/release_update_releases_json.sh
@@ -33,7 +33,7 @@ export TAGNAME=v${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}
 
 # Update releases.json w/ new release in gcs and github
 git config user.name "minikube-bot"
-git config user.email "minikube-bot@google.com"
+git config user.email "20374350+minikube-bot@users.noreply.github.com"
 
 git checkout -b "jenkins-releases.json-${TAGNAME}"
 

--- a/hack/jenkins/storage_provisioner.sh
+++ b/hack/jenkins/storage_provisioner.sh
@@ -53,7 +53,7 @@ ${SED} "s/PreloadVersion = .*/PreloadVersion = \"${PLV}\"/" pkg/minikube/downloa
 
 # Open a PR with the changes
 git config user.name "minikube-bot"
-git config user.email "minikube-bot@google.com"
+git config user.email "20374350+minikube-bot@users.noreply.github.com"
 
 branch=storage-provisioner-${SP_VERSION}
 git checkout -b ${branch}


### PR DESCRIPTION
The EasyCLA check fails for all minikube-bot commits because minikube-bot@google.com is not linked to the minikube-bot GitHub account. Use the GitHub noreply email (20374350+minikube-bot@ users.noreply.github.com) which is always linked to the account, fixing the CLA check for all workflows.

Example minikube-bot commits with fixed email address:
https://github.com/kubernetes/minikube/pull/23218/changes/9c8181aa6e149567a0421099c0c66fa27212a307