### PR TITLE
Skip Docker client initialization for non-Docker drivers

### DIFF
--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/cruntime"
 	"k8s.io/minikube/pkg/minikube/detect"
+	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/image"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/out"
@@ -97,7 +98,7 @@ func LoadCachedImages(cc *config.ClusterConfig, runner command.Runner, imgs []st
 	var g errgroup.Group
 
 	var imgClient *client.Client
-	if cr.Name() == "Docker" {
+	if driver.IsDocker(cc.Driver) && cr.Name() == "Docker" {
 		imgClient, err = client.NewClientWithOpts(client.FromEnv) // image client
 		if err != nil {
 			klog.Infof("couldn't get a local image daemon which might be ok: %v", err)


### PR DESCRIPTION
## Summary

`minikube start` could initialize a client for the host Docker daemon whenever the guest container runtime was Docker, even when Minikube was using a non-Docker driver such as `vfkit`.

For VM drivers, access to the host Docker daemon is unnecessary. When Docker Desktop is stopped or unavailable, attempting to initialize the Docker client can introduce unnecessary connection attempts and startup delays.

This PR guards Docker client initialization so it only occurs when Minikube is actually running with a Docker-based driver.

---

## Root Cause

The Docker client initialization was previously guarded only by the guest container runtime:

```go
if cr.Name() == "Docker" {
	imgClient, err = client.NewClientWithOpts(client.FromEnv)
	if err != nil {
		klog.Infof("couldn't get a local image daemon which might be ok: %v", err)
	}
}
```

This correctly checks whether Docker is the **guest container runtime**, but it does **not** verify that the selected Minikube driver is Docker.

As a result, VM drivers such as `vfkit` could still attempt to initialize a Docker client for the host even though the host Docker daemon is not required.

Example:

```
Driver: vfkit
Guest container runtime: Docker
```

In this configuration, Docker runs **inside the VM**, not on the host, so attempting to initialize a host Docker client is unnecessary.

---

## What this PR changes

Docker client initialization is now guarded by both:

- the selected Minikube driver
- the guest container runtime

```go
if driver.IsDocker(cc.Driver) && cr.Name() == "Docker" {
	imgClient, err = client.NewClientWithOpts(client.FromEnv)
	if err != nil {
		klog.Infof("couldn't get a local image daemon which might be ok: %v", err)
	}
}
```

The Docker client is now initialized **only when**:

- the selected driver is Docker, and
- the guest container runtime is Docker.

For non-Docker drivers (`vfkit`, `hyperkit`, `qemu`, `kvm`, etc.), the Docker client initialization is skipped and the existing image-loading path continues unchanged.

---

## Scope

This PR only changes the condition controlling Docker client initialization during `minikube start`.

---

## Testing

### Environment

```
OS: macOS 26.5.1
Architecture: amd64
Minikube: v1.38.1 (development build)
Driver: vfkit
Guest Runtime: Docker 28.5.2
Kubernetes: v1.36.2
```

---

### Functional verification

#### 1. Non-Docker driver

Docker Desktop stopped.

```bash
./out/minikube start \
  --profile=minikube-dev-tester \
  -d vfkit
```

Result:

- Cluster starts successfully
- No dependency on the host Docker daemon
- Existing image-loading behavior preserved

---

#### 2. Docker driver

Docker Desktop running.

```bash
./out/minikube start \
  --profile=minikube-dev-docker \
  -d docker
```

Result:

- Cluster starts successfully
- Existing Docker-driver behavior unchanged

---

## Startup timing

Startup timing was measured using both the previous build and the modified build. I noticed the new build starts up the cluster about 10 - 15 seconds earlier than the older the build.

Startup timing varied between runs because of factors outside this change, including:

- VM provisioning
- DHCP allocation
- Registry connectivity
- Host machine load

The purpose of this change is **not** to optimize startup time directly, but to eliminate unnecessary host Docker daemon initialization for non-Docker drivers.

---

## How to reproduce

### Before this change

Stop Docker Desktop.

```bash
time ./out/minikube start \
  --profile=minikube-dev-tester \
  -d vfkit \
  --container-runtime=docker \
  -v=9
```

Observe that Minikube initializes a Docker client even though the selected driver is not Docker.

---

### After this change

Stop Docker Desktop.

```bash
time ./out/minikube start \
  --profile=minikube-dev-tester \
  -d vfkit \
  --container-runtime=docker \
  -v=9
```

The Docker client initialization path is skipped for non-Docker drivers while preserving existing startup behavior.

---

Fixes #23349