### PR TITLE
addons: Fail fast when an addon callback returns an error

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -74,8 +74,13 @@ func RunCallbacks(cc *config.ClusterConfig, name string, value string, options *
 		return fmt.Errorf("%s is not a valid addon", name)
 	}
 
+	run := invoke
+	if value != "true" {
+		run = invokeAll
+	}
+
 	// Run any additional validations for this property
-	if err := invoke(cc, name, value, a.validations, options); err != nil {
+	if err := run(cc, name, value, a.validations, options); err != nil {
 		if errors.Is(err, ErrSkipThisAddon) {
 			return err
 		}
@@ -85,7 +90,7 @@ func RunCallbacks(cc *config.ClusterConfig, name string, value string, options *
 	preStartMessages(name, value)
 
 	// Run any callbacks for this property
-	if err := invoke(cc, name, value, a.callbacks, options); err != nil {
+	if err := run(cc, name, value, a.callbacks, options); err != nil {
 		if errors.Is(err, ErrSkipThisAddon) {
 			return err
 		}
@@ -211,12 +216,21 @@ func SetAndSave(profile string, name string, value string, options *run.CommandO
 	return config.Write(profile, cc)
 }
 
-// Runs all the validation or callback functions and collects errors
+// invoke runs validation or callback functions and returns on the first error encountered, failing fast
 func invoke(cc *config.ClusterConfig, name string, value string, fns []setFn, options *run.CommandOptions) error {
+	for _, fn := range fns {
+		if err := fn(cc, name, value, options); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// invokeAll runs all validation or callback functions, accumulating errors so cleanup can proceed
+func invokeAll(cc *config.ClusterConfig, name string, value string, fns []setFn, options *run.CommandOptions) error {
 	var errs []error
 	for _, fn := range fns {
-		err := fn(cc, name, value, options)
-		if err != nil {
+		if err := fn(cc, name, value, options); err != nil {
 			if errors.Is(err, ErrSkipThisAddon) {
 				return ErrSkipThisAddon
 			}

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -211,20 +211,12 @@ func SetAndSave(profile string, name string, value string, options *run.CommandO
 	return config.Write(profile, cc)
 }
 
-// Runs all the validation or callback functions and collects errors
+// Runs all the validation or callback functions and returns the first error encountered, failing fast
 func invoke(cc *config.ClusterConfig, name string, value string, fns []setFn, options *run.CommandOptions) error {
-	var errs []error
 	for _, fn := range fns {
-		err := fn(cc, name, value, options)
-		if err != nil {
-			if errors.Is(err, ErrSkipThisAddon) {
-				return ErrSkipThisAddon
-			}
-			errs = append(errs, err)
+		if err := fn(cc, name, value, options); err != nil {
+			return err
 		}
-	}
-	if len(errs) > 0 {
-		return fmt.Errorf("%v", errs)
 	}
 	return nil
 }

--- a/pkg/addons/addons_test.go
+++ b/pkg/addons/addons_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package addons
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -171,5 +172,28 @@ func TestStartWithAllAddonsDisabled(t *testing.T) {
 		if assets.Addons[name].IsEnabled(cc) {
 			t.Errorf("expected %s to be disabled", name)
 		}
+	}
+}
+
+func TestInvokeFailFast(t *testing.T) {
+	secondCalled := false
+	expectedErr := fmt.Errorf("first callback failed")
+
+	firstFn := func(cc *config.ClusterConfig, name string, value string, options *run.CommandOptions) error {
+		return expectedErr
+	}
+	secondFn := func(cc *config.ClusterConfig, name string, value string, options *run.CommandOptions) error {
+		secondCalled = true
+		return nil
+	}
+
+	fns := []setFn{firstFn, secondFn}
+	err := invoke(nil, "test", "true", fns, nil)
+
+	if err != expectedErr {
+		t.Errorf("expected error %v, got %v", expectedErr, err)
+	}
+	if secondCalled {
+		t.Errorf("expected second callback NOT to be called after first callback failed")
 	}
 }

--- a/pkg/addons/addons_test.go
+++ b/pkg/addons/addons_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package addons
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -173,3 +175,159 @@ func TestStartWithAllAddonsDisabled(t *testing.T) {
 		}
 	}
 }
+
+func TestInvokeFailFast(t *testing.T) {
+	secondCalled := false
+	expectedErr := fmt.Errorf("first callback failed")
+
+	firstFn := func(cc *config.ClusterConfig, name string, value string, options *run.CommandOptions) error {
+		return expectedErr
+	}
+	secondFn := func(cc *config.ClusterConfig, name string, value string, options *run.CommandOptions) error {
+		secondCalled = true
+		return nil
+	}
+
+	fns := []setFn{firstFn, secondFn}
+	err := invoke(nil, "test", "true", fns, nil)
+
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("expected error %v, got %v", expectedErr, err)
+	}
+	if secondCalled {
+		t.Errorf("expected second callback NOT to be called after first callback failed")
+	}
+}
+
+func TestInvokeAll(t *testing.T) {
+	secondCalled := false
+	err1 := fmt.Errorf("first callback failed")
+	err2 := fmt.Errorf("second callback failed")
+
+	firstFn := func(cc *config.ClusterConfig, name string, value string, options *run.CommandOptions) error {
+		return err1
+	}
+	secondFn := func(cc *config.ClusterConfig, name string, value string, options *run.CommandOptions) error {
+		secondCalled = true
+		return err2
+	}
+
+	fns := []setFn{firstFn, secondFn}
+	err := invokeAll(nil, "test", "false", fns, nil)
+
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+	if !secondCalled {
+		t.Errorf("expected second callback to be called despite first callback failure")
+	}
+}
+
+func TestInvokeAllSkipAddon(t *testing.T) {
+	secondCalled := false
+
+	firstFn := func(cc *config.ClusterConfig, name string, value string, options *run.CommandOptions) error {
+		return ErrSkipThisAddon
+	}
+	secondFn := func(cc *config.ClusterConfig, name string, value string, options *run.CommandOptions) error {
+		secondCalled = true
+		return nil
+	}
+
+	fns := []setFn{firstFn, secondFn}
+	err := invokeAll(nil, "test", "false", fns, nil)
+
+	if !errors.Is(err, ErrSkipThisAddon) {
+		t.Errorf("expected ErrSkipThisAddon, got %v", err)
+	}
+	if secondCalled {
+		t.Errorf("expected second callback NOT to be called after ErrSkipThisAddon")
+	}
+}
+
+func TestRunCallbacksMultiCallback(t *testing.T) {
+	firstErr := fmt.Errorf("first callback failed")
+	secondErr := fmt.Errorf("second callback failed")
+
+	var firstCalled, secondCalled bool
+	testAddon := &Addon{
+		name: "test-multicallback-addon",
+		callbacks: []setFn{
+			func(cc *config.ClusterConfig, name string, value string, options *run.CommandOptions) error {
+				firstCalled = true
+				return firstErr
+			},
+			func(cc *config.ClusterConfig, name string, value string, options *run.CommandOptions) error {
+				secondCalled = true
+				return secondErr
+			},
+		},
+	}
+
+	Addons = append(Addons, testAddon)
+	defer func() {
+		Addons = Addons[:len(Addons)-1]
+	}()
+
+	cc := &config.ClusterConfig{Name: "test-profile"}
+
+	t.Run("enable fails fast on first callback error", func(t *testing.T) {
+		firstCalled = false
+		secondCalled = false
+
+		err := RunCallbacks(cc, testAddon.name, "true", nil)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !firstCalled {
+			t.Errorf("expected first callback to be called")
+		}
+		if secondCalled {
+			t.Errorf("expected second callback NOT to be called on enable failure")
+		}
+		if !errors.Is(err, firstErr) {
+			t.Errorf("expected error %v to wrap %v", err, firstErr)
+		}
+	})
+
+	t.Run("disable runs all callbacks despite errors", func(t *testing.T) {
+		firstCalled = false
+		secondCalled = false
+
+		err := RunCallbacks(cc, testAddon.name, "false", nil)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !firstCalled {
+			t.Errorf("expected first callback to be called")
+		}
+		if !secondCalled {
+			t.Errorf("expected second callback to be called on disable failure")
+		}
+	})
+
+	t.Run("enable with ErrSkipThisAddon returns sentinel unwrapped", func(t *testing.T) {
+		skipAddon := &Addon{
+			name: "test-skip-addon",
+			callbacks: []setFn{
+				func(cc *config.ClusterConfig, name string, value string, options *run.CommandOptions) error {
+					return ErrSkipThisAddon
+				},
+				func(cc *config.ClusterConfig, name string, value string, options *run.CommandOptions) error {
+					t.Errorf("expected second callback NOT to be called after ErrSkipThisAddon")
+					return nil
+				},
+			},
+		}
+		Addons = append(Addons, skipAddon)
+		defer func() {
+			Addons = Addons[:len(Addons)-1]
+		}()
+
+		err := RunCallbacks(cc, skipAddon.name, "true", nil)
+		if !errors.Is(err, ErrSkipThisAddon) {
+			t.Errorf("expected ErrSkipThisAddon, got %v", err)
+		}
+	})
+}
+


### PR DESCRIPTION
### Problem
When enabling or modifying an addon (e.g. `minikube addons enable traefik`), `invoke()` executed callback functions sequentially in a loop (`[]setFn{EnableOrDisableAddon,verifyAddonStatus}`).

If the first callback (`EnableOrDisableAddon`) failed (for instance, due to an invalid Helm chart reference, broken manifest, or execution failure), `invoke()` collected the error into a slice and continued to execute the next callback (`verifyAddonStatus`). This caused `minikube` to sit for **6 minutes** attempting to wait for pods that were never deployed (`context deadline exceeded`).

### Solution
1. **Fail-Fast Invocation**: Updated `invoke()` in `pkg/addons/addons.go` to return immediately upon encountering the first callback or validation error, failing fast and returning the root error without executing subsequent callbacks.

2. **Unit Test**: Added `TestInvokeFailFast` in `pkg/addons/addons_test.go` to ensure that when a callback fails, any subsequent callbacks in the slice are skipped.

### How Has This Been Tested?
- **Unit Testing**: Ran `go test -v ./pkg/addons/... -run TestInvokeFailFast` (PASSED in 0.04s).
- **Fail-Fast Behaviour**: Verified that when a callback returns an error, `minikube` exits immediately in under 2 seconds instead of waiting 6 minutes.


Fixes #23442


After the fix was applied, a simulation with a wrong OCI repo was done and here is the result;
```bash
$ timestamp out/minikube addons enable traefik --logtostderr --v=8
[    0.000] out/minikube addons enable traefik --logtostderr --v=8
[    0.059] I0804 18:03:00.989811  743555 out.go:361] Setting OutFile to fd 1 ...
[    0.059] I0804 18:03:00.989836  743555 out.go:414] isatty.IsTerminal(1) = false
[    0.059] I0804 18:03:00.989839  743555 out.go:375] Setting ErrFile to fd 2...
[    0.059] I0804 18:03:00.989843  743555 out.go:414] isatty.IsTerminal(2) = false
[    0.059] I0804 18:03:00.990020  743555 root.go:332] Updating PATH: /home/roslaan001/.minikube/bin
[    0.060] W0804 18:03:00.990873  743555 root.go:308] Error reading config file at /home/roslaan001/.minikube/config/config.json: open /home/roslaan001/.minikube/config/config.json: no such file or directory
[    0.061] I0804 18:03:00.991165  743555 mustload.go:66] Loading cluster: minikube
[    0.061] I0804 18:03:00.991667  743555 config.go:187] Loaded profile config "minikube": Driver=docker, ContainerRuntime=docker, KubernetesVersion=v1.36.2
[    0.061] I0804 18:03:00.991681  743555 addons.go:628] checking whether the cluster is paused
[    0.061] I0804 18:03:00.991791  743555 config.go:187] Loaded profile config "minikube": Driver=docker, ContainerRuntime=docker, KubernetesVersion=v1.36.2
[    0.061] I0804 18:03:00.991803  743555 host.go:67] Checking if "minikube" exists ...
[    0.062] I0804 18:03:00.992394  743555 cli_runner.go:164] Run: docker container inspect minikube --format={{.State.Status}}
[    0.092] I0804 18:03:01.022637  743555 ssh_runner.go:191] Run: systemctl --version
[    0.092] I0804 18:03:01.022768  743555 cli_runner.go:164] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
[    0.107] I0804 18:03:01.037076  743555 sshutil.go:53] new ssh client: &{IP:127.0.0.1 Port:32768 SSHKeyPath:/home/roslaan001/.minikube/machines/minikube/id_rsa Username:docker}
[    0.230] I0804 18:03:01.160637  743555 command_runner.go:137] > systemd 252 (252.39-1~deb12u2)
[    0.230] I0804 18:03:01.160835  743555 command_runner.go:137] > +PAM +AUDIT +SELINUX +APPARMOR +IMA +SMACK +SECCOMP +GCRYPT -GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +IPTC +KMOD +LIBCRYPTSETUP +LIBFDISK +PCRE2 -PWQUALITY +P11KIT +QRENCODE +TPM2 +BZIP2 +LZ4 +XZ +ZLIB +ZSTD -BPF_FRAMEWORK -XKBCOMMON +UTMP +SYSVINIT default-hierarchy=unified
[    0.231] I0804 18:03:01.161115  743555 ssh_runner.go:191] Run: docker ps --filter status=paused --filter=name=k8s_.*_(kube-system)_ --format={{.ID}}
[    0.269] ! traefik is a 3rd party addon and is not maintained or verified by minikube maintainers, enable at your own risk.
[    0.270] I0804 18:03:01.200064  743555 out.go:180] ! traefik is a 3rd party addon and is not maintained or verified by minikube maintainers, enable at your own risk.
[    0.270] * traefik is maintained by 3rd party (Traefik Labs) for any concerns contact traefik on GitHub.
[    0.270] I0804 18:03:01.200105  743555 out.go:180] * traefik is maintained by 3rd party (Traefik Labs) for any concerns contact traefik on GitHub.
[    0.270] I0804 18:03:01.200320  743555 config.go:187] Loaded profile config "minikube": Driver=docker, ContainerRuntime=docker, KubernetesVersion=v1.36.2
[    0.270] I0804 18:03:01.200332  743555 addons.go:71] Setting traefik=true in profile "minikube"
[    0.270] I0804 18:03:01.200342  743555 addons.go:239] Setting addon traefik=true in "minikube"
[    0.270] W0804 18:03:01.200352  743555 addons.go:248] addon traefik should already be in state true
[    0.270] I0804 18:03:01.200375  743555 host.go:67] Checking if "minikube" exists ...
[    0.271] I0804 18:03:01.201152  743555 cli_runner.go:164] Run: docker container inspect minikube --format={{.State.Status}}
[    0.284] I0804 18:03:01.215034  743555 ssh_runner.go:191] Run: /usr/bin/helm version --template {{.Version}}
[    0.285] I0804 18:03:01.215118  743555 cli_runner.go:164] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
[    0.297] I0804 18:03:01.227845  743555 sshutil.go:53] new ssh client: &{IP:127.0.0.1 Port:32768 SSHKeyPath:/home/roslaan001/.minikube/machines/minikube/id_rsa Username:docker}
[    0.448] I0804 18:03:01.378139  743555 command_runner.go:146] > v4.2.3
[    0.448] I0804 18:03:01.378179  743555 addons.go:462] using helm 4.2.3
[    0.448] I0804 18:03:01.378586  743555 ssh_runner.go:191] Run: sudo KUBECONFIG=/var/lib/minikube/kubeconfig helm upgrade --install traefik oci://ghcr.io/invalid-path/traefik --create-namespace --namespace kube-system --set api.insecure=true --set ingressClass.isDefaultClass=true --set ports.web.hostPort=80 --set ports.websecure.hostPort=443 --set ports.traefik.expose.default=true --set service.labels.kubernetes\.io/minikube-addons-endpoint=traefik
[    1.687] I0804 18:03:02.617867  743555 command_runner.go:137] ! Error: GET "https://ghcr.io/v2/invalid-path/traefik/tags/list": GET "https://ghcr.io/token?scope=repository%3Ainvalid-path%2Ftraefik%3Apull&service=ghcr.io": response status code 403: denied: requested access to the resource is denied
[    1.695] I0804 18:03:02.625545  743555 ssh_runner.go:230] Completed: sudo KUBECONFIG=/var/lib/minikube/kubeconfig helm upgrade --install traefik oci://ghcr.io/invalid-path/traefik --create-namespace --namespace kube-system --set api.insecure=true --set ingressClass.isDefaultClass=true --set ports.web.hostPort=80 --set ports.websecure.hostPort=443 --set ports.traefik.expose.default=true --set service.labels.kubernetes\.io/minikube-addons-endpoint=traefik: (1.246916946s)
[    1.695]
[    1.695] I0804 18:03:02.626019  743555 out.go:204]
[    1.695] W0804 18:03:02.626054  743555 out.go:286] X Exiting due to MK_ADDON_ENABLE: enable failed: run callbacks: running callbacks: sudo KUBECONFIG=/var/lib/minikube/kubeconfig helm upgrade --install traefik oci://ghcr.io/invalid-path/traefik --create-namespace --namespace kube-system --set api.insecure=true --set ingressClass.isDefaultClass=true --set ports.web.hostPort=80 --set ports.websecure.hostPort=443 --set ports.traefik.expose.default=true --set service.labels.kubernetes\.io/minikube-addons-endpoint=traefik: Process exited with status 1
[    1.696] stdout:
[    1.696]
[    1.696] stderr:
[    1.696] Error: GET "https://ghcr.io/v2/invalid-path/traefik/tags/list": GET "https://ghcr.io/token?scope=repository%3Ainvalid-path%2Ftraefik%3Apull&service=ghcr.io": response status code 403: denied: requested access to the resource is denied
[    1.696]
[    1.696] X Exiting due to MK_ADDON_ENABLE: enable failed: run callbacks: running callbacks: sudo KUBECONFIG=/var/lib/minikube/kubeconfig helm upgrade --install traefik oci://ghcr.io/invalid-path/traefik --create-namespace --namespace kube-system --set api.insecure=true --set ingressClass.isDefaultClass=true --set ports.web.hostPort=80 --set ports.websecure.hostPort=443 --set ports.traefik.expose.default=true --set service.labels.kubernetes\.io/minikube-addons-endpoint=traefik: Process exited with status 1
[    1.696] stdout:
[    1.696]
[    1.696] stderr:
[    1.696] Error: GET "https://ghcr.io/v2/invalid-path/traefik/tags/list": GET "https://ghcr.io/token?scope=repository%3Ainvalid-path%2Ftraefik%3Apull&service=ghcr.io": response status code 403: denied: requested access to the resource is denied
[    1.696]
[    1.696] W0804 18:03:02.626062  743555 out.go:286] *
[    1.696] *
[    1.696]
[    1.696] W0804 18:03:02.626568  743555 out.go:309] ╭─────────────────────────────────────────────────────────────────────────────────────────────╮
[    1.696] │                                                                                             │
[    1.696] │    * If the above advice does not help, please let us know:                                 │
[    1.696] │      https://github.com/kubernetes/minikube/issues/new/choose                               │
[    1.696] │                                                                                             │
[    1.696] │    * Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
[    1.696] │    * Please also attach the following file to the GitHub issue:                             │
[    1.696] │    * - /tmp/minikube_addons_df0cbf299c3c7307bd4a25f4151ffdd1c7dba392_0.log                  │
[    1.696] │                                                                                             │
[    1.696] ╰─────────────────────────────────────────────────────────────────────────────────────────────╯
[    1.696] ╭─────────────────────────────────────────────────────────────────────────────────────────────╮
[    1.696] │                                                                                             │
[    1.696] │    * If the above advice does not help, please let us know:                                 │
[    1.696] │      https://github.com/kubernetes/minikube/issues/new/choose                               │
[    1.696] │                                                                                             │
[    1.696] │    * Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
[    1.696] │    * Please also attach the following file to the GitHub issue:                             │
[    1.696] │    * - /tmp/minikube_addons_df0cbf299c3c7307bd4a25f4151ffdd1c7dba392_0.log                  │
[    1.696] │                                                                                             │
[    1.696] ╰─────────────────────────────────────────────────────────────────────────────────────────────╯
[    1.696] I0804 18:03:02.626585  743555 out.go:204]

```

Instead of hanging for 6 minutes, it ran for 1.69 seconds and does not run `verifyAddonStatus` but instead stopped immediately and reported the install error
