### PR TITLE
addons: Upgrade default guest Helm client to Helm 4

### DIFF
--- a/pkg/addons/helm.go
+++ b/pkg/addons/helm.go
@@ -110,7 +110,7 @@ func HelmVersion(runner command.Runner) (semver.Version, error) {
 // Use /usr/bin/helm which is always in the PATH, unlike /usr/local/bin.
 func InstallHelm(runner command.Runner, opts HelmOptions) error {
 	script := `
-		curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+		curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4
 		chmod 700 get_helm.sh
 		HELM_INSTALL_DIR=/usr/bin ./get_helm.sh`
 

--- a/test/integration/helm_test.go
+++ b/test/integration/helm_test.go
@@ -42,7 +42,7 @@ import (
 //
 // Bump this occasionally to catch the CDN serving something stale or
 // broken. It doesn't need to track every Helm release.
-var minExpectedHelmVersion = semver.Version{Major: 3, Minor: 20}
+var minExpectedHelmVersion = semver.Version{Major: 4, Minor: 2, Patch: 1}
 
 // TestHelmInstall verifies that InstallHelm can install, upgrade, and
 // re-install helm inside a live node.
@@ -66,7 +66,7 @@ func TestHelmInstall(t *testing.T) {
 	// Skip if the node has no internet — helm install downloads from
 	// get.helm.sh which requires outbound connectivity.
 	t.Log("checking network connectivity")
-	_, err = runner.RunCmd(exec.Command("curl", "-fsSL", "--max-time", "10", "-o", "/dev/null", "https://get.helm.sh/helm3-latest-version"))
+	_, err = runner.RunCmd(exec.Command("curl", "-fsSL", "--max-time", "10", "-o", "/dev/null", "https://get.helm.sh/helm4-latest-version"))
 	if err != nil {
 		t.Skip("skipping: guest VM/container has no outbound internet access (this is required to download helm): https://github.com/kubernetes/minikube/issues/23275")
 	}


### PR DESCRIPTION
## What this PR does / why we need it
  
Helm 3 is entering its End-Of-Life (EOL) timeline (final minor release scheduled for September 2026, security support ending in February 2027). Staying on Helm 3 past its EOL would trigger security scanners and expose minikube users to unpatched CVEs.                                                                                                                                                                                                                       
  
This PR upgrades the default Helm binary installer executed inside the minikube guest nodes from Helm 3 to Helm 4 by updating pkg/addons/helm.go and modifying the integration tests to target Helm 4 version tags.
  
### Key Changes:
  
  1. Installer Upgrade: Updated the helper script in` pkg/addons/helm.go` to download the official `get-helm-4 `installer script instead of `get-helm-3`.
  
  2. Version Checks: Updated the integration test suite in `test/integration/helm_test.go` to probe the Helm 4 latest version endpoint (`https://get.helm.sh/helm4-latest-version`).
   
  3. Upgrade Validation: Updated the upgrade validation test case to verify upgrading from an older Helm 4 version (`v4.0.0`) to the latest, rather than `v3.12.0.`


 fixes https://github.com/kubernetes/minikube/issues/23380

