### PR TITLE
Return an error when image build fails on some profiles

### DIFF
--- a/pkg/minikube/machine/build_images.go
+++ b/pkg/minikube/machine/build_images.go
@@ -132,6 +132,9 @@ func BuildImage(srcPath string, file string, tag string, push bool, env []string
 
 	klog.Infof("succeeded building to: %s", strings.Join(succeeded, " "))
 	klog.Infof("failed building to: %s", strings.Join(failed, " "))
+	if len(failed) > 0 {
+		return fmt.Errorf("failed to build image to profile(s): %s", strings.Join(failed, " "))
+	}
 	return nil
 }
 

--- a/test/integration/image_test.go
+++ b/test/integration/image_test.go
@@ -49,6 +49,7 @@ func TestImageBuild(t *testing.T) {
 			{"BuildWithDockerIgnore", validateImageBuildWithDockerIgnore},
 			{"BuildWithSpecifiedDockerfile", validateNormalImageBuildWithSpecifiedDockerfile},
 			{"validateImageBuildWithBuildEnv", validateImageBuildWithBuildEnv},
+			{"FailedBuildWithInvalidPath", validateFailedImageBuild},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
@@ -78,6 +79,18 @@ func validateNormalImageBuild(ctx context.Context, t *testing.T, profile string)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
 		t.Fatalf("failed to build image with args: %q : %v", rr.Command(), err)
+	}
+}
+
+// validateFailedImageBuild makes sure 'minikube image build' with an invalid path
+// exits with a non-zero code instead of silently succeeding.
+// Regression test for https://github.com/kubernetes/minikube/issues/12556
+func validateFailedImageBuild(ctx context.Context, t *testing.T, profile string) {
+	defer PostMortemLogs(t, profile)
+	args := []string{"image", "build", "-t", "aaa:latest", "./testdata/image-build/nonexistent", "-p", profile}
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	if err == nil {
+		t.Fatalf("expected a non-zero exit code building an invalid path, but the command succeeded: %q\n%s", rr.Command(), rr.Output())
 	}
 }
 


### PR DESCRIPTION
Fixes #12556

`minikube image build <invalid-path>` printed a build failure as a warning but exited 0, because `machine.BuildImage` always returned nil even when a profile/node failed.

This returns an error when any target failed, so the caller surfaces it via `exit.Error` and the command exits non-zero. The happy path is unchanged.

**Verification** (docker driver):

| command | before | after |
|---|---|---|
| `minikube image build /nonexistent` | exit 0 | exit 80, `Failed to build image: failed to build image to profile(s): minikube` |
| `minikube image build <valid dir>` | exit 0 | exit 0 |

Also adds an integration test case (`FailedBuildWithInvalidPath`) asserting a build with an invalid path exits non-zero.