### PR TITLE
Added build file generated by delve to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 *.a
 *.so
+__debug_bin*
 
 # Folders
 .cache


### PR DESCRIPTION
The dlv debugger that VS Code uses creates a _debug binary file for the IDE to use, but if VS Code crashes or is closed during the session the binary file fails to be cleaned up. Stopping the debug session also causes this behavior as well.
