### PR TITLE
Allow one CPU when starting without Kubernetes

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1258,8 +1258,10 @@ func validateCPUCount(drvName string) {
 		availableCPUs = ci
 	}
 
+	minRequiredCPUs := minimumRequiredCPUs(viper.GetBool(noKubernetes))
+
 	switch {
-	case availableCPUs < 2:
+	case availableCPUs < minRequiredCPUs:
 		switch {
 		case drvName == oci.Docker && runtime.GOOS == "darwin":
 			exitIfNotForced(reason.RsrcInsufficientDarwinDockerCores, "Docker Desktop has less than 2 CPUs configured, but Kubernetes requires at least 2 to be available")
@@ -1275,8 +1277,8 @@ func validateCPUCount(drvName string) {
 		return
 	}
 
-	if cpuCount < minimumCPUS {
-		exitIfNotForced(reason.RsrcInsufficientCores, "Requested cpu count {{.requested_cpus}} is less than the minimum allowed of {{.minimum_cpus}}", out.V{"requested_cpus": cpuCount, "minimum_cpus": minimumCPUS})
+	if cpuCount < minRequiredCPUs {
+		exitIfNotForced(reason.RsrcInsufficientCores, "Requested cpu count {{.requested_cpus}} is less than the minimum allowed of {{.minimum_cpus}}", out.V{"requested_cpus": cpuCount, "minimum_cpus": minRequiredCPUs})
 	}
 
 	if availableCPUs < cpuCount {
@@ -1293,6 +1295,13 @@ func validateCPUCount(drvName string) {
 
 		exitIfNotForced(reason.RsrcInsufficientCores, "Requested cpu count {{.requested_cpus}} is greater than the available cpus of {{.avail_cpus}}", out.V{"requested_cpus": cpuCount, "avail_cpus": availableCPUs})
 	}
+}
+
+func minimumRequiredCPUs(noKubernetes bool) int {
+	if noKubernetes {
+		return 1
+	}
+	return minimumCPUS
 }
 
 // validateFlags validates the supplied flags against known bad combinations

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -679,6 +679,32 @@ func TestValidatePorts(t *testing.T) {
 	}
 }
 
+func TestMinimumRequiredCPUs(t *testing.T) {
+	tests := []struct {
+		description  string
+		noKubernetes bool
+		want         int
+	}{
+		{
+			description: "kubernetes requires two cpus",
+			want:        minimumCPUS,
+		},
+		{
+			description:  "no-kubernetes allows one cpu",
+			noKubernetes: true,
+			want:         1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			if got := minimumRequiredCPUs(tc.noKubernetes); got != tc.want {
+				t.Errorf("minimumRequiredCPUs(%t) = %d, want %d", tc.noKubernetes, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestValidateSubnet(t *testing.T) {
 	type subnetTest struct {
 		subnet   string


### PR DESCRIPTION
Fixes #22152

When `--no-kubernetes` is set, minikube should not enforce the Kubernetes minimum CPU requirement. This changes CPU validation so normal Kubernetes starts still require 2 CPUs, while `--no-kubernetes` allows 1 CPU.

Before:

```powershell
minikube start --cpus=1 --no-kubernetes
```

Failed unless `--force` was used.

After:

```powershell
minikube start --cpus=1 --no-kubernetes
```

Passes CPU validation without requiring `--force`.

Tested with:

```powershell
go test ./cmd/minikube/cmd
```