### PR TITLE
Add .hugo_build.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ deploy/iso/minikube-iso/board/minikube/aarch64/rootfs-overlay/version.json
 /site/resources
 /_gen
 /site/public
+.hugo_build.lock
 
 # gopogh filldb
 hack/legacy_fill_db/gopogh_filldb_log.txt


### PR DESCRIPTION
Hugo creates `.hugo_build.lock` during `hugo serve` and `hugo build` to prevent
concurrent builds. If Hugo is interrupted the lock file may be left behind in
the working tree. Add it to `.gitignore` to prevent accidental commits.