### PR TITLE
fix: preserve tag for registry refs with a port

### DIFF
--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -107,20 +107,22 @@ func DigestByGoLib(imgName string) string {
 	return cf.Hex
 }
 
-// Tag returns just the image with the tag
-// eg image:tag@sha256:digest -> image:tag if there is an associated tag
-// if not possible, just return the initial img
+// Tag returns the image ref with any digest stripped
+//
+//	image:tag@sha256:digest	-> image:tag
+//	image@sha256:digest	-> image
+//	localhost:5000/myimage:v1@sha256:digest	-> localhost:5000/myimage:v1
+//
+// refs without a digest are returned unchanged:
+//
+//	image:tag -> image:tag
+//	image	-> image
 func Tag(img string) string {
 	at := strings.LastIndex(img, "@")
 	if at == -1 {
 		return img
 	}
-	base := img[:at]
-	slash := strings.LastIndex(base, "/")
-	if strings.IndexByte(base[slash+1:], ':') == -1 {
-		return img
-	}
-	return base
+	return img[:at]
 }
 
 func canonicalName(ref name.Reference) string {

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -111,12 +111,16 @@ func DigestByGoLib(imgName string) string {
 // eg image:tag@sha256:digest -> image:tag if there is an associated tag
 // if not possible, just return the initial img
 func Tag(img string) string {
-	split := strings.Split(img, ":")
-	if len(split) == 3 {
-		tag := strings.Split(split[1], "@")[0]
-		return fmt.Sprintf("%s:%s", split[0], tag)
+	at := strings.LastIndex(img, "@")
+	if at == -1 {
+		return img
 	}
-	return img
+	base := img[:at]
+	slash := strings.LastIndex(base, "/")
+	if strings.IndexByte(base[slash+1:], ':') == -1 {
+		return img
+	}
+	return base
 }
 
 func canonicalName(ref name.Reference) string {

--- a/pkg/minikube/image/image_test.go
+++ b/pkg/minikube/image/image_test.go
@@ -31,7 +31,7 @@ func TestTag(t *testing.T) {
 			expected: "image:tag",
 		}, {
 			image:    "image@sha256:digest",
-			expected: "image@sha256:digest",
+			expected: "image",
 		}, {
 			image:    "image",
 			expected: "image",
@@ -45,6 +45,12 @@ func TestTag(t *testing.T) {
 		}, {
 			image:    "registry.io:5000/path/img:v1@sha256:digest",
 			expected: "registry.io:5000/path/img:v1",
+		}, {
+			image:    "localhost:5000/myimage:v1@sha256:digest",
+			expected: "localhost:5000/myimage:v1",
+		}, {
+			image:    "localhost:5000/mymirror/kube-apiserver:v1.30.0@sha256:digest",
+			expected: "localhost:5000/mymirror/kube-apiserver:v1.30.0",
 		},
 	}
 	for _, tc := range tcs {

--- a/pkg/minikube/image/image_test.go
+++ b/pkg/minikube/image/image_test.go
@@ -36,6 +36,16 @@ func TestTag(t *testing.T) {
 			image:    "image",
 			expected: "image",
 		},
+		{
+			image:    "localhost:5000/myimage:v1",
+			expected: "localhost:5000/myimage:v1",
+		}, {
+			image:    "localhost:5000/mymirror/kube-apiserver:v1.30.0",
+			expected: "localhost:5000/mymirror/kube-apiserver:v1.30.0",
+		}, {
+			image:    "registry.io:5000/path/img:v1@sha256:digest",
+			expected: "registry.io:5000/path/img:v1",
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.image, func(t *testing.T) {


### PR DESCRIPTION
fixes #23227                                                                                                                            

image.Tag() guesses whether a ref has a digest by counting colons (3 = has digest). That breaks for registries with a port - host:port/repo:tag also has 3 parts. So --image-repository localhost:5000/... (standard air-gapped/offline setup) keeps the sha256 on the kicbase ref, name.NewTag() rejects it, minikube falls back to docker.io instead of the mirror. Offline, the cluster won't start.

Reproduced on master:                                                                                                                                   
                                                                                                                                                         
 ```                                                                                                                                                     
cache.go:183] failed to download localhost:5050/mirror/k8s-minikube/kicbase-builds:v0.0.50-...@sha256:...,                                            
will try fallback image if available: parsing tag: repository can only contain ... @sha256                                                            
 ```                                                                                                                                                     

fix: don't count colons - strip from the last @ (a digest is always @-delimited); treat the part after the last / as the tag (a registry port's : sits before the /).                                                                                                                                          

Before/after:                                                                                                                                           
                                                                                                                                                         
 ```                                                                                                                                                     
Tag("localhost:5000/repo/kicbase-builds:v0.0.50@sha256:abc")
 before: "...kicbase-builds:v0.0.50@sha256:abc"  # NewTag fails
 after:  "...kicbase-builds:v0.0.50"

Tag("localhost:5000/repo/img:v1")
 before: "localhost:5000/repo/img"   # tag dropped
 after:  "localhost:5000/repo/img:v1"
 ```                                                                                                                                                     

only the kicbase path (download.ImageToCache/CacheToDaemon) calls Tag(). k8s component img use image.SaveToDir and aren't affected.                
                                                                                                                                                         
Tested w/ go test ./pkg/minikube/image/ (added 3 port cases), re-ran the repro against the fix - mirror ref parses, fallback no longer triggers.