### PR TITLE
fix(kvm2): check libvirt group membership before running virsh

### DIFF
--- a/pkg/minikube/registry/drvs/kvm2/kvm2.go
+++ b/pkg/minikube/registry/drvs/kvm2/kvm2.go
@@ -118,6 +118,36 @@ func status(_ *run.CommandOptions) registry.State {
 		return rs
 	}
 
+	// Check libvirt group membership before running any virsh commands.
+	// This avoids waiting on a potentially slow or hanging virsh call
+	// when we already know the user lacks the required permissions,
+	// and ensures a clear PR_KVM_USER_PERMISSION error is returned
+	// instead of the outer Status() timeout swallowing the real cause.
+	// See https://github.com/kubernetes/minikube/issues/23360
+	member, err := isCurrentUserLibvirtGroupMember()
+	if err != nil {
+		return registry.State{
+			Installed: true,
+			Running:   true,
+			// keep the error message in sync with reason.providerIssues(Kind.ID: "PR_KVM_USER_PERMISSION") regexp
+			Error:  fmt.Errorf("libvirt group membership check failed:\n%v", err.Error()),
+			Reason: "PR_KVM_USER_PERMISSION",
+			Fix:    "Check that libvirtd is properly installed and that you are a member of the appropriate libvirt group (remember to relogin for group changes to take effect!)",
+			Doc:    docURL,
+		}
+	}
+	if !member {
+		return registry.State{
+			Installed: true,
+			Running:   true,
+			// keep the error message in sync with reason.providerIssues(Kind.ID: "PR_KVM_USER_PERMISSION") regexp
+			Error:  errors.New("libvirt group membership check failed:\nuser is not a member of the appropriate libvirt group"),
+			Reason: "PR_KVM_USER_PERMISSION",
+			Fix:    "Check that libvirtd is properly installed and that you are a member of the appropriate libvirt group (remember to relogin for group changes to take effect!)",
+			Doc:    docURL,
+		}
+	}
+
 	// Allow no more than 6 seconds for querying state
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
 	defer cancel()
@@ -131,33 +161,6 @@ func status(_ *run.CommandOptions) registry.State {
 	cmd := exec.CommandContext(ctx, path, "domcapabilities", "--virttype", "kvm")
 	cmd.Env = append(os.Environ(), fmt.Sprintf("LIBVIRT_DEFAULT_URI=%s", defaultURI()))
 	out, err := cmd.CombinedOutput()
-
-	// If we fail to connect to libvirt, first check whether we're member of the libvirt group.
-	if err != nil {
-		member, err := isCurrentUserLibvirtGroupMember()
-		if err != nil {
-			return registry.State{
-				Installed: true,
-				Running:   true,
-				// keep the error message in sync with reason.providerIssues(Kind.ID: "PR_KVM_USER_PERMISSION") regexp
-				Error:  fmt.Errorf("libvirt group membership check failed:\n%v", err.Error()),
-				Reason: "PR_KVM_USER_PERMISSION",
-				Fix:    "Check that libvirtd is properly installed and that you are a member of the appropriate libvirt group (remember to relogin for group changes to take effect!)",
-				Doc:    docURL,
-			}
-		}
-		if !member {
-			return registry.State{
-				Installed: true,
-				Running:   true,
-				// keep the error message in sync with reason.providerIssues(Kind.ID: "PR_KVM_USER_PERMISSION") regexp
-				Error:  errors.New("libvirt group membership check failed:\nuser is not a member of the appropriate libvirt group"),
-				Reason: "PR_KVM_USER_PERMISSION",
-				Fix:    "Check that libvirtd is properly installed and that you are a member of the appropriate libvirt group (remember to relogin for group changes to take effect!)",
-				Doc:    docURL,
-			}
-		}
-	}
 
 	if ctx.Err() == context.DeadlineExceeded {
 		return registry.State{

--- a/pkg/minikube/registry/drvs/kvm2/kvm2.go
+++ b/pkg/minikube/registry/drvs/kvm2/kvm2.go
@@ -127,19 +127,14 @@ func status(_ *run.CommandOptions) registry.State {
 	member, err := isCurrentUserLibvirtGroupMember()
 	if err != nil {
 		return registry.State{
-			Installed: true,
-			Running:   true,
-			// keep the error message in sync with reason.providerIssues(Kind.ID: "PR_KVM_USER_PERMISSION") regexp
-			Error:  fmt.Errorf("libvirt group membership check failed:\n%v", err.Error()),
-			Reason: "PR_KVM_USER_PERMISSION",
-			Fix:    "Check that libvirtd is properly installed and that you are a member of the appropriate libvirt group (remember to relogin for group changes to take effect!)",
+			Error:  fmt.Errorf("failed to check libvirt group membership:\n%v", err.Error()),
+			Reason: "PR_KVM_GROUP_CHECK_FAILED",
+			Fix:    "This is likely an internal error. Please check that your system's user/group database is working correctly.",
 			Doc:    docURL,
 		}
 	}
 	if !member {
 		return registry.State{
-			Installed: true,
-			Running:   true,
 			// keep the error message in sync with reason.providerIssues(Kind.ID: "PR_KVM_USER_PERMISSION") regexp
 			Error:  errors.New("libvirt group membership check failed:\nuser is not a member of the appropriate libvirt group"),
 			Reason: "PR_KVM_USER_PERMISSION",


### PR DESCRIPTION
## What this PR does
Moves the **isCurrentUserLibvirtGroupMember()** check before the **virsh domcapabilities** call in the kvm2 driver's **status()** function.

## Why
Previously, the group membership check ran only *after* a failed **virsh** call. If **virsh** hung or was slow, the outer **Status()** timeout (20s) could fire first, returning an empty **DriverState{}** — which **selectDriver()** misinterpreted as "OS not supported," producing the misleading **DRV_UNSUPPORTED_OS** error instead of the correct **PR_KVM_USER_PERMISSION** error.

By checking group membership first, users who aren't in the **libvirt** group get a fast, clear, actionable error without waiting on **virsh** at all.

Fixes #23360

## Testing
- **go build ./pkg/minikube/registry/drvs/kvm2/...** passes
- Manually verified **isCurrentUserLibvirtGroupMember()** returns correctly on a local Ubuntu VM