### PR TITLE
fix(iso): use tabs in nerdctl-bin aarch64 Buildroot package files

### DIFF
--- a/deploy/iso/minikube-iso/arch/aarch64/package/nerdctl-bin-aarch64/Config.in
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/nerdctl-bin-aarch64/Config.in
@@ -1,4 +1,4 @@
 config BR2_PACKAGE_NERDCTL_BIN_AARCH64
-        bool "nerdctl-bin"
-        default y
-        depends on BR2_aarch64
+	bool "nerdctl-bin"
+	default y
+	depends on BR2_aarch64

--- a/deploy/iso/minikube-iso/arch/aarch64/package/nerdctl-bin-aarch64/nerdctl-bin.mk
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/nerdctl-bin-aarch64/nerdctl-bin.mk
@@ -11,9 +11,9 @@ NERDCTL_BIN_AARCH64_SOURCE = nerdctl-$(NERDCTL_BIN_AARCH64_VERSION)-linux-arm64.
 NERDCTL_BIN_AARCH64_STRIP_COMPONENTS = 0
 
 define NERDCTL_BIN_AARCH64_INSTALL_TARGET_CMDS
-        $(INSTALL) -D -m 0755 \
-                $(@D)/nerdctl \
-                $(TARGET_DIR)/usr/bin/nerdctl
+	$(INSTALL) -D -m 0755 \
+		$(@D)/nerdctl \
+		$(TARGET_DIR)/usr/bin/nerdctl
 endef
 
 $(eval $(generic-package))

--- a/deploy/iso/minikube-iso/arch/x86_64/package/nerdctl-bin/Config.in
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/nerdctl-bin/Config.in
@@ -1,4 +1,4 @@
 config BR2_PACKAGE_NERDCTL_BIN
-        bool "nerdctl-bin"
-        default y
-        depends on BR2_x86_64
+	bool "nerdctl-bin"
+	default y
+	depends on BR2_x86_64

--- a/deploy/iso/minikube-iso/arch/x86_64/package/nerdctl-bin/nerdctl-bin.mk
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/nerdctl-bin/nerdctl-bin.mk
@@ -1,19 +1,19 @@
 ################################################################################
-# 
+#
 # nerdctl-bin
-# 
+#
 ################################################################################
 
 NERDCTL_BIN_VERSION = 2.3.5
 NERDCTL_BIN_COMMIT = 347782c28efe1753d5cc9652f6304752ed431221
 NERDCTL_BIN_SITE = https://github.com/containerd/nerdctl/releases/download/v$(NERDCTL_BIN_VERSION)
-NERDCTL_BIN_SOURCE = nerdctl-$(NERDCTL_BIN_AARCH64_VERSION)-linux-amd64.tar.gz
+NERDCTL_BIN_SOURCE = nerdctl-$(NERDCTL_BIN_VERSION)-linux-amd64.tar.gz
 NERDCTL_BIN_STRIP_COMPONENTS = 0
 
 define NERDCTL_BIN_INSTALL_TARGET_CMDS
-        $(INSTALL) -D -m 0755 \
-                $(@D)/nerdctl \
-                $(TARGET_DIR)/usr/bin/nerdctl
+	$(INSTALL) -D -m 0755 \
+		$(@D)/nerdctl \
+		$(TARGET_DIR)/usr/bin/nerdctl
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
## Summary
The nerdctl-bin aarch64 Buildroot package used spaces for indentation in `Config.in` and `nerdctl-bin.mk`. Buildroot/Kconfig/Make conventions require tabs (see sibling packages such as `crio-bin`).

## Changes
- `Config.in`: single-tab indent for bool/default/depends.
- `nerdctl-bin.mk`: tab-indented install recipe body.

Closes #23437