### PR TITLE
bugfix(ui):copy button and code block overlap

### DIFF
--- a/site/assets/scss/_variables_project.scss
+++ b/site/assets/scss/_variables_project.scss
@@ -229,6 +229,14 @@ div.code-toolbar > .toolbar {
     top: -.3em !important;
 }
 
+// Prism paints the copy button with a translucent background so code can show
+// through it. Use Prism's solid fallback color instead so the label stays
+// readable when long lines sit under the button.
+// https://github.com/PrismJS/prism/blob/293dce42ff8911b508cb904a6f7a6b3283e1e85c/plugins/toolbar/prism-toolbar.css#L51
+div.code-toolbar > .toolbar > .toolbar-item > button {
+    background: #f5f2f0 !important;
+}
+
 .option-button {
     border-radius: 0.2rem !important;
     margin-right: 0.2rem;

--- a/site/assets/scss/_variables_project.scss
+++ b/site/assets/scss/_variables_project.scss
@@ -227,6 +227,9 @@ div.td-content {
 
 div.code-toolbar > .toolbar {
     top: -.3em !important;
+    button {
+          background: rgba(255, 255, 255, 0.8)!important;
+    }
 }
 
 .option-button {


### PR DESCRIPTION
## Description
On smaller screen sizes or narrow viewports, long code lines inside code blocks overlap with the floating "Copy" button in the top-right corner. The button text and code text blend together, making both the code and the button hard to read.

### Solution
Override the copy button background in site/assets/scss/_variables_project.scss using Prism's solid fallback color (#f5f2f0).

- Uses the exact selector from Prism's toolbar CSS (div.code-toolbar > .toolbar > .toolbar-item > button) to target the button cleanly.
- Completely blocks out underlying code so the button text remains readable in both normal and hover states.
- Includes upstream documentation comments for future maintenance.

Fix #23434 
### Screenshot
Before:

https://github.com/user-attachments/assets/354f5f74-1351-4b21-a913-5ee385a559a1


After:

https://github.com/user-attachments/assets/63c0682b-f136-4911-93c1-48fc70d5abf6


If the style no, I can continue to modify
Welcome to give directions!