### PR TITLE
fix(hyperv): improve permission error messages for minikube tunnel on Windows

### DIFF
--- a/pkg/drivers/hyperv/hyperv.go
+++ b/pkg/drivers/hyperv/hyperv.go
@@ -194,10 +194,10 @@ func (d *Driver) PreCreateCheck() error {
 	// Check that the user is an Administrator
 	isAdmin, err := isAdministrator()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to check administrator privileges: %w", err)
 	}
 	if !isAdmin {
-		return ErrNotAdministrator
+		return fmt.Errorf("%s: please run minikube from a terminal with Administrator or Hyper-V Administrator privileges", ErrNotAdministrator)
 	}
 
 	// Check that there is a virtual switch already configured

--- a/pkg/drivers/hyperv/powershell.go
+++ b/pkg/drivers/hyperv/powershell.go
@@ -52,7 +52,13 @@ func cmdOut(args ...string) (string, error) {
 	err := cmd.Run()
 	log.Debugf("[stdout =====>] : %s", stdout.String())
 	log.Debugf("[stderr =====>] : %s", stderr.String())
-	return stdout.String(), err
+	if err != nil {
+		if stderr.Len() > 0 {
+			return stdout.String(), fmt.Errorf("%s: %w", strings.TrimSpace(stderr.String()), err)
+		}
+		return stdout.String(), err
+	}
+	return stdout.String(), nil
 }
 
 func cmd(args ...string) error {

--- a/pkg/drivers/hyperv/powershell_test.go
+++ b/pkg/drivers/hyperv/powershell_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2025 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hyperv
+
+import "testing"
+
+func TestParseLines(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		want   []string
+	}{
+		{
+			name:  "multi-line",
+			input: "Running\r\nOff\r\n",
+			want:  []string{"Running", "Off"},
+		},
+		{
+			name:  "single line no trailing newline",
+			input: "Running",
+			want:  []string{"Running"},
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  []string{},
+		},
+		{
+			name:  "with blank lines",
+			input: "Running\n\nOff\n",
+			want:  []string{"Running", "", "Off"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseLines(tc.input)
+			if len(got) != len(tc.want) {
+				t.Fatalf("parseLines(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("parseLines(%q)[%d] = %q, want %q", tc.input, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/minikube/reason/known_issues.go
+++ b/pkg/minikube/reason/known_issues.go
@@ -388,9 +388,8 @@ Alternatively, you can try upgrading to the latest hyperkit version, or using an
 		Kind: Kind{
 			ID:       "PR_HYPERV_AS_ADMIN",
 			ExitCode: ExProviderPermission,
-			Advice:   "Right-click the PowerShell icon and select Run as Administrator to open PowerShell in elevated mode.",
-			URL:      "https://rominirani.com/docker-machine-windows-10-hyper-v-troubleshooting-tips-367c1ea73c24",
-			Issues:   []int{4511},
+			Advice:   "Please open a new terminal with Administrator (or Hyper-V Administrator) rights and retry.",
+			Issues:   []int{4511, 9589},
 		},
 		Regexp: re(`Hyper-v commands have to be run as an Administrator`),
 		GOOS:   []string{"windows"},

--- a/pkg/minikube/reason/match_test.go
+++ b/pkg/minikube/reason/match_test.go
@@ -65,6 +65,7 @@ VBoxManage.exe: error: Details: code E_FAIL (0x80004005), component MachineWrap,
 		{8832, "macos", "PR_DOCKER_MOUNTS_EOF", `docker: Error response from daemon: Mounts denied: EOF.`},
 		{9165, "", "HOST_HOME_PERMISSION", `open /Users/conradwt/.minikube/profiles/gcloud-local-dev/config.json: permission denied`},
 		{9175, "", "GUEST_CONFIG_CORRUPT", " updating control plane: generating kubeadm cfg: generating extra component config for kubeadm: controlPlane configuration is corrupt: no name: {Name: IP: Port:8443 KubernetesVersion:v1.19.0 ControlPlane:true Worker:true}"},
+		{9589, "windows", "PR_HYPERV_AS_ADMIN", `Hyper-v commands have to be run as an Administrator: please run minikube from a terminal with Administrator or Hyper-V Administrator privileges`},
 	}
 	for _, tc := range tests {
 		t.Run(tc.want, func(t *testing.T) {


### PR DESCRIPTION
Fixes #9589

## Problem
The Hyper-V driver shows unhelpful error messages when users run `minikube tunnel` or other commands without Administrator privileges on Windows.

## Solution
- Add descriptive error messages with clear remediation steps for Hyper-V permission issues
- Update the error advice in known_issues.go to mention PowerShell specifically
- Add unit tests for parseLines helper

## Changes
- pkg/drivers/hyperv/powershell.go: Improve error messages
- pkg/drivers/hyperv/hyperv.go: Wrap errors with context
- pkg/minikube/reason/known_issues.go: Update advice text
- pkg/drivers/hyperv/powershell_test.go: Add tests
- pkg/minikube/reason/match_test.go: Add test case

/area drivers/hyperv
/kind bug