### PR TITLE
Testing prow build failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1104,3 +1104,5 @@ _update-all:
 
 # targets for tests on prow
 include ./hack/prow/prow.mk
+
+# Testing


### PR DESCRIPTION
We see failure in this Prow build pull-minikube-build. Looks like we are mixing build with smoke test and starting minikube started to fail in this environment, likely because of an environment issue.

    pod_spec:
      containers:
      - args:
        - bash
        - -c - make && ./out/minikube start --force-systemd --force && kubectl get pods -A command: - runner.sh