### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/pkg/libmachine/mcnutils/utils.go
+++ b/pkg/libmachine/mcnutils/utils.go
@@ -123,10 +123,7 @@ func WaitFor(f func() bool) error {
 // was way overkill to include the whole module, so we just have these bits
 // that we're using here.
 func TruncateID(id string) string {
-	shortLen := 12
-	if len(id) < shortLen {
-		shortLen = len(id)
-	}
+	shortLen := min(len(id), 12)
 	return id[:shortLen]
 }
 

--- a/pkg/libmachine/versioncmp/compare.go
+++ b/pkg/libmachine/versioncmp/compare.go
@@ -87,10 +87,7 @@ func compareNumeric(v1, v2 string) int {
 		otherTab = strings.Split(v2, ".")
 	)
 
-	maxLen := len(currTab)
-	if len(otherTab) > maxLen {
-		maxLen = len(otherTab)
-	}
+	maxLen := max(len(otherTab), len(currTab))
 	for i := 0; i < maxLen; i++ {
 		var currInt, otherInt int
 


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.