### PR TITLE
fix: ignore kubeconfig parse errors when listing profiles

### DIFF
--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
 	"k8s.io/minikube/pkg/minikube/localpath"
+	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/util/lock"
 )
 
@@ -190,6 +191,10 @@ var DockerContainers = func() ([]string, error) {
 // invalidPs are the profiles that have a directory or config file but not usable
 // invalidPs would be suggested to be deleted
 func ListProfiles(miniHome ...string) (validPs []*Profile, inValidPs []*Profile, err error) {
+	return listProfiles(kubeconfig.PathFromEnv(), DockerContainers, miniHome...)
+}
+
+func listProfiles(kubeconfigPath string, dockerContainers func() ([]string, error), miniHome ...string) (validPs []*Profile, inValidPs []*Profile, err error) {
 	activeP := viper.GetString(ProfileName)
 	// try to get profiles list based on left over evidences such as directory
 	pDirs, err := profileDirs(miniHome...)
@@ -197,14 +202,16 @@ func ListProfiles(miniHome ...string) (validPs []*Profile, inValidPs []*Profile,
 		return nil, nil, err
 	}
 	// try to get profiles list based on all containers created by docker driver
-	cs, err := DockerContainers()
+	cs, err := dockerContainers()
 	if err == nil {
 		pDirs = append(pDirs, cs...)
 	}
 
-	activeKubeContext, err := kubeconfig.GetCurrentContext(kubeconfig.PathFromEnv())
-	if err != nil {
-		return nil, nil, err
+	activeKubeContext := ""
+	if ctx, err := kubeconfig.GetCurrentContext(kubeconfigPath); err != nil {
+		out.WarningT("Unable to determine the current kubeconfig context: {{.error}}", out.V{"error": err})
+	} else {
+		activeKubeContext = ctx
 	}
 	nodeNames := map[string]bool{}
 	for _, n := range removeDupes(pDirs) {

--- a/pkg/minikube/config/profile_test.go
+++ b/pkg/minikube/config/profile_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -79,6 +80,38 @@ func TestListProfiles(t *testing.T) {
 
 	if err != nil {
 		t.Errorf("error listing profiles %v", err)
+	}
+}
+
+func TestListProfilesWithInvalidKubeconfig(t *testing.T) {
+	miniDir, err := filepath.Abs("./testdata/profile/.minikube")
+	if err != nil {
+		t.Errorf("error getting dir path for ./testdata/.minikube : %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	kubeconfig := filepath.Join(tmpDir, "invalid-kubeconfig")
+	if err := os.WriteFile(kubeconfig, []byte("not: [valid\n"), 0600); err != nil {
+		t.Fatalf("failed to write invalid kubeconfig: %v", err)
+	}
+	val, inv, err := listProfiles(kubeconfig, func() ([]string, error) {
+		return []string{}, nil
+	}, miniDir)
+	if err != nil {
+		t.Fatalf("ListProfiles returned unexpected error: %v", err)
+	}
+
+	if len(val) != 2 {
+		t.Fatalf("ListProfiles valid profile count = %d, expected 2", len(val))
+	}
+	if len(inv) != 3 {
+		t.Fatalf("ListProfiles invalid profile count = %d, expected 3", len(inv))
+	}
+
+	for _, p := range val {
+		if p.ActiveKubeContext {
+			t.Errorf("expected profile %q not to be marked as active kubecontext", p.Name)
+		}
 	}
 }
 


### PR DESCRIPTION
`minikube profile list` should not faceplant when `KUBECONFIG` is malformed.

We only read kubeconfig here to mark the active kubecontext column. This keeps profile discovery working and just leaves `ActiveKubeContext` unset if kubeconfig parsing blows up. small bug, pretty user visible.

Repro:
```sh
tmp=$(mktemp)
printf 'not: [valid\n' > "$tmp"
KUBECONFIG="$tmp" minikube profile list
```

Before this, profile discovery could fail and no profiles were returned.
After this, profiles still show up, just no active kubecontext marker. all good.

Tests:
```sh
KUBECONFIG="$tmp" go test ./pkg/minikube/config -run TestListProfiles -count=1
go test ./pkg/minikube/config -count=1
```
