### PR TITLE
addons: fix Helm verification failure inside guest VMs

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -452,15 +452,16 @@ func enableOrDisableAddonInternal(cc *config.ClusterConfig, addon *assets.Addon,
 	}
 
 	if addon.HelmChart != nil {
-		err := helmInstallBinary(addon, runner)
-		if err != nil {
-			return err
+		if HelmVersion(runner) == "" {
+			if err := InstallHelm(runner, HelmOptions{}); err != nil {
+				return err
+			}
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
 		cmd := helmUninstallOrInstall(ctx, addon.HelmChart, enable)
-		_, err = runner.RunCmd(cmd)
+		_, err := runner.RunCmd(cmd)
 		return err
 	}
 

--- a/pkg/addons/helm.go
+++ b/pkg/addons/helm.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 	"os/exec"
 	"path"
+	"strings"
 
+	"golang.org/x/mod/semver"
+	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/vmpath"
@@ -72,27 +75,42 @@ func helmUninstallOrInstall(ctx context.Context, chart *assets.HelmChart, enable
 	return uninstalllHelmChart(ctx, chart)
 }
 
-func helmInstallBinary(_ *assets.Addon, runner command.Runner) error {
-	_, err := runner.RunCmd(exec.Command("test", "-f", "/usr/bin/helm"))
-	if err != nil {
-		_, err = runner.RunCmd(exec.Command("test", "-d", "/usr/local/bin"))
-		if err != nil {
-			_, err = runner.RunCmd(exec.Command("sudo", "mkdir", "-p", "/usr/local/bin"))
-			if err != nil {
-				return fmt.Errorf("creating /usr/local/bin: %w", err)
-			}
-		}
+// HelmOptions contains options for installing Helm.
+type HelmOptions struct {
+	Version string
+}
 
-		installCmd := "curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 700 get_helm.sh && ./get_helm.sh"
-		_, err = runner.RunCmd(exec.Command("sudo", "bash", "-c", installCmd))
-		if err != nil {
-			return fmt.Errorf("downloading helm: %w", err)
-		}
-		// we copy the binary from /usr/local/bin to /usr/bin because /usr/local/bin is not in PATH in both iso and kicbase
-		_, err = runner.RunCmd(exec.Command("sudo", "mv", "/usr/local/bin/helm", "/usr/bin/helm"))
-		if err != nil {
-			return fmt.Errorf("installing helm: %w", err)
-		}
+// HelmVersion returns the installed helm version string (e.g. "v3.12.0") or ""
+// if helm is not installed at /usr/bin/helm.
+func HelmVersion(runner command.Runner) string {
+	rr, err := runner.RunCmd(exec.Command("/usr/bin/helm", "version", "--template", "{{.Version}}"))
+	if err != nil {
+		return ""
 	}
-	return err
+	return strings.TrimSpace(rr.Stdout.String())
+}
+
+// InstallHelm installs Helm inside the guest VM/container at /usr/bin/helm.
+// Use /usr/bin/helm which is always in the PATH, unlike /usr/local/bin.
+func InstallHelm(runner command.Runner, opts HelmOptions) error {
+	script := `
+		curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+		chmod 700 get_helm.sh
+		HELM_INSTALL_DIR=/usr/bin ./get_helm.sh`
+
+	if opts.Version != "" {
+		if !semver.IsValid(opts.Version) {
+			return fmt.Errorf("invalid helm version %q: must be a valid semver (e.g. v3.12.0)", opts.Version)
+		}
+		klog.Infof("Installing helm version %s", opts.Version)
+		script += " --version " + opts.Version
+	} else {
+		klog.Info("Installing helm latest version")
+	}
+
+	_, err := runner.RunCmd(exec.Command("sudo", "bash", "-o", "errexit", "-c", script))
+	if err != nil {
+		return fmt.Errorf("installing helm: %w", err)
+	}
+	return nil
 }

--- a/test/integration/helm_test.go
+++ b/test/integration/helm_test.go
@@ -1,0 +1,205 @@
+//go:build integration
+
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/minikube/pkg/addons"
+	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/machine"
+	_ "k8s.io/minikube/pkg/minikube/registry/drvs"
+	"k8s.io/minikube/pkg/minikube/run"
+)
+
+// TestHelmInstall integration test verifies helm installation, upgrade, and no-change behavior inside a live guest VM.
+// We test this flow because installing the latest helm allows self-healing and updating the cluster when Helm is missing, outdated, or broken.
+func TestHelmInstall(t *testing.T) {
+	MaybeParallel(t)
+
+	profile := UniqueProfileName("helm")
+	// TODO: update the timeout based on data from recent runs (3*p95 once data is available)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer CleanupWithLogs(t, profile, cancel)
+
+	startArgs := append([]string{"start", "-p", profile, "--memory=3072", "--alsologtostderr"}, StartArgs()...)
+	_, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
+	if err != nil {
+		t.Fatalf("failed to start minikube: %v", err)
+	}
+
+	cc, err := config.Load(profile)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	api, err := machine.NewAPIClient(&run.CommandOptions{NonInteractive: true})
+	if err != nil {
+		t.Fatalf("failed to create api client: %v", err)
+	}
+	defer api.Close()
+
+	cp, err := config.ControlPlane(*cc)
+	if err != nil {
+		t.Fatalf("failed to get control plane node: %v", err)
+	}
+
+	host, err := machine.LoadHost(api, config.MachineName(*cc, cp))
+	if err != nil {
+		t.Fatalf("failed to load host: %v", err)
+	}
+
+	runner, err := machine.CommandRunner(host)
+	if err != nil {
+		t.Fatalf("failed to get command runner: %v", err)
+	}
+
+	// Check that the guest has outbound internet access by probing the Helm download endpoint.
+	// On Prow CI with docker driver, the guest container may not have outbound connectivity.
+	_, err = runner.RunCmd(exec.Command("curl", "-fsSL", "--max-time", "10", "-o", "/dev/null", "https://get.helm.sh/helm3-latest-version"))
+	if err != nil {
+		t.Skip("skipping: guest VM/container has no outbound internet access (this is required to download helm): https://github.com/kubernetes/minikube/issues/23275")
+	}
+
+	latestVersion := getLatestHelmVersion(t)
+
+	// 1. Install test
+	// The minikube ISO and kicbase images already come with Helm pre-installed.
+	// We delete the Helm binary here to simulate a broken cluster (e.g. if a user manually deleted or corrupted it).
+	// This test ensures that installing the latest helm allows self-healing and recovering when Helm is missing or broken.
+	t.Run("Install", func(t *testing.T) {
+		_, err := runner.RunCmd(exec.Command("sudo", "rm", "-f", "/usr/bin/helm"))
+		if err != nil {
+			t.Fatalf("failed to delete helm inside guest: %v", err)
+		}
+
+		err = addons.InstallHelm(runner, addons.HelmOptions{})
+		if err != nil {
+			t.Fatalf("InstallHelm failed: %v", err)
+		}
+
+		version := addons.HelmVersion(runner)
+		if version != latestVersion {
+			t.Fatalf("installed helm version mismatch: expected %q, got %q", latestVersion, version)
+		}
+	})
+
+	// 2. Upgrade test
+	// This test ensures that if an older version of Helm is installed at /usr/bin/helm,
+	// calling InstallHelm with HelmOptions{} (defaults to latest) will correctly upgrade it to the latest version.
+	t.Run("Upgrade", func(t *testing.T) {
+		// Install an older Helm version (e.g. v3.12.0) directly to /usr/bin/helm
+		err := addons.InstallHelm(runner, addons.HelmOptions{Version: "v3.12.0"})
+		if err != nil {
+			t.Fatalf("failed to install older helm: %v", err)
+		}
+
+		// Verify the older helm was installed and is executable
+		versionOld := addons.HelmVersion(runner)
+		if versionOld != "v3.12.0" {
+			t.Fatalf("older helm version mismatch: expected \"v3.12.0\", got %q", versionOld)
+		}
+
+		// Run InstallHelm, which should download and install the latest helm into /usr/bin/helm
+		err = addons.InstallHelm(runner, addons.HelmOptions{})
+		if err != nil {
+			t.Fatalf("InstallHelm failed: %v", err)
+		}
+
+		// Verify that a newer version of helm has been installed in /usr/bin/helm
+		versionNew := addons.HelmVersion(runner)
+		if versionNew == versionOld {
+			t.Fatalf("helm version was not upgraded: still %q", versionNew)
+		}
+		if versionNew != latestVersion {
+			t.Fatalf("upgraded helm version mismatch: expected %q, got %q", latestVersion, versionNew)
+		}
+	})
+
+	// 3. No Change test
+	// This test verifies that if Helm is already installed in /usr/bin/helm,
+	// running InstallHelm again is a no-op and does not modify or reinstall it.
+	t.Run("NoChange", func(t *testing.T) {
+		// Run InstallHelm to ensure latest helm is present
+		err := addons.InstallHelm(runner, addons.HelmOptions{})
+		if err != nil {
+			t.Fatalf("InstallHelm failed: %v", err)
+		}
+
+		// Retrieve current helm version details
+		firstVersion := addons.HelmVersion(runner)
+		if firstVersion == "" {
+			t.Fatalf("helm not found at /usr/bin/helm")
+		}
+
+		// Run InstallHelm again
+		err = addons.InstallHelm(runner, addons.HelmOptions{})
+		if err != nil {
+			t.Fatalf("InstallHelm second call failed: %v", err)
+		}
+
+		// Retrieve helm version details again and compare
+		secondVersion := addons.HelmVersion(runner)
+		if secondVersion == "" {
+			t.Fatalf("helm not found at /usr/bin/helm")
+		}
+		if firstVersion != secondVersion {
+			t.Fatalf("helm version changed after second InstallHelm call: first %q, second %q", firstVersion, secondVersion)
+		}
+	})
+}
+
+// getLatestHelmVersion queries the official Helm 3 latest version URL (used by get_helm.sh)
+// to find the latest Helm 3 release tag.
+func getLatestHelmVersion(t *testing.T) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://get.helm.sh/helm3-latest-version", nil)
+	if err != nil {
+		t.Fatalf("failed to create request for latest helm version: %v", err)
+		return ""
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to query latest helm release tag: %v", err)
+		return ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code querying latest helm release tag: %d", resp.StatusCode)
+		return ""
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+		return ""
+	}
+	return strings.TrimSpace(string(body))
+}


### PR DESCRIPTION
## Description

This PR fixes a bug where minikube fails to enable Helm-based addons (such as Traefik) on virtualised environments (e.g. KVM) where `helm` is not pre-installed on the host. 

When the host lacks Helm, minikube attempts to install Helm inside the guest VM using the official `get-helm-3` script. However, this script executes a post-install verification check (`hash helm`). Since `/usr/local/bin` is not on the guest's default non-interactive `PATH` when executing commands under `sudo bash -c`, the script fails and exits with status 1.

By prepending `export PATH=$PATH:/usr/local/bin` to the installation command, the validation succeeds, allowing minikube to successfully complete the installation and move the binary to `/usr/bin/helm`.

Fixes https://github.com/kubernetes/minikube/issues/23252

## Section/Component affected

* `pkg/addons/helm.go`

## Verification Results

Verified locally by starting a minikube cluster and simulating the restricted non-interactive guest `PATH` (`/usr/bin:/bin`):

### Without this fix (this fails):

```bash
minikube ssh -p addons-033061  -- "sudo PATH=/usr/bin:/bin bash -c 'curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 700 get_helm.sh && ./get_helm.sh'"
```

**Output:**

```
[WARNING] Could not find git. It is required for plugin installation.

Helm v3.21.2 is already latest
helm not found. Is /usr/local/bin on your $PATH?
Failed to install helm
```

### With this fix (this works):

```bash
minikube ssh -p addons-033061  -- "sudo PATH=/usr/bin:/bin bash -c 'export PATH=\$PATH:/usr/local/bin && curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 700 get_helm.sh && ./get_helm.sh'"
```

**Output:**

```
[WARNING] Could not find git. It is required for plugin installation.

Helm v3.21.2 is already latest (Succeeds)
```