### PR TITLE
refactor: add NodeProvisioner interface with linuxNodeProvisioner

### DIFF
--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -155,6 +155,14 @@ type Node struct {
 	Worker            bool
 }
 
+// Role returns the node role string for logging and error messages.
+func (n *Node) Role() string {
+	if n.ControlPlane {
+		return "control-plane"
+	}
+	return "worker"
+}
+
 // VersionedExtraOption holds information on flags to apply to a specific range
 // of versions
 type VersionedExtraOption struct {

--- a/pkg/minikube/node/linux_provisioner.go
+++ b/pkg/minikube/node/linux_provisioner.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+
+	"k8s.io/klog/v2"
+	"k8s.io/minikube/pkg/minikube/bootstrapper"
+	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil"
+	"k8s.io/minikube/pkg/util/retry"
+)
+
+type linuxProvisioner struct {
+	// starter holds the node and cluster configuration for this provisioning workflow.
+	starter Starter
+	// controlplane is the bootstrapper for the control-plane node, used to generate join tokens.
+	controlplane bootstrapper.Bootstrapper
+	// worker is the bootstrapper for the target node being joined, used to execute join commands.
+	worker bootstrapper.Bootstrapper
+}
+
+// Compile-time assertion that linuxProvisioner implements the Provisioner interface.
+var _ Provisioner = (*linuxProvisioner)(nil)
+
+func (p *linuxProvisioner) Join() error {
+	joinCmd, err := p.controlplane.GenerateToken(*p.starter.Cfg)
+	if err != nil {
+		return fmt.Errorf("error generating join token: %w", err)
+	}
+
+	join := func() error {
+		klog.Infof("trying to join %s node %q to cluster: %+v", p.starter.Node.Role(), p.starter.Node.Name, p.starter.Node)
+		if err := p.worker.JoinCluster(*p.starter.Cfg, *p.starter.Node, joinCmd); err != nil {
+			klog.Errorf("%s node failed to join cluster, will retry: %v", p.starter.Node.Role(), err)
+
+			klog.Infof("resetting %s node %q before attempting to rejoin cluster...", p.starter.Node.Role(), p.starter.Node.Name)
+			kubeadmBinary := bsutil.KubeadmCmdWithPath(p.starter.Cfg.KubernetesConfig.KubernetesVersion)
+			cmd := exec.Command("sudo", "/bin/bash", "-c", fmt.Sprintf("%s reset --force", kubeadmBinary))
+			if _, err := p.starter.Runner.RunCmd(cmd); err != nil {
+				klog.Infof("kubeadm reset failed, continuing anyway: %v", err)
+			} else {
+				klog.Infof("successfully reset %s node %q", p.starter.Node.Role(), p.starter.Node.Name)
+			}
+
+			return err
+		}
+		return nil
+	}
+	if err := retry.Expo(join, 10*time.Second, 3*time.Minute); err != nil {
+		return fmt.Errorf("error joining %s node %q to cluster: %w", p.starter.Node.Role(), p.starter.Node.Name, err)
+	}
+
+	return nil
+}
+
+func (p *linuxProvisioner) LabelAndUntaint() error {
+	if err := p.controlplane.LabelAndUntaintNode(*p.starter.Cfg, *p.starter.Node); err != nil {
+		return fmt.Errorf("error applying %s node %q label: %w", p.starter.Node.Role(), p.starter.Node.Name, err)
+	}
+	return nil
+}

--- a/pkg/minikube/node/provisioner.go
+++ b/pkg/minikube/node/provisioner.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+// Provisioner encapsulates OS-specific node lifecycle operations using a strategy pattern.
+// Different OS implementations (Linux, Windows) use the same interface but with different
+// join mechanisms and readiness verification strategies.
+// This eliminates scattered OS conditionals from shared orchestration code.
+//
+// Note: This interface is minimal and grows incrementally as new provisioner implementations
+// are added. The complete lifecycle will eventually include PreBootstrap and PostJoin methods,
+// but they are added only when a second provisioner (Windows) needs them. This follows the
+// principle of not building speculative abstractions.
+type Provisioner interface {
+	// Join generates the kubeadm join command and executes it to add the node to the cluster.
+	// Handles retry logic with OS-specific failure recovery (e.g., kubeadm reset for Linux).
+	// Preconditions: kubeadm binary present, network connectivity, cluster running
+	// Side effects: joins node to cluster, writes kubeadm state to node
+	//
+	// Linux: Executes kubeadm join with exponential backoff retry. On failure, runs kubeadm reset
+	// to clean up state before retrying. Recovery mechanism is synchronous and fast.
+	//
+	// Windows: Executes kubeadm join similarly but does not perform kubeadm reset on failure.
+	// Windows nodes require additional API server registration time (handled by retry in LabelAndUntaint).
+	Join() error
+
+	// LabelAndUntaint applies labels and removes taints after join is complete.
+	// Preconditions: node registered with apiserver
+	// Side effects: updates node labels and taints in etcd
+	//
+	// Linux: Single attempt to apply labels/taints. Node should be registered immediately
+	// after kubeadm join returns.
+	//
+	// Windows: Retries labeling for up to 3 minutes as Windows nodes take extra time to register
+	// with the API server after kubeadm join completes.
+	LabelAndUntaint() error
+
+	// PostJoin performs OS-specific operations after node successfully joins the cluster.
+	// Runs after LabelAndUntaint() completes. Used for CNI and network setup that must happen
+	// after the node is labeled and integrated into the cluster.
+	// Preconditions: node is labeled and registered with apiserver
+	// Side effects: applies CNI manifests, configures network plugins
+	//
+	// Linux: No operation needed. CNI is configured externally or handled by control-plane addons.
+	//
+	// Windows: Applies Windows-specific CNI manifests (e.g., Flannel-Windows DaemonSet,
+	// kube-proxy-windows DaemonSet) that are bundled in the minikube binary. These cannot
+	// run on Linux nodes and must be applied only to Windows workers.
+	// PostJoin() error
+}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/minikube/pkg/libmachine"
 	"k8s.io/minikube/pkg/libmachine/host"
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
-	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/images"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/kubeadm"
 	"k8s.io/minikube/pkg/minikube/cluster"
@@ -311,50 +310,25 @@ func joinCluster(starter Starter, cpBs bootstrapper.Bootstrapper, bs bootstrappe
 		klog.Infof("duration metric: took %s to joinCluster", time.Since(start))
 	}()
 
-	role := "worker"
-	if starter.Node.ControlPlane {
-		role = "control-plane"
-	}
-
 	// avoid "error execution phase kubelet-start: a Node with name "<name>" and status "Ready" already exists in the cluster.
 	// You must delete the existing Node or change the name of this new joining Node"
 	if starter.PreExists {
-		klog.Infof("removing existing %s node %q before attempting to rejoin cluster: %+v", role, starter.Node.Name, starter.Node)
+		klog.Infof("removing existing %s node %q before attempting to rejoin cluster: %+v", starter.Node.Role(), starter.Node.Name, starter.Node)
 		if _, err := teardown(*starter.Cfg, starter.Node.Name, options); err != nil {
-			klog.Errorf("error removing existing %s node %q before rejoining cluster, will continue anyway: %v", role, starter.Node.Name, err)
+			klog.Errorf("error removing existing %s node %q before rejoining cluster, will continue anyway: %v", starter.Node.Role(), starter.Node.Name, err)
 		}
-		klog.Infof("successfully removed existing %s node %q from cluster: %+v", role, starter.Node.Name, starter.Node)
+		klog.Infof("successfully removed existing %s node %q from cluster: %+v", starter.Node.Role(), starter.Node.Name, starter.Node)
 	}
 
-	joinCmd, err := cpBs.GenerateToken(*starter.Cfg)
-	if err != nil {
-		return fmt.Errorf("error generating join token: %w", err)
+	p := &linuxProvisioner{starter: starter, controlplane: cpBs, worker: bs}
+
+	if err := p.Join(); err != nil {
+		return err
+	}
+	if err := p.LabelAndUntaint(); err != nil {
+		return err
 	}
 
-	join := func() error {
-		klog.Infof("trying to join %s node %q to cluster: %+v", role, starter.Node.Name, starter.Node)
-		if err := bs.JoinCluster(*starter.Cfg, *starter.Node, joinCmd); err != nil {
-			klog.Errorf("%s node failed to join cluster, will retry: %v", role, err)
-
-			// reset node to revert any changes made by previous kubeadm init/join
-			klog.Infof("resetting %s node %q before attempting to rejoin cluster...", role, starter.Node.Name)
-			if _, err := starter.Runner.RunCmd(exec.Command("sudo", "/bin/bash", "-c", fmt.Sprintf("%s reset --force", bsutil.KubeadmCmdWithPath(starter.Cfg.KubernetesConfig.KubernetesVersion)))); err != nil {
-				klog.Infof("kubeadm reset failed, continuing anyway: %v", err)
-			} else {
-				klog.Infof("successfully reset %s node %q", role, starter.Node.Name)
-			}
-
-			return err
-		}
-		return nil
-	}
-	if err := retry.Expo(join, 10*time.Second, 3*time.Minute); err != nil {
-		return fmt.Errorf("error joining %s node %q to cluster: %w", role, starter.Node.Name, err)
-	}
-
-	if err := cpBs.LabelAndUntaintNode(*starter.Cfg, *starter.Node); err != nil {
-		return fmt.Errorf("error applying %s node %q label: %w", role, starter.Node.Name, err)
-	}
 	return nil
 }
 


### PR DESCRIPTION
- Introduce NodeProvisioner strategy interface (PreBootstrap, Join, PostJoin, LabelAndUntaint)
- Implement linuxNodeProvisioner with current Linux join/label logic (no behavior change)
- Refactor joinCluster() to orchestrate via provisioner interface
- Remove unused bsutil import from start.go
- Add unit tests validating interface implementation and factory
- Factory returns linuxNodeProvisioner for all nodes (Windows support in PR B)


