### PR TITLE
Remove broken node start --delete-on-failure flag

### DIFF
--- a/cmd/minikube/cmd/node_start.go
+++ b/cmd/minikube/cmd/node_start.go
@@ -20,7 +20,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"k8s.io/minikube/cmd/minikube/cmd/flags"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
@@ -60,7 +59,7 @@ var nodeStartCmd = &cobra.Command{
 		}
 
 		register.Reg.SetStep(register.InitialSetup)
-		r, p, m, h, err := node.Provision(cc, n, viper.GetBool(deleteOnFailure), options)
+		r, p, m, h, err := node.Provision(cc, n, false, options)
 		if err != nil {
 			exit.Error(reason.GuestNodeProvision, "provisioning host for node", err)
 		}
@@ -86,6 +85,5 @@ var nodeStartCmd = &cobra.Command{
 }
 
 func init() {
-	nodeStartCmd.Flags().Bool(deleteOnFailure, false, "If set, delete the current cluster if start fails and try again. Defaults to false.")
 	nodeCmd.AddCommand(nodeStartCmd)
 }

--- a/site/content/en/docs/commands/node.md
+++ b/site/content/en/docs/commands/node.md
@@ -228,12 +228,6 @@ minikube node start NODE_NAME [flags]
 minikube node start m02
 ```
 
-### Options
-
-```
-      --delete-on-failure   If set, delete the current cluster if start fails and try again. Defaults to false.
-```
-
 ### Options inherited from parent commands
 
 ```


### PR DESCRIPTION
Viper has a single global flag namespace, but cobra registers flags per-command. A local flag only becomes visible to `viper.Get*()` if it is explicitly bound with `viper.BindPFlags()` for the command being run. Only `root`, `start`, and `delete` do this binding, so any other command reading a local flag via `viper.Get*()` is silently broken.

Two commands were affected:

- `minikube cache add --all` — the flag was registered on `addCacheCmd` but never bound to viper, so it was always read as `false` and images were only cached to the current profile, never to all running profiles.
- `minikube node start --delete-on-failure` — same issue: `viper.GetBool(deleteOnFailure)` always returned `false`, so a failed node start was never deleted and retried.

`BindPFlags` can't simply be added for these commands because flag names collide across commands (e.g. `--all` is also used by `cache delete` and `stop`), and since every command's `init()` runs at startup, binding one command's flags to the global viper namespace would clobber bindings for other commands using the same name.

## Fix

- `minikube node start --delete-on-failure` never worked and nobody has reported relying on it, so the flag is removed rather than wired up. `minikube start --delete-on-failure` is unaffected. (`minikube cache` is kept as it is).

Docs were regenerated (`make generate-docs`) to drop the removed command and flag.

Fixes #23347
