### PR TITLE
Validate memory requirements for VM drivers

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1170,6 +1170,13 @@ func suggestMemoryAllocation(sysLimit, containerLimit, nodes int) int {
 	return suggested
 }
 
+func memoryRequirements(drvName string) (minimum, recommended int) {
+	if driver.IsVM(drvName) && !driver.IsSSH(drvName) {
+		return minVMUsableMem, minVMRecommendedMem
+	}
+	return minUsableMem, minRecommendedMem
+}
+
 // validateRequestedMemorySize validates the memory size matches the minimum recommended
 func validateRequestedMemorySize(req int, drvName string) {
 	// TODO: Fix MB vs MiB confusion
@@ -1177,21 +1184,22 @@ func validateRequestedMemorySize(req int, drvName string) {
 	if err != nil {
 		klog.Warningf("Unable to query memory limits: %v", err)
 	}
+	minimumMemory, recommendedMemory := memoryRequirements(drvName)
 
 	// Detect if their system doesn't have enough memory to work with.
-	if driver.IsKIC(drvName) && containerLimit < minUsableMem {
+	if driver.IsKIC(drvName) && containerLimit < minimumMemory {
 		if driver.IsDockerDesktop(drvName) {
 			if runtime.GOOS == "darwin" {
-				exitIfNotForced(reason.RsrcInsufficientDarwinDockerMemory, "Docker Desktop only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": containerLimit, "req": minUsableMem, "recommend": "2.25 GB"})
+				exitIfNotForced(reason.RsrcInsufficientDarwinDockerMemory, "Docker Desktop only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": containerLimit, "req": minimumMemory, "recommend": "2.25 GB"})
 			} else {
-				exitIfNotForced(reason.RsrcInsufficientWindowsDockerMemory, "Docker Desktop only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": containerLimit, "req": minUsableMem, "recommend": "2.25 GB"})
+				exitIfNotForced(reason.RsrcInsufficientWindowsDockerMemory, "Docker Desktop only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": containerLimit, "req": minimumMemory, "recommend": "2.25 GB"})
 			}
 		}
-		exitIfNotForced(reason.RsrcInsufficientContainerMemory, "{{.driver}} only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": containerLimit, "driver": drvName, "req": minUsableMem})
+		exitIfNotForced(reason.RsrcInsufficientContainerMemory, "{{.driver}} only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": containerLimit, "driver": drvName, "req": minimumMemory})
 	}
 
-	if sysLimit < minUsableMem {
-		exitIfNotForced(reason.RsrcInsufficientSysMemory, "System only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": sysLimit, "req": minUsableMem})
+	if sysLimit < minimumMemory {
+		exitIfNotForced(reason.RsrcInsufficientSysMemory, "System only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": sysLimit, "req": minimumMemory})
 	}
 
 	// if --memory=no-limit, ignore remaining checks
@@ -1199,18 +1207,18 @@ func validateRequestedMemorySize(req int, drvName string) {
 		return
 	}
 
-	if req < minUsableMem {
-		exitIfNotForced(reason.RsrcInsufficientReqMemory, "Requested memory allocation {{.requested}}MiB is less than the usable minimum of {{.minimum_memory}}MB", out.V{"requested": req, "minimum_memory": minUsableMem})
+	if req < minimumMemory {
+		exitIfNotForced(reason.RsrcInsufficientReqMemory, "Requested memory allocation {{.requested}}MiB is less than the usable minimum of {{.minimum_memory}}MB", out.V{"requested": req, "minimum_memory": minimumMemory})
 	}
-	if req < minRecommendedMem {
+	if req < recommendedMemory {
 		if driver.IsDockerDesktop(drvName) {
 			if runtime.GOOS == "darwin" {
-				out.WarnReason(reason.RsrcInsufficientDarwinDockerMemory, "Docker Desktop only has {{.size}}MiB available, you may encounter application deployment failures.", out.V{"size": containerLimit, "req": minUsableMem, "recommend": "2.25 GB"})
+				out.WarnReason(reason.RsrcInsufficientDarwinDockerMemory, "Docker Desktop only has {{.size}}MiB available, you may encounter application deployment failures.", out.V{"size": containerLimit, "req": minimumMemory, "recommend": "2.25 GB"})
 			} else {
-				out.WarnReason(reason.RsrcInsufficientWindowsDockerMemory, "Docker Desktop only has {{.size}}MiB available, you may encounter application deployment failures.", out.V{"size": containerLimit, "req": minUsableMem, "recommend": "2.25 GB"})
+				out.WarnReason(reason.RsrcInsufficientWindowsDockerMemory, "Docker Desktop only has {{.size}}MiB available, you may encounter application deployment failures.", out.V{"size": containerLimit, "req": minimumMemory, "recommend": "2.25 GB"})
 			}
 		} else {
-			out.WarnReason(reason.RsrcInsufficientReqMemory, "Requested memory allocation ({{.requested}}MB) is less than the recommended minimum {{.recommend}}MB. Deployments may fail.", out.V{"requested": req, "recommend": minRecommendedMem})
+			out.WarnReason(reason.RsrcInsufficientReqMemory, "Requested memory allocation ({{.requested}}MB) is less than the recommended minimum {{.recommend}}MB. Deployments may fail.", out.V{"requested": req, "recommend": recommendedMemory})
 		}
 	}
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -114,6 +114,8 @@ const (
 	nativeSSH               = "native-ssh"
 	minUsableMem            = 1800 // Kubernetes (kubeadm) will not start with less
 	minRecommendedMem       = 1900 // Warn at no lower than existing configurations
+	minVMUsableMem          = 2500 // VM drivers cannot start reliably with less
+	minVMRecommendedMem     = 3072 // Default and tested VM allocation
 	minimumCPUS             = 2
 	minimumDiskSize         = 2000
 	autoUpdate              = "auto-update-drivers"

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -114,8 +114,8 @@ const (
 	nativeSSH               = "native-ssh"
 	minUsableMem            = 1800 // Kubernetes (kubeadm) will not start with less
 	minRecommendedMem       = 1900 // Warn at no lower than existing configurations
-	minVMUsableMem          = 2500 // VM drivers cannot start reliably with less
-	minVMRecommendedMem     = 3072 // Default and tested VM allocation
+	minVMUsableMem          = 2500 // See https://github.com/kubernetes/minikube/issues/23317
+	minVMRecommendedMem     = 3072 // Warn below the default and tested VM allocation
 	minimumCPUS             = 2
 	minimumDiskSize         = 2000
 	autoUpdate              = "auto-update-drivers"

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -304,6 +304,30 @@ func TestSuggestMemoryAllocation(t *testing.T) {
 	}
 }
 
+func TestMemoryRequirements(t *testing.T) {
+	tests := []struct {
+		name            string
+		driver          string
+		wantMinimum     int
+		wantRecommended int
+	}{
+		{"KVM2", driver.KVM2, 2500, 3072},
+		{"VirtualBox", driver.VirtualBox, 2500, 3072},
+		{"Docker", driver.Docker, 1800, 1900},
+		{"none", driver.None, 1800, 1900},
+		{"SSH", driver.SSH, 1800, 1900},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotMinimum, gotRecommended := memoryRequirements(test.driver)
+			if gotMinimum != test.wantMinimum || gotRecommended != test.wantRecommended {
+				t.Errorf("memoryRequirements(%q) = (%d, %d), want (%d, %d)", test.driver, gotMinimum, gotRecommended, test.wantMinimum, test.wantRecommended)
+			}
+		})
+	}
+}
+
 func TestBaseImageFlagDriverCombo(t *testing.T) {
 	tests := []struct {
 		driver        string

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -304,30 +304,6 @@ func TestSuggestMemoryAllocation(t *testing.T) {
 	}
 }
 
-func TestMemoryRequirements(t *testing.T) {
-	tests := []struct {
-		name            string
-		driver          string
-		wantMinimum     int
-		wantRecommended int
-	}{
-		{"KVM2", driver.KVM2, 2500, 3072},
-		{"VirtualBox", driver.VirtualBox, 2500, 3072},
-		{"Docker", driver.Docker, 1800, 1900},
-		{"none", driver.None, 1800, 1900},
-		{"SSH", driver.SSH, 1800, 1900},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			gotMinimum, gotRecommended := memoryRequirements(test.driver)
-			if gotMinimum != test.wantMinimum || gotRecommended != test.wantRecommended {
-				t.Errorf("memoryRequirements(%q) = (%d, %d), want (%d, %d)", test.driver, gotMinimum, gotRecommended, test.wantMinimum, test.wantRecommended)
-			}
-		})
-	}
-}
-
 func TestBaseImageFlagDriverCombo(t *testing.T) {
 	tests := []struct {
 		driver        string


### PR DESCRIPTION
## What changed

- use a 2500 MB minimum for VM drivers while preserving the existing 1800 MB minimum for container, bare-metal, and SSH drivers
- warn VM-driver users below the tested 3072 MB recommendation
- add focused coverage for VM and non-VM requirement selection

## Why

VM drivers currently reuse the general 1800/1900 MB thresholds. That allows configurations such as KVM2 with 2048 MB to reach VM provisioning even though they cannot start reliably, which surfaces later as an unrelated-looking IP timeout.

Before:

```text
minikube start --driver=kvm2 --memory=2048
...
waiting for IP: domain minikube didn't return IP after 1m30s
```

After this change, the same request exits during resource validation because 2048 MB is below the 2500 MB VM minimum. Requests from 2500 MB through 3071 MB continue with the existing low-memory warning, now using the 3072 MB VM recommendation.

Fixes #23317

## Validation

- `go test ./cmd/minikube/cmd -count=1`
- `go test ./pkg/minikube/driver -count=1`
- `TESTSUITE=unittest make test` with the repository-selected Go 1.26.4 toolchain
- `go vet ./cmd/minikube/cmd`
- `make gofmt`
- `TESTSUITE=boilerplate make test`
- `make out/minikube`
- repository-configured `golangci-lint` on `./cmd/minikube/cmd`: 0 issues

The repository-wide lint invocation reports four existing `revive` findings in untouched vfkit, krunkit, and parallels files. No changed file is involved.

This contribution was assisted by OpenAI Codex and manually reviewed and validated by the contributor.
