### PR TITLE
fix(iso): use tabs in nerdctl Buildroot files

### DIFF
--- a/deploy/iso/minikube-iso/arch/aarch64/package/nerdctl-bin-aarch64/Config.in
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/nerdctl-bin-aarch64/Config.in
@@ -1,4 +1,4 @@
 config BR2_PACKAGE_NERDCTL_BIN_AARCH64
-        bool "nerdctl-bin"
-        default y
-        depends on BR2_aarch64
+	bool "nerdctl-bin"
+	default y
+	depends on BR2_aarch64

--- a/deploy/iso/minikube-iso/arch/aarch64/package/nerdctl-bin-aarch64/nerdctl-bin.mk
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/nerdctl-bin-aarch64/nerdctl-bin.mk
@@ -11,9 +11,9 @@ NERDCTL_BIN_AARCH64_SOURCE = nerdctl-$(NERDCTL_BIN_AARCH64_VERSION)-linux-arm64.
 NERDCTL_BIN_AARCH64_STRIP_COMPONENTS = 0
 
 define NERDCTL_BIN_AARCH64_INSTALL_TARGET_CMDS
-        $(INSTALL) -D -m 0755 \
-                $(@D)/nerdctl \
-                $(TARGET_DIR)/usr/bin/nerdctl
+	$(INSTALL) -D -m 0755 \
+		$(@D)/nerdctl \
+		$(TARGET_DIR)/usr/bin/nerdctl
 endef
 
 $(eval $(generic-package))

--- a/deploy/iso/minikube-iso/arch/x86_64/package/nerdctl-bin/Config.in
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/nerdctl-bin/Config.in
@@ -1,4 +1,4 @@
 config BR2_PACKAGE_NERDCTL_BIN
-        bool "nerdctl-bin"
-        default y
-        depends on BR2_x86_64
+	bool "nerdctl-bin"
+	default y
+	depends on BR2_x86_64

--- a/deploy/iso/minikube-iso/arch/x86_64/package/nerdctl-bin/nerdctl-bin.mk
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/nerdctl-bin/nerdctl-bin.mk
@@ -11,9 +11,9 @@ NERDCTL_BIN_SOURCE = nerdctl-$(NERDCTL_BIN_AARCH64_VERSION)-linux-amd64.tar.gz
 NERDCTL_BIN_STRIP_COMPONENTS = 0
 
 define NERDCTL_BIN_INSTALL_TARGET_CMDS
-        $(INSTALL) -D -m 0755 \
-                $(@D)/nerdctl \
-                $(TARGET_DIR)/usr/bin/nerdctl
+	$(INSTALL) -D -m 0755 \
+		$(@D)/nerdctl \
+		$(TARGET_DIR)/usr/bin/nerdctl
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
Fixes #23437.

Replace leading spaces with tabs in the four nerdctl-bin Buildroot package files, matching the formatting used by the neighboring packages.

Validation:
- Checked all affected directives and commands for tab indentation.
- `git diff --check` passes.