### PR TITLE
docs: document WSL2 service access for the Docker driver

### DIFF
--- a/site/content/en/docs/drivers/docker.md
+++ b/site/content/en/docs/drivers/docker.md
@@ -15,7 +15,7 @@ The Docker driver allows you to install Kubernetes into an existing Docker insta
 
 - [Install Docker](https://docs.docker.com/engine/install/) 18.09 or higher (20.10 or higher is recommended)
 - amd64 or arm64 system.
-- If using WSL complete [these steps]({{<ref "/docs/tutorials/wsl_docker_driver">}}) first
+- If using WSL, complete [these steps]({{<ref "/docs/tutorials/wsl_docker_driver">}}) first.
 - Don't forget to follow this [step](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) to manage Docker as a non-root user.
 
 ## Usage
@@ -72,6 +72,8 @@ It is recommended to set the `--container-runtime` flag to "containerd".
 - On WSL2 (experimental - see [#5392](https://github.com/kubernetes/minikube/issues/5392)), you may need to run:
 
    `sudo mkdir /sys/fs/cgroup/systemd && sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd`.
+
+- On Windows and WSL 2 with the Docker driver, the node IP is not reachable directly from the host. To access your workloads, use `minikube service <service-name> --url` for `NodePort` services and `minikube tunnel` for `LoadBalancer` services. See [Setting Up WSL 2]({{<ref "/docs/tutorials/wsl_docker_driver">}}) for details.
 
 Also see [co/docker-driver open issues](https://github.com/kubernetes/minikube/labels/co%2Fdocker-driver).
 

--- a/site/content/en/docs/tutorials/wsl_docker_driver.md
+++ b/site/content/en/docs/tutorials/wsl_docker_driver.md
@@ -1,17 +1,60 @@
 ---
-title: "Setting Up WSL 2 & Docker Desktop"                                 
-linkTitle: "Setting Up WSL 2 & Docker Desktop"
+title: "Setting Up WSL 2 for the Docker driver"
+linkTitle: "Setting Up WSL 2"
 weight: 1
 date: 2022-01-12
 ---
 
 ## Overview
 
-- This guide will show you how to setup WSL 2 and Docker Desktop.
+This guide shows how to set up [WSL 2](https://learn.microsoft.com/windows/wsl/) on Windows so you can run minikube with the Docker driver, and how to reach your workloads from a Windows browser.
 
+There are two supported ways to provide Docker inside WSL 2:
+
+- **Docker Engine inside your WSL distribution** — install Docker directly in the Linux distribution where you run `minikube`.
+- **Docker Desktop with WSL integration** — install Docker Desktop for Windows and enable WSL integration for the distribution where you run `minikube`.
 
 ## Steps
-Microsoft and Docker have in-depth guides for both, just follow along for a successful setup!
 
-1. [Install WSL](https://docs.microsoft.com/en-us/windows/wsl/install)
-2. Install and setup [Docker Desktop for Windows](https://docs.docker.com/desktop/windows/wsl/#download)
+1. [Install WSL](https://learn.microsoft.com/windows/wsl/install) and confirm you are using WSL 2.
+
+2. Set up Docker using one of the two options above:
+
+   - To install Docker Engine inside WSL, follow the [Docker Engine install guide](https://docs.docker.com/engine/install/) and the [Linux post-install steps](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) so you can run Docker as a non-root user.
+   - To use Docker Desktop, install [Docker Desktop for Windows](https://docs.docker.com/desktop/windows/wsl/) and enable WSL integration for your distribution under **Settings > Resources > WSL integration**.
+
+3. From inside WSL, confirm Docker is working:
+
+   ```shell
+   docker version
+   docker ps
+   ```
+
+4. Start minikube with the Docker driver:
+
+   ```shell
+   minikube start --driver=docker
+   ```
+
+## Accessing your services from Windows
+
+With the Docker driver on Windows and WSL 2, the minikube node runs inside a container, so the node IP printed by `minikube ip` is **not** reachable directly from a Windows browser. Use one of the following instead:
+
+- **NodePort services** — run the command below and browse to the printed `http://127.0.0.1:<port>` address. Keep the terminal open while you use the URL:
+
+  ```shell
+  minikube service <service-name> --url
+  ```
+
+- **LoadBalancer services** — run `minikube tunnel` in a separate terminal and keep it running, then reach the service on `127.0.0.1`:
+
+  ```shell
+  minikube tunnel
+  ```
+
+For more ways to reach your applications, see the [Accessing apps]({{<ref "/docs/handbook/accessing">}}) handbook page.
+
+## See also
+
+- [Docker driver]({{<ref "/docs/drivers/docker">}})
+- [Accessing apps]({{<ref "/docs/handbook/accessing">}})


### PR DESCRIPTION
## Summary

Resolves the long-standing confusion in #7879: with the Docker driver on Windows/WSL, the minikube node IP is not reachable directly from a Windows browser, and this was not documented in the WSL tutorial.

- **`docs/tutorials/wsl_docker_driver.md`** — cover both "Docker Engine inside WSL" and "Docker Desktop with WSL integration", refresh the setup steps and links, and add an **"Accessing your services from Windows"** section: `minikube service <service-name> --url` for `NodePort` services and `minikube tunnel` for `LoadBalancer` services.
- **`docs/drivers/docker.md`** — add a matching note under Known Issues and fix a small grammar issue in the WSL requirement line.

The guidance mirrors the existing [Accessing apps handbook](https://minikube.sigs.k8s.io/docs/handbook/accessing/).

## Validation

Built the site locally with Hugo v0.160.1 extended (the version pinned in `netlify.toml`): it builds cleanly with no new warnings or errors, and all cross-references resolve.

Fixes #7879
