### PR TITLE
helm: improve error handling, type safety, and test clarity

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -452,10 +452,15 @@ func enableOrDisableAddonInternal(cc *config.ClusterConfig, addon *assets.Addon,
 	}
 
 	if addon.HelmChart != nil {
-		if HelmVersion(runner) == "" {
+		// Install helm if we don't have a usable helm executable. This can
+		// happen if helm is missing, corrupted, or returns an invalid version.
+		if v, err := HelmVersion(runner); err != nil {
+			klog.Info(err)
 			if err := InstallHelm(runner, HelmOptions{}); err != nil {
 				return err
 			}
+		} else {
+			klog.Infof("using helm %s", v)
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)

--- a/pkg/addons/helm.go
+++ b/pkg/addons/helm.go
@@ -81,7 +81,7 @@ func helmUninstallOrInstall(ctx context.Context, chart *assets.HelmChart, enable
 
 // HelmOptions contains options for installing Helm.
 type HelmOptions struct {
-	Version string
+	Version *semver.Version
 }
 
 // HelmVersion returns the installed helm version at /usr/bin/helm. Returns an
@@ -114,14 +114,9 @@ func InstallHelm(runner command.Runner, opts HelmOptions) error {
 		chmod 700 get_helm.sh
 		HELM_INSTALL_DIR=/usr/bin ./get_helm.sh`
 
-	if opts.Version != "" {
-		// semver.Parse does not support "v" prefix.
-		parsed, err := semver.Parse(strings.TrimPrefix(opts.Version, "v"))
-		if err != nil {
-			return fmt.Errorf("invalid helm version %q: %w", opts.Version, err)
-		}
+	if opts.Version != nil {
 		klog.Infof("Installing helm version %s", opts.Version)
-		script += " --version v" + parsed.String()
+		script += " --version v" + opts.Version.String()
 	} else {
 		klog.Info("Installing helm latest version")
 	}

--- a/pkg/addons/helm.go
+++ b/pkg/addons/helm.go
@@ -18,6 +18,7 @@ package addons
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"path"
@@ -29,6 +30,9 @@ import (
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/vmpath"
 )
+
+// ErrHelmNotInstalled indicates that /usr/bin/helm does not exist on the node.
+var ErrHelmNotInstalled = errors.New("helm is not installed")
 
 // runs a helm install within the minikube vm or container based on the contents of chart *assets.HelmChart
 func installHelmChart(ctx context.Context, chart *assets.HelmChart) *exec.Cmd {
@@ -80,14 +84,26 @@ type HelmOptions struct {
 	Version string
 }
 
-// HelmVersion returns the installed helm version string (e.g. "v3.12.0") or ""
-// if helm is not installed at /usr/bin/helm.
-func HelmVersion(runner command.Runner) string {
+// HelmVersion returns the installed helm version at /usr/bin/helm. Returns an
+// error if helm is not installed, fails to run, or returns an invalid version
+// string.
+func HelmVersion(runner command.Runner) (semver.Version, error) {
 	rr, err := runner.RunCmd(exec.Command("/usr/bin/helm", "version", "--template", "{{.Version}}"))
 	if err != nil {
-		return ""
+		if rr.ExitCode == command.NotFound {
+			// Expected when starting a new or stopped cluster since /usr/bin/
+			// is not persisted.
+			stderr := strings.TrimSpace(rr.Stderr.String())
+			return semver.Version{}, fmt.Errorf("%w: %s", ErrHelmNotInstalled, stderr)
+		}
+		return semver.Version{}, fmt.Errorf("failed to run helm version: %w", err)
 	}
-	return strings.TrimSpace(rr.Stdout.String())
+	raw := strings.TrimPrefix(strings.TrimSpace(rr.Stdout.String()), "v")
+	v, err := semver.Parse(raw)
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("failed to parse helm version %q: %w", raw, err)
+	}
+	return v, nil
 }
 
 // InstallHelm installs Helm inside the guest VM/container at /usr/bin/helm.

--- a/pkg/addons/helm.go
+++ b/pkg/addons/helm.go
@@ -123,7 +123,7 @@ func InstallHelm(runner command.Runner, opts HelmOptions) error {
 
 	_, err := runner.RunCmd(exec.Command("sudo", "bash", "-o", "errexit", "-c", script))
 	if err != nil {
-		return fmt.Errorf("installing helm: %w", err)
+		return fmt.Errorf("failed to install helm: %w", err)
 	}
 	return nil
 }

--- a/pkg/minikube/command/command_runner.go
+++ b/pkg/minikube/command/command_runner.go
@@ -33,6 +33,10 @@ import (
 	"k8s.io/minikube/pkg/minikube/assets"
 )
 
+// NotFound is the POSIX exit code returned when the command binary
+// does not exist.
+const NotFound = 127
+
 var (
 	// ErrPrefix notes an error
 	ErrPrefix = "! "
@@ -46,8 +50,10 @@ var (
 
 // RunResult holds the results of a Runner
 type RunResult struct {
-	Stdout   bytes.Buffer
-	Stderr   bytes.Buffer
+	Stdout bytes.Buffer
+	Stderr bytes.Buffer
+	// ExitCode is the exit code of the command, or NotFound if the binary
+	// does not exist.
 	ExitCode int
 	Args     []string // the args that was passed to Runner
 }

--- a/pkg/minikube/command/exec_runner.go
+++ b/pkg/minikube/command/exec_runner.go
@@ -76,9 +76,7 @@ func (e *execRunner) RunCmd(cmd *exec.Cmd) (*RunResult, error) {
 	err := cmd.Run()
 	elapsed := time.Since(start)
 
-	if exitError, ok := err.(*exec.ExitError); ok {
-		rr.ExitCode = exitError.ExitCode()
-	}
+	rr.ExitCode = e.exitCode(err)
 	// Decrease log spam
 	if elapsed > (1 * time.Second) {
 		klog.Infof("Completed: %s: (%s)", rr.Command(), elapsed)
@@ -122,13 +120,11 @@ func (*execRunner) StartCmd(cmd *exec.Cmd) (*StartedCmd, error) {
 }
 
 // WaitCmd implements the Command Runner interface to wait until a started exec.Cmd object finishes
-func (*execRunner) WaitCmd(sc *StartedCmd) (*RunResult, error) {
+func (e *execRunner) WaitCmd(sc *StartedCmd) (*RunResult, error) {
 	rr := sc.rr
 
 	err := sc.cmd.Wait()
-	if exitError, ok := err.(*exec.ExitError); ok {
-		rr.ExitCode = exitError.ExitCode()
-	}
+	rr.ExitCode = e.exitCode(err)
 
 	if err == nil {
 		return rr, nil
@@ -218,4 +214,22 @@ func (e *execRunner) Remove(f assets.CopyableFile) error {
 
 func (e *execRunner) ReadableFile(_ string) (assets.ReadableFile, error) {
 	return nil, errors.New("execRunner does not support ReadableFile - you could be the first to add it")
+}
+
+// exitCode extracts the exit code from an exec error, handling the following
+// cases:
+// - *exec.ExitError: the process ran and exited with a non-zero code.
+// - os.ErrNotExist: absolute path does not exist (kernel ENOENT).
+// - exec.ErrNotFound: PATH lookup found no matching executable.
+// The last two both mean "binary not found" but Go returns different
+// errors depending on whether the path is absolute or relative.
+// Returns 0 for other errors (e.g. permission denied).
+func (*execRunner) exitCode(err error) int {
+	if exitError, ok := err.(*exec.ExitError); ok {
+		return exitError.ExitCode()
+	}
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, exec.ErrNotFound) {
+		return NotFound
+	}
+	return 0
 }

--- a/pkg/minikube/command/kic_runner.go
+++ b/pkg/minikube/command/kic_runner.go
@@ -124,9 +124,7 @@ func (k *kicRunner) RunCmd(cmd *exec.Cmd) (*RunResult, error) {
 		}
 		return rr, nil
 	}
-	if exitError, ok := err.(*exec.ExitError); ok {
-		rr.ExitCode = exitError.ExitCode()
-	}
+	rr.ExitCode = k.exitCode(err)
 	return rr, fmt.Errorf("%s: %v\nstdout:\n%s\nstderr:\n%s", rr.Command(), err, rr.Stdout.String(), rr.Stderr.String())
 
 }
@@ -296,6 +294,18 @@ func (k *kicRunner) Remove(f assets.CopyableFile) error {
 
 	_, err := k.RunCmd(exec.Command("sudo", "rm", dst))
 	return err
+}
+
+// exitCode extracts the exit code from an exec error.
+// docker/podman exec propagates the container's exit code (including
+// 127 for missing binaries) as the process exit code, so
+// *exec.ExitError is sufficient — no special handling needed unlike
+// execRunner.
+func (*kicRunner) exitCode(err error) int {
+	if exitError, ok := err.(*exec.ExitError); ok {
+		return exitError.ExitCode()
+	}
+	return 0
 }
 
 // isTerminal returns true if the writer w is a terminal

--- a/pkg/minikube/command/ssh_runner.go
+++ b/pkg/minikube/command/ssh_runner.go
@@ -154,16 +154,6 @@ func (s *SSHRunner) Remove(f assets.CopyableFile) error {
 	return sess.Run(fmt.Sprintf("sudo rm %s", dst))
 }
 
-// sshExitCode extracts the exit code from an SSH error.
-// For non-exit errors (e.g. network failures), returns 0 to match
-// ExecRunner and KICRunner behavior.
-func sshExitCode(err error) int {
-	if exitError, ok := err.(*ssh.ExitError); ok {
-		return exitError.ExitStatus()
-	}
-	return 0
-}
-
 // teeSSH runs an SSH command, streaming stdout, stderr to logs
 func teeSSH(s *ssh.Session, cmd string, outB io.Writer, errB io.Writer) error {
 	outPipe, err := s.StdoutPipe()
@@ -233,7 +223,7 @@ func (s *SSHRunner) RunCmd(cmd *exec.Cmd) (*RunResult, error) {
 	err = teeSSH(sess, shellquote.Join(cmd.Args...), outb, errb)
 	elapsed := time.Since(start)
 
-	rr.ExitCode = sshExitCode(err)
+	rr.ExitCode = s.exitCode(err)
 
 	// Decrease log spam
 	if elapsed > (1 * time.Second) {
@@ -324,7 +314,7 @@ func (s *SSHRunner) WaitCmd(sc *StartedCmd) (*RunResult, error) {
 	rr := sc.rr
 
 	err := s.s.Wait()
-	rr.ExitCode = sshExitCode(err)
+	rr.ExitCode = s.exitCode(err)
 
 	sc.wg.Wait()
 
@@ -549,4 +539,14 @@ func (s *SSHRunner) ReadableFile(sourcePath string) (assets.ReadableFile, error)
 		modTime:     modTime,
 		sess:        sess,
 	}, nil
+}
+
+// exitCode extracts the exit code from an SSH error.
+// For non-exit errors (e.g. network failures), returns 0 to match
+// ExecRunner and KICRunner behavior.
+func (*SSHRunner) exitCode(err error) int {
+	if exitError, ok := err.(*ssh.ExitError); ok {
+		return exitError.ExitStatus()
+	}
+	return 0
 }

--- a/test/integration/helm_test.go
+++ b/test/integration/helm_test.go
@@ -87,14 +87,13 @@ func TestHelmInstall(t *testing.T) {
 			t.Fatalf("InstallHelm failed: %v", err)
 		}
 
-		version := addons.HelmVersion(runner)
-		t.Logf("installed helm version: %q", version)
-		parsed, err := semver.Parse(strings.TrimPrefix(version, "v"))
+		version, err := addons.HelmVersion(runner)
 		if err != nil {
-			t.Fatalf("failed to parse helm version: %q: %v", version, err)
+			t.Fatal(err)
 		}
-		if parsed.LT(minExpectedHelmVersion) {
-			t.Fatalf("installed helm version %q is older than minimum expected %q", parsed, minExpectedHelmVersion)
+		t.Logf("installed helm version: %s", version)
+		if version.LT(minExpectedHelmVersion) {
+			t.Fatalf("installed helm version %q is older than minimum expected %q", version, minExpectedHelmVersion)
 		}
 	})
 
@@ -109,13 +108,12 @@ func TestHelmInstall(t *testing.T) {
 		}
 
 		t.Log("checking installed helm version")
-		versionOld := addons.HelmVersion(runner)
-		t.Logf("installed helm version: %s (expected %s)", versionOld, minExpectedHelmVersion)
-		parsedOld, err := semver.Parse(strings.TrimPrefix(versionOld, "v"))
+		versionOld, err := addons.HelmVersion(runner)
 		if err != nil {
-			t.Fatalf("failed to parse helm version: %q: %v", versionOld, err)
+			t.Fatal(err)
 		}
-		if parsedOld.NE(minExpectedHelmVersion) {
+		t.Logf("installed helm version: %s", versionOld)
+		if versionOld.NE(minExpectedHelmVersion) {
 			t.Fatalf("helm version mismatch: expected %q, got %q", minExpectedHelmVersion, versionOld)
 		}
 
@@ -126,14 +124,13 @@ func TestHelmInstall(t *testing.T) {
 		}
 
 		t.Log("checking upgraded helm version")
-		versionNew := addons.HelmVersion(runner)
-		t.Logf("upgraded helm version: %s (from %s)", versionNew, versionOld)
-		parsedNew, err := semver.Parse(strings.TrimPrefix(versionNew, "v"))
+		versionNew, err := addons.HelmVersion(runner)
 		if err != nil {
-			t.Fatalf("failed to parse helm version: %q: %v", versionNew, err)
+			t.Fatal(err)
 		}
-		if parsedNew.LTE(minExpectedHelmVersion) {
-			t.Fatalf("installed version %q not newer than older version %q", parsedNew, minExpectedHelmVersion)
+		t.Logf("upgraded helm version: %s (from %s)", versionNew, versionOld)
+		if versionNew.LTE(minExpectedHelmVersion) {
+			t.Fatalf("upgraded version %q not newer than older version %q", versionNew, minExpectedHelmVersion)
 		}
 	})
 
@@ -148,11 +145,11 @@ func TestHelmInstall(t *testing.T) {
 		}
 
 		t.Log("checking first helm version")
-		firstVersion := addons.HelmVersion(runner)
-		t.Logf("first helm version: %s", firstVersion)
-		if firstVersion == "" {
-			t.Fatalf("helm not found at /usr/bin/helm")
+		firstVersion, err := addons.HelmVersion(runner)
+		if err != nil {
+			t.Fatal(err)
 		}
+		t.Logf("first helm version: %s", firstVersion)
 
 		t.Logf("installing helm %s again", minExpectedHelmVersion)
 		err = addons.InstallHelm(runner, addons.HelmOptions{Version: minExpectedHelmVersion.String()})
@@ -161,13 +158,13 @@ func TestHelmInstall(t *testing.T) {
 		}
 
 		t.Log("checking second helm version")
-		secondVersion := addons.HelmVersion(runner)
-		t.Logf("second helm version: %s", secondVersion)
-		if secondVersion == "" {
-			t.Fatalf("helm not found at /usr/bin/helm")
+		secondVersion, err := addons.HelmVersion(runner)
+		if err != nil {
+			t.Fatal(err)
 		}
-		if firstVersion != secondVersion {
-			t.Fatalf("helm version changed after second InstallHelm call: first %q, second %q", firstVersion, secondVersion)
+		t.Logf("second helm version: %s", secondVersion)
+		if firstVersion.NE(secondVersion) {
+			t.Fatalf("helm version changed: first %q, second %q", firstVersion, secondVersion)
 		}
 	})
 }

--- a/test/integration/helm_test.go
+++ b/test/integration/helm_test.go
@@ -50,7 +50,7 @@ func TestHelmInstall(t *testing.T) {
 	profile := UniqueProfileName("helm")
 	// TODO: update the timeout based on data from recent runs (3*p95 once data is available)
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
-	defer CleanupWithLogs(t, profile, cancel)
+	t.Cleanup(func() { CleanupWithLogs(t, profile, cancel) })
 
 	startArgs := append([]string{"start", "-p", profile, "--memory=3072", "--alsologtostderr"}, StartArgs()...)
 	_, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
@@ -67,7 +67,7 @@ func TestHelmInstall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create api client: %v", err)
 	}
-	defer api.Close()
+	t.Cleanup(func() { api.Close() })
 
 	cp, err := config.ControlPlane(*cc)
 	if err != nil {

--- a/test/integration/helm_test.go
+++ b/test/integration/helm_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"k8s.io/minikube/pkg/addons"
+	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/machine"
 	_ "k8s.io/minikube/pkg/minikube/registry/drvs"
@@ -58,31 +59,7 @@ func TestHelmInstall(t *testing.T) {
 		t.Fatalf("failed to start minikube: %v", err)
 	}
 
-	cc, err := config.Load(profile)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	api, err := machine.NewAPIClient(&run.CommandOptions{NonInteractive: true})
-	if err != nil {
-		t.Fatalf("failed to create api client: %v", err)
-	}
-	t.Cleanup(func() { api.Close() })
-
-	cp, err := config.ControlPlane(*cc)
-	if err != nil {
-		t.Fatalf("failed to get control plane node: %v", err)
-	}
-
-	host, err := machine.LoadHost(api, config.MachineName(*cc, cp))
-	if err != nil {
-		t.Fatalf("failed to load host: %v", err)
-	}
-
-	runner, err := machine.CommandRunner(host)
-	if err != nil {
-		t.Fatalf("failed to get command runner: %v", err)
-	}
+	runner := runnerForProfile(t, profile)
 
 	// Check that the guest has outbound internet access by probing the Helm download endpoint.
 	// On Prow CI with docker driver, the guest container may not have outbound connectivity.
@@ -189,4 +166,37 @@ func TestHelmInstall(t *testing.T) {
 			t.Fatalf("helm version changed after second InstallHelm call: first %q, second %q", firstVersion, secondVersion)
 		}
 	})
+}
+
+// runnerForProfile returns a command runner for the control plane node of the given profile.
+func runnerForProfile(t *testing.T, profile string) command.Runner {
+	t.Helper()
+
+	cc, err := config.Load(profile)
+	if err != nil {
+		t.Fatalf("failed to load config for %s: %v", profile, err)
+	}
+
+	api, err := machine.NewAPIClient(&run.CommandOptions{NonInteractive: true})
+	if err != nil {
+		t.Fatalf("failed to create api client: %v", err)
+	}
+	t.Cleanup(func() { api.Close() })
+
+	cp, err := config.ControlPlane(*cc)
+	if err != nil {
+		t.Fatalf("failed to get control plane node for %s: %v", profile, err)
+	}
+
+	host, err := machine.LoadHost(api, config.MachineName(*cc, cp))
+	if err != nil {
+		t.Fatalf("failed to load host for %s: %v", profile, err)
+	}
+
+	runner, err := machine.CommandRunner(host)
+	if err != nil {
+		t.Fatalf("failed to get command runner for %s: %v", profile, err)
+	}
+
+	return runner
 }

--- a/test/integration/helm_test.go
+++ b/test/integration/helm_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"os/exec"
-	"strings"
 	"testing"
 	"time"
 
@@ -92,7 +91,7 @@ func TestHelmInstall(t *testing.T) {
 		t.Log("installing helm latest version")
 		err = addons.InstallHelm(runner, addons.HelmOptions{})
 		if err != nil {
-			t.Fatalf("InstallHelm failed: %v", err)
+			t.Fatal(err)
 		}
 
 		version, err := addons.HelmVersion(runner)
@@ -110,9 +109,9 @@ func TestHelmInstall(t *testing.T) {
 	// calling InstallHelm with HelmOptions{} (defaults to latest) will correctly upgrade it to the latest version.
 	t.Run("Upgrade", func(t *testing.T) {
 		t.Logf("installing helm %s", minExpectedHelmVersion)
-		err := addons.InstallHelm(runner, addons.HelmOptions{Version: minExpectedHelmVersion.String()})
+		err := addons.InstallHelm(runner, addons.HelmOptions{Version: &minExpectedHelmVersion})
 		if err != nil {
-			t.Fatalf("failed to install helm %s: %v", minExpectedHelmVersion, err)
+			t.Fatal(err)
 		}
 
 		t.Log("checking installed helm version")
@@ -128,7 +127,7 @@ func TestHelmInstall(t *testing.T) {
 		t.Log("upgrading helm to latest version")
 		err = addons.InstallHelm(runner, addons.HelmOptions{})
 		if err != nil {
-			t.Fatalf("failed to upgrade helm: %v", err)
+			t.Fatal(err)
 		}
 
 		t.Log("checking upgraded helm version")
@@ -147,9 +146,9 @@ func TestHelmInstall(t *testing.T) {
 	// running InstallHelm again is a no-op and does not modify or reinstall it.
 	t.Run("NoChange", func(t *testing.T) {
 		t.Logf("installing helm %s", minExpectedHelmVersion)
-		err := addons.InstallHelm(runner, addons.HelmOptions{Version: minExpectedHelmVersion.String()})
+		err := addons.InstallHelm(runner, addons.HelmOptions{Version: &minExpectedHelmVersion})
 		if err != nil {
-			t.Fatalf("failed to install helm %s: %v", minExpectedHelmVersion, err)
+			t.Fatal(err)
 		}
 
 		t.Log("checking first helm version")
@@ -160,9 +159,9 @@ func TestHelmInstall(t *testing.T) {
 		t.Logf("first helm version: %s", firstVersion)
 
 		t.Logf("installing helm %s again", minExpectedHelmVersion)
-		err = addons.InstallHelm(runner, addons.HelmOptions{Version: minExpectedHelmVersion.String()})
+		err = addons.InstallHelm(runner, addons.HelmOptions{Version: &minExpectedHelmVersion})
 		if err != nil {
-			t.Fatalf("failed to reinstall helm: %v", err)
+			t.Fatal(err)
 		}
 
 		t.Log("checking second helm version")

--- a/test/integration/helm_test.go
+++ b/test/integration/helm_test.go
@@ -34,17 +34,18 @@ import (
 	"k8s.io/minikube/pkg/minikube/run"
 )
 
-// minExpectedHelmVersion is the minimum helm version we expect to be installed.
-// We cannot check for the exact latest version because during Helm release rollouts,
-// CDN propagation delays can cause our version query and the get_helm.sh install script
-// to see different versions, leading to flaky test failures.
+// minExpectedHelmVersion is the minimum helm version we expect to be
+// installed. We check ">= minimum" rather than "== latest" because CDN
+// propagation delays during Helm releases can make the install script and
+// our version query see different versions, causing flaky failures.
 // See https://github.com/kubernetes/minikube/issues/23323
-// Bumped occasionally (not on every release) to catch the CDN serving something
-// wildly stale or broken, without needing to track the exact current latest.
+//
+// Bump this occasionally to catch the CDN serving something stale or
+// broken. It doesn't need to track every Helm release.
 var minExpectedHelmVersion = semver.Version{Major: 3, Minor: 20}
 
-// TestHelmInstall integration test verifies helm installation, upgrade, and no-change behavior inside a live guest VM.
-// We test this flow because installing the latest helm allows self-healing and updating the cluster when Helm is missing, outdated, or broken.
+// TestHelmInstall verifies that InstallHelm can install, upgrade, and
+// re-install helm inside a live node.
 func TestHelmInstall(t *testing.T) {
 	MaybeParallel(t)
 
@@ -62,18 +63,17 @@ func TestHelmInstall(t *testing.T) {
 
 	runner := runnerForProfile(t, profile)
 
-	// Check that the guest has outbound internet access by probing the Helm download endpoint.
-	// On Prow CI with docker driver, the guest container may not have outbound connectivity.
+	// Skip if the node has no internet — helm install downloads from
+	// get.helm.sh which requires outbound connectivity.
 	t.Log("checking network connectivity")
 	_, err = runner.RunCmd(exec.Command("curl", "-fsSL", "--max-time", "10", "-o", "/dev/null", "https://get.helm.sh/helm3-latest-version"))
 	if err != nil {
 		t.Skip("skipping: guest VM/container has no outbound internet access (this is required to download helm): https://github.com/kubernetes/minikube/issues/23275")
 	}
 
-	// 1. Install test
-	// The minikube ISO and kicbase images already come with Helm pre-installed.
-	// We delete the Helm binary here to simulate a broken cluster (e.g. if a user manually deleted or corrupted it).
-	// This test ensures that installing the latest helm allows self-healing and recovering when Helm is missing or broken.
+	// Verify that InstallHelm installs helm when it is not installed. This
+	// happens when enabling the first helm-based addon. Since /usr/bin is not
+	// persisted, this happens again after restarting a stopped cluster.
 	t.Run("Install", func(t *testing.T) {
 		t.Log("removing helm to simulate missing binary")
 		_, err := runner.RunCmd(exec.Command("sudo", "rm", "-f", "/usr/bin/helm"))
@@ -104,9 +104,8 @@ func TestHelmInstall(t *testing.T) {
 		}
 	})
 
-	// 2. Upgrade test
-	// This test ensures that if minExpectedHelmVersion is installed at /usr/bin/helm,
-	// calling InstallHelm with HelmOptions{} (defaults to latest) will correctly upgrade it to the latest version.
+	// Verify that InstallHelm upgrades an older helm to the latest
+	// version. This functionality is not used yet by minikube.
 	t.Run("Upgrade", func(t *testing.T) {
 		t.Logf("installing helm %s", minExpectedHelmVersion)
 		err := addons.InstallHelm(runner, addons.HelmOptions{Version: &minExpectedHelmVersion})
@@ -141,9 +140,8 @@ func TestHelmInstall(t *testing.T) {
 		}
 	})
 
-	// 3. No Change test
-	// This test verifies that if Helm is already installed in /usr/bin/helm,
-	// running InstallHelm again is a no-op and does not modify or reinstall it.
+	// Verify that InstallHelm with a pinned version is idempotent — running
+	// it twice does not modify the binary. This is not used yet by minikube.
 	t.Run("NoChange", func(t *testing.T) {
 		t.Logf("installing helm %s", minExpectedHelmVersion)
 		err := addons.InstallHelm(runner, addons.HelmOptions{Version: &minExpectedHelmVersion})

--- a/test/integration/helm_test.go
+++ b/test/integration/helm_test.go
@@ -53,6 +53,7 @@ func TestHelmInstall(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	t.Cleanup(func() { CleanupWithLogs(t, profile, cancel) })
 
+	t.Logf("starting minikube profile %s", profile)
 	startArgs := append([]string{"start", "-p", profile, "--memory=3072", "--alsologtostderr"}, StartArgs()...)
 	_, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
 	if err != nil {
@@ -63,6 +64,7 @@ func TestHelmInstall(t *testing.T) {
 
 	// Check that the guest has outbound internet access by probing the Helm download endpoint.
 	// On Prow CI with docker driver, the guest container may not have outbound connectivity.
+	t.Log("checking network connectivity")
 	_, err = runner.RunCmd(exec.Command("curl", "-fsSL", "--max-time", "10", "-o", "/dev/null", "https://get.helm.sh/helm3-latest-version"))
 	if err != nil {
 		t.Skip("skipping: guest VM/container has no outbound internet access (this is required to download helm): https://github.com/kubernetes/minikube/issues/23275")
@@ -73,11 +75,13 @@ func TestHelmInstall(t *testing.T) {
 	// We delete the Helm binary here to simulate a broken cluster (e.g. if a user manually deleted or corrupted it).
 	// This test ensures that installing the latest helm allows self-healing and recovering when Helm is missing or broken.
 	t.Run("Install", func(t *testing.T) {
+		t.Log("removing helm to simulate missing binary")
 		_, err := runner.RunCmd(exec.Command("sudo", "rm", "-f", "/usr/bin/helm"))
 		if err != nil {
-			t.Fatalf("failed to delete helm inside guest: %v", err)
+			t.Fatalf("failed to remove helm: %v", err)
 		}
 
+		t.Log("installing helm latest version")
 		err = addons.InstallHelm(runner, addons.HelmOptions{})
 		if err != nil {
 			t.Fatalf("InstallHelm failed: %v", err)
@@ -98,13 +102,13 @@ func TestHelmInstall(t *testing.T) {
 	// This test ensures that if minExpectedHelmVersion is installed at /usr/bin/helm,
 	// calling InstallHelm with HelmOptions{} (defaults to latest) will correctly upgrade it to the latest version.
 	t.Run("Upgrade", func(t *testing.T) {
-		// Install minExpectedHelmVersion directly to /usr/bin/helm
+		t.Logf("installing helm %s", minExpectedHelmVersion)
 		err := addons.InstallHelm(runner, addons.HelmOptions{Version: minExpectedHelmVersion.String()})
 		if err != nil {
 			t.Fatalf("failed to install helm %s: %v", minExpectedHelmVersion, err)
 		}
 
-		// Verify the pinned helm version was installed and is executable
+		t.Log("checking installed helm version")
 		versionOld := addons.HelmVersion(runner)
 		t.Logf("installed helm version: %s (expected %s)", versionOld, minExpectedHelmVersion)
 		parsedOld, err := semver.Parse(strings.TrimPrefix(versionOld, "v"))
@@ -115,13 +119,13 @@ func TestHelmInstall(t *testing.T) {
 			t.Fatalf("helm version mismatch: expected %q, got %q", minExpectedHelmVersion, versionOld)
 		}
 
-		// Run InstallHelm, which should download and install the latest helm into /usr/bin/helm
+		t.Log("upgrading helm to latest version")
 		err = addons.InstallHelm(runner, addons.HelmOptions{})
 		if err != nil {
-			t.Fatalf("InstallHelm failed: %v", err)
+			t.Fatalf("failed to upgrade helm: %v", err)
 		}
 
-		// Verify that a newer version of helm has been installed in /usr/bin/helm
+		t.Log("checking upgraded helm version")
 		versionNew := addons.HelmVersion(runner)
 		t.Logf("upgraded helm version: %s (from %s)", versionNew, versionOld)
 		parsedNew, err := semver.Parse(strings.TrimPrefix(versionNew, "v"))
@@ -137,26 +141,26 @@ func TestHelmInstall(t *testing.T) {
 	// This test verifies that if Helm is already installed in /usr/bin/helm,
 	// running InstallHelm again is a no-op and does not modify or reinstall it.
 	t.Run("NoChange", func(t *testing.T) {
-		// Run InstallHelm to ensure the pinned helm version is present
+		t.Logf("installing helm %s", minExpectedHelmVersion)
 		err := addons.InstallHelm(runner, addons.HelmOptions{Version: minExpectedHelmVersion.String()})
 		if err != nil {
-			t.Fatalf("InstallHelm failed: %v", err)
+			t.Fatalf("failed to install helm %s: %v", minExpectedHelmVersion, err)
 		}
 
-		// Retrieve current helm version details
+		t.Log("checking first helm version")
 		firstVersion := addons.HelmVersion(runner)
 		t.Logf("first helm version: %s", firstVersion)
 		if firstVersion == "" {
 			t.Fatalf("helm not found at /usr/bin/helm")
 		}
 
-		// Run InstallHelm again with the same pinned version
+		t.Logf("installing helm %s again", minExpectedHelmVersion)
 		err = addons.InstallHelm(runner, addons.HelmOptions{Version: minExpectedHelmVersion.String()})
 		if err != nil {
-			t.Fatalf("InstallHelm second call failed: %v", err)
+			t.Fatalf("failed to reinstall helm: %v", err)
 		}
 
-		// Retrieve helm version details again and compare
+		t.Log("checking second helm version")
 		secondVersion := addons.HelmVersion(runner)
 		t.Logf("second helm version: %s", secondVersion)
 		if secondVersion == "" {

--- a/test/integration/helm_test.go
+++ b/test/integration/helm_test.go
@@ -20,6 +20,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"strings"
 	"testing"
@@ -80,6 +81,13 @@ func TestHelmInstall(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to remove helm: %v", err)
 		}
+
+		t.Log("checking helm version with missing binary")
+		_, err = addons.HelmVersion(runner)
+		if !errors.Is(err, addons.ErrHelmNotInstalled) {
+			t.Fatalf("expected ErrHelmNotInstalled, got: %v", err)
+		}
+		t.Logf("helm version error: %v", err)
 
 		t.Log("installing helm latest version")
 		err = addons.InstallHelm(runner, addons.HelmOptions{})


### PR DESCRIPTION
Clean up the helm addon code and integration test to improve error
handling, type safety, and test readability.

## Consistent exit codes across all runners

All runners now return exit code 127 for missing binaries. SSHRunner
and kicRunner already did this naturally (via shell / docker exec), but
execRunner did not — it calls execve directly with no shell, so a
missing binary returned ExitCode 0. This broke `HelmVersion` on the
none driver.

## HelmVersion error handling

`HelmVersion` now returns `(semver.Version, error)` instead of a raw
string. When helm is not installed (the common case — `/usr/bin/` is on
a non-persistent filesystem and lost on every cluster stop/start), the
error is short and clear:

    helm is not installed: bash: /usr/bin/helm: No such file or directory

Unexpected failures return the full runner error with stdout/stderr for
debugging:

    failed to run helm version: /usr/bin/helm version ...: exit status 1
    stdout:
    ...
    stderr:
    ...

Previously, errors were silently dropped and `"minikube logs"` showed
no evidence of why helm was reinstalled.

## Type safety

`HelmOptions.Version` changed from `string` to `*semver.Version`:
- `nil` clearly means "install latest"
- Non-nil means "install exactly this version"
- No redundant string/parse/string round-trips

## Test improvements

- Use `t.Cleanup` instead of `defer` for robustness with parallel subtests
- Extract `runnerForProfile` helper to reduce boilerplate
- Add `t.Log` progress lines for easier CI debugging and parallel output filtering
- Verify `HelmVersion` returns `ErrHelmNotInstalled` when helm is missing
- Rewrite comments to document real use cases instead of narrating code

## Example test run

The new test logs make it easy to filter test logs when running tests in parallel.

```console
% timestamp make integration TEST_ARGS="-minikube-start-args='--driver=vfkit' -test.run 'TestHelmInstall'" | grep -E '(TestHelmInstall|helm_test.go)'
[    0.000] make integration "TEST_ARGS=-minikube-start-args='--driver=vfkit' -test.run 'TestHelmInstall'"
[   16.406] go test -ldflags="-X k8s.io/minikube/pkg/version.version=v1.38.1 -X k8s.io/minikube/pkg/version.isoVersion=v1.38.0-1784111624-23365 -X k8s.io/minikube/pkg/version.gitCommitID="eddada234f1f6f28b75e8825c04e793aba63d2f8" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -v -test.timeout=90m ./test/integration --tags="integration libvirt_dlopen" -minikube-start-args='--driver=vfkit' -test.run 'TestHelmInstall' 2>&1 | tee "./out/testout_eddada234.txt"
[   21.773] === RUN   TestHelmInstall
[   21.773] === PAUSE TestHelmInstall
[   21.773] === CONT  TestHelmInstall
[   21.773]     helm_test.go:57: starting minikube profile helm-942000
[   21.773]     helm_test.go:59: (dbg) Run:  out/minikube start -p helm-942000 --memory=3072 --alsologtostderr --driver=vfkit
[   39.820]     helm_test.go:59: (dbg) Done: out/minikube start -p helm-942000 --memory=3072 --alsologtostderr --driver=vfkit: (18.046858125s)
[   39.822]     helm_test.go:68: checking network connectivity
[   40.218] === RUN   TestHelmInstall/Install
[   40.218]     helm_test.go:78: removing helm to simulate missing binary
[   40.228]     helm_test.go:84: checking helm version with missing binary
[   40.231]     helm_test.go:89: helm version error: helm is not installed: bash: line 1: /usr/bin/helm: No such file or directory
[   40.231]     helm_test.go:91: installing helm latest version
[   42.421]     helm_test.go:101: installed helm version: 3.21.3
[   42.421] === RUN   TestHelmInstall/Upgrade
[   42.421]     helm_test.go:110: installing helm 3.20.0
[   44.210]     helm_test.go:116: checking installed helm version
[   44.260]     helm_test.go:121: installed helm version: 3.20.0
[   44.260]     helm_test.go:126: upgrading helm to latest version
[   46.267]     helm_test.go:132: checking upgraded helm version
[   46.303]     helm_test.go:137: upgraded helm version: 3.21.3 (from 3.20.0)
[   46.303] === RUN   TestHelmInstall/NoChange
[   46.303]     helm_test.go:146: installing helm 3.20.0
[   48.040]     helm_test.go:152: checking first helm version
[   48.075]     helm_test.go:157: first helm version: 3.20.0
[   48.075]     helm_test.go:159: installing helm 3.20.0 again
[   48.279]     helm_test.go:165: checking second helm version
[   48.308]     helm_test.go:170: second helm version: 3.20.0
[   48.308] === NAME  TestHelmInstall
[   48.448] --- PASS: TestHelmInstall (26.67s)
[   48.448]     --- PASS: TestHelmInstall/Install (2.20s)
[   48.448]     --- PASS: TestHelmInstall/Upgrade (3.88s)
[   48.448]     --- PASS: TestHelmInstall/NoChange (2.01s)
```
