### PR TITLE
[WIP] pkg/minikube/certs: zero-configuration trusted HTTPS (--https)

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/minikube/pkg/drivers/kic"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/libmachine"
+	minikubehttps "k8s.io/minikube/pkg/minikube/certs/https"
 	"k8s.io/minikube/pkg/minikube/cluster"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -331,6 +332,7 @@ func deleteProfileTimeout(profile *config.Profile, options *run.CommandOptions) 
 func deleteProfile(ctx context.Context, profile *config.Profile, options *run.CommandOptions) error {
 	klog.Infof("Deleting %s", profile.Name)
 	register.Reg.SetStep(register.Deleting)
+	_ = minikubehttps.CleanupHTTPS(profile.Name)
 
 	viper.Set(config.ProfileName, profile.Name)
 	if profile.Config != nil {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -51,12 +51,14 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/libmachine/ssh"
 
+	"k8s.io/minikube/pkg/kapi"
 	cmdcfg "k8s.io/minikube/cmd/minikube/cmd/config"
 	"k8s.io/minikube/cmd/minikube/cmd/flags"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/kverify"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/images"
+	minikubehttps "k8s.io/minikube/pkg/minikube/certs/https"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -302,6 +304,16 @@ func runStart(cmd *cobra.Command, _ []string) {
 	if starter.Cfg.VerifyComponents[kverify.ExtraKey] {
 		if err := kverify.WaitExtra(ClusterFlagValue(), kverify.CorePodsLabels, kconst.DefaultControlPlaneTimeout); err != nil {
 			exit.Message(reason.GuestStart, "extra waiting: {{.error}}", out.V{"error": err})
+		}
+	}
+
+	if starter.Cfg.HTTPS {
+		client, err := kapi.Client(starter.Cfg.Name)
+		if err != nil {
+			klog.Warningf("Failed to get k8s client for HTTPS setup: %v", err)
+		}
+		if err := minikubehttps.SetupHTTPS(starter.Cfg.Name, net.ParseIP(starter.Node.IP), client); err != nil {
+			out.WarningT("Failed to setup HTTPS: {{.error}}", out.V{"error": err})
 		}
 	}
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -55,6 +55,7 @@ import (
 )
 
 const (
+	httpsFlag               = "https"
 	isoURL                  = "iso-url"
 	memory                  = "memory"
 	cpus                    = "cpus"
@@ -220,6 +221,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().StringP(gpus, "g", "", "Allow pods to use your GPUs. Options include: [all,nvidia,amd] (Docker driver with Docker container-runtime only)")
 	startCmd.Flags().Duration(autoPauseInterval, time.Minute*1, "Duration of inactivity before the minikube VM is paused (default 1m0s)")
 	startCmd.Flags().String(preloadSrc, "auto", "Which source to download the preload from (valid options: gcs, github, auto). Defaults to auto (try github first, then gcs as failover).")
+	startCmd.Flags().Bool(httpsFlag, false, "Install a trusted TLS certificate in the cluster and add the CA to the browser trust store. Enables HTTPS access to minikube services without security warnings.")
 }
 
 // initKubernetesFlags inits the commandline flags for Kubernetes related options
@@ -675,6 +677,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 
 	cc = config.ClusterConfig{
 		Name:                    ClusterFlagValue(),
+		HTTPS:                   viper.GetBool(httpsFlag),
 		KeepContext:             viper.GetBool(keepContext),
 		EmbedCerts:              viper.GetBool(embedCerts),
 		MinikubeISO:             viper.GetString(isoURL),
@@ -936,6 +939,7 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 	}
 
 	updateBoolFromFlag(cmd, &cc.KeepContext, keepContext)
+	updateBoolFromFlag(cmd, &cc.HTTPS, httpsFlag)
 	updateBoolFromFlag(cmd, &cc.EmbedCerts, embedCerts)
 	updateStringFromFlag(cmd, &cc.MinikubeISO, isoURL)
 	updateStringFromFlag(cmd, &cc.KicBaseImage, kicBaseImage)

--- a/pkg/minikube/certs/https/ca.go
+++ b/pkg/minikube/certs/https/ca.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"k8s.io/minikube/pkg/minikube/localpath"
+)
+
+// Certificate file names in profile directory
+const (
+	CACertFile     = "ingress-ca.crt"
+	ServerCertFile = "ingress-tls.crt"
+	ServerKeyFile  = "ingress-tls.key"
+)
+
+// CACertPath returns the path to the profile's CA certificate
+func CACertPath(profile string) string {
+	return filepath.Join(localpath.Profile(profile), CACertFile)
+}
+
+// ServerCertPath returns the path to the profile's server TLS certificate
+func ServerCertPath(profile string) string {
+	return filepath.Join(localpath.Profile(profile), ServerCertFile)
+}
+
+// ServerKeyPath returns the path to the profile's server TLS key
+func ServerKeyPath(profile string) string {
+	return filepath.Join(localpath.Profile(profile), ServerKeyFile)
+}
+
+// GenerateCerts creates an in-memory CA and signs a server certificate for the minikube cluster.
+// The CA private key is generated in memory, used only to sign the server cert, and discarded.
+func GenerateCerts(profile string, clusterIP net.IP, extraSANs ...string) (caCertPEM []byte, serverCertPEM []byte, serverKeyPEM []byte, err error) {
+	// 1. Generate CA private key in memory
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to generate CA key: %w", err)
+	}
+
+	caCommonName := fmt.Sprintf("minikube-%s", profile)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	caSerial, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to generate CA serial number: %w", err)
+	}
+
+	caTemplate := &x509.Certificate{
+		SerialNumber: caSerial,
+		Subject: pkix.Name{
+			CommonName:   caCommonName,
+			Organization: []string{"minikube"},
+		},
+		NotBefore:             time.Now().Add(-10 * time.Minute),
+		NotAfter:              time.Now().AddDate(10, 0, 0), // Valid for 10 years
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create CA certificate: %w", err)
+	}
+
+	caCertPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
+
+	// 2. Generate Server private key
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to generate server key: %w", err)
+	}
+
+	serverSerial, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to generate server serial number: %w", err)
+	}
+
+	sansMap := map[string]bool{
+		fmt.Sprintf("*.%s.minikube.internal", profile): true,
+		"*.nip.io":   true,
+		"*.sslip.io": true,
+		"*.local":    true,
+		"localhost":  true,
+	}
+
+	ips := []net.IP{net.ParseIP("127.0.0.1")}
+	if clusterIP != nil {
+		ips = append(ips, clusterIP)
+	}
+
+	for _, extra := range extraSANs {
+		if extra == "" {
+			continue
+		}
+		if ip := net.ParseIP(extra); ip != nil {
+			ips = append(ips, ip)
+		} else {
+			sansMap[extra] = true
+		}
+	}
+
+	sans := make([]string, 0, len(sansMap))
+	for s := range sansMap {
+		sans = append(sans, s)
+	}
+
+	serverTemplate := &x509.Certificate{
+		SerialNumber: serverSerial,
+		Subject: pkix.Name{
+			CommonName:   fmt.Sprintf("%s-server", caCommonName),
+			Organization: []string{"minikube"},
+		},
+		NotBefore:             time.Now().Add(-10 * time.Minute),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              sans,
+		IPAddresses:           ips,
+		BasicConstraintsValid: true,
+	}
+
+	serverCertDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caTemplate, &serverKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create server certificate: %w", err)
+	}
+
+	serverCertPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverCertDER})
+
+	serverKeyBytes, err := x509.MarshalECPrivateKey(serverKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to marshal server private key: %w", err)
+	}
+	serverKeyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: serverKeyBytes})
+
+	// CA key is discarded here as it goes out of scope and is not saved anywhere.
+	return caCertPEM, serverCertPEM, serverKeyPEM, nil
+}
+
+// SaveCertificates saves the CA cert, server cert, and server key to the profile directory.
+func SaveCertificates(profile string, caCertPEM, serverCertPEM, serverKeyPEM []byte) error {
+	profileDir := localpath.Profile(profile)
+	if err := os.MkdirAll(profileDir, 0755); err != nil {
+		return fmt.Errorf("failed to create profile directory: %w", err)
+	}
+
+	if err := os.WriteFile(CACertPath(profile), caCertPEM, 0644); err != nil {
+		return fmt.Errorf("failed to write CA cert: %w", err)
+	}
+
+	if err := os.WriteFile(ServerCertPath(profile), serverCertPEM, 0644); err != nil {
+		return fmt.Errorf("failed to write server cert: %w", err)
+	}
+
+	if err := os.WriteFile(ServerKeyPath(profile), serverKeyPEM, 0600); err != nil {
+		return fmt.Errorf("failed to write server key: %w", err)
+	}
+
+	return nil
+}
+
+// CertificatesExist checks if all HTTPS certificates exist in the profile directory.
+func CertificatesExist(profile string) bool {
+	if _, err := os.Stat(CACertPath(profile)); err != nil {
+		return false
+	}
+	if _, err := os.Stat(ServerCertPath(profile)); err != nil {
+		return false
+	}
+	if _, err := os.Stat(ServerKeyPath(profile)); err != nil {
+		return false
+	}
+	return true
+}
+
+// IsCertValidForIP checks whether the existing server certificate in the profile directory includes the cluster IP.
+func IsCertValidForIP(profile string, ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	certPEM, err := os.ReadFile(ServerCertPath(profile))
+	if err != nil {
+		return false
+	}
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return false
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return false
+	}
+
+	// Check if IP is included in IPAddresses
+	for _, certIP := range cert.IPAddresses {
+		if certIP.Equal(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/minikube/certs/https/ca_test.go
+++ b/pkg/minikube/certs/https/ca_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"testing"
+)
+
+func TestGenerateCerts(t *testing.T) {
+	profile := "test-profile"
+	clusterIP := net.ParseIP("192.168.64.3")
+
+	caCertPEM, serverCertPEM, serverKeyPEM, err := GenerateCerts(profile, clusterIP)
+	if err != nil {
+		t.Fatalf("GenerateCerts failed: %v", err)
+	}
+
+	if len(caCertPEM) == 0 {
+		t.Errorf("expected non-empty caCertPEM")
+	}
+	if len(serverCertPEM) == 0 {
+		t.Errorf("expected non-empty serverCertPEM")
+	}
+	if len(serverKeyPEM) == 0 {
+		t.Errorf("expected non-empty serverKeyPEM")
+	}
+
+	// Parse CA Cert
+	block, _ := pem.Decode(caCertPEM)
+	if block == nil {
+		t.Fatalf("failed to decode CA cert PEM")
+	}
+	caCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse CA cert: %v", err)
+	}
+	if caCert.Subject.CommonName != "minikube-test-profile" {
+		t.Errorf("unexpected CA CN: got %q, want %q", caCert.Subject.CommonName, "minikube-test-profile")
+	}
+	if !caCert.IsCA {
+		t.Errorf("expected CA cert to have IsCA=true")
+	}
+
+	// Parse Server Cert
+	block, _ = pem.Decode(serverCertPEM)
+	if block == nil {
+		t.Fatalf("failed to decode Server cert PEM")
+	}
+	serverCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse Server cert: %v", err)
+	}
+
+	// Verify SANs
+	expectedDNS := "*.test-profile.minikube.internal"
+	foundDNS := false
+	for _, dns := range serverCert.DNSNames {
+		if dns == expectedDNS {
+			foundDNS = true
+			break
+		}
+	}
+	if !foundDNS {
+		t.Errorf("expected DNS SAN %q in server cert SANs: %v", expectedDNS, serverCert.DNSNames)
+	}
+
+	foundIP := false
+	for _, ip := range serverCert.IPAddresses {
+		if ip.Equal(clusterIP) {
+			foundIP = true
+			break
+		}
+	}
+	if !foundIP {
+		t.Errorf("expected IP SAN %v in server cert IP addresses: %v", clusterIP, serverCert.IPAddresses)
+	}
+
+	// Verify server cert is signed by CA cert
+	roots := x509.NewCertPool()
+	roots.AddCert(caCert)
+
+	opts := x509.VerifyOptions{
+		Roots:       roots,
+		CurrentTime: serverCert.NotBefore.Add(1 * timeMinute),
+		DNSName:     "app.test-profile.minikube.internal",
+	}
+
+	if _, err := serverCert.Verify(opts); err != nil {
+		t.Errorf("server cert verification against CA failed: %v", err)
+	}
+}
+
+const timeMinute = 60 * 1000 * 1000 * 1000

--- a/pkg/minikube/certs/https/secret.go
+++ b/pkg/minikube/certs/https/secret.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+const (
+	SecretName      = "minikube-tls"
+	SecretNamespace = "kube-system"
+)
+
+// CreateOrUpdateTLSSecret creates or updates the minikube-tls secret in kube-system namespace
+func CreateOrUpdateTLSSecret(client kubernetes.Interface, serverCertPEM, caCertPEM, serverKeyPEM []byte) error {
+	return CreateOrUpdateTLSSecretInNamespace(client, SecretNamespace, serverCertPEM, caCertPEM, serverKeyPEM)
+}
+
+// CreateOrUpdateTLSSecretInNamespace creates or updates the minikube-tls secret in the specified namespace
+func CreateOrUpdateTLSSecretInNamespace(client kubernetes.Interface, namespace string, serverCertPEM, caCertPEM, serverKeyPEM []byte) error {
+	certChain := append([]byte{}, serverCertPEM...)
+	if len(caCertPEM) > 0 {
+		certChain = append(certChain, caCertPEM...)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      SecretName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "minikube",
+			},
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certChain,
+			corev1.TLSPrivateKeyKey: serverKeyPEM,
+		},
+	}
+
+	secretsClient := client.CoreV1().Secrets(namespace)
+
+	_, err := secretsClient.Get(context.Background(), SecretName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			_, err = secretsClient.Create(context.Background(), secret, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to create secret %s/%s: %w", namespace, SecretName, err)
+			}
+			klog.Infof("Created TLS secret %s/%s in cluster", namespace, SecretName)
+			return nil
+		}
+		return fmt.Errorf("failed to get secret %s/%s: %w", namespace, SecretName, err)
+	}
+
+	_, err = secretsClient.Update(context.Background(), secret, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update secret %s/%s: %w", namespace, SecretName, err)
+	}
+	klog.Infof("Updated TLS secret %s/%s in cluster", namespace, SecretName)
+	return nil
+}

--- a/pkg/minikube/certs/https/secret_test.go
+++ b/pkg/minikube/certs/https/secret_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import (
+	"context"
+	"bytes"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCreateOrUpdateTLSSecret(t *testing.T) {
+	client := fake.NewClientset()
+
+	certPEM := []byte("FAKE CERT PEM")
+	caCertPEM := []byte("FAKE CA PEM")
+	keyPEM := []byte("FAKE KEY PEM")
+
+	// Test initial creation
+	err := CreateOrUpdateTLSSecret(client, certPEM, caCertPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("CreateOrUpdateTLSSecret initial failed: %v", err)
+	}
+
+	secret, err := client.CoreV1().Secrets(SecretNamespace).Get(context.Background(), SecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get secret: %v", err)
+	}
+
+	if secret.Type != corev1.SecretTypeTLS {
+		t.Errorf("expected secret type %v, got %v", corev1.SecretTypeTLS, secret.Type)
+	}
+	expectedChain := append([]byte("FAKE CERT PEM"), []byte("FAKE CA PEM")...)
+	if !bytes.Equal(secret.Data[corev1.TLSCertKey], expectedChain) {
+		t.Errorf("cert data mismatch")
+	}
+	if !bytes.Equal(secret.Data[corev1.TLSPrivateKeyKey], keyPEM) {
+		t.Errorf("key data mismatch")
+	}
+
+	// Test update
+	newCertPEM := []byte("NEW FAKE CERT PEM")
+	newCACertPEM := []byte("NEW FAKE CA PEM")
+	newKeyPEM := []byte("NEW FAKE KEY PEM")
+	err = CreateOrUpdateTLSSecret(client, newCertPEM, newCACertPEM, newKeyPEM)
+	if err != nil {
+		t.Fatalf("CreateOrUpdateTLSSecret update failed: %v", err)
+	}
+
+	secret, err = client.CoreV1().Secrets(SecretNamespace).Get(context.Background(), SecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get updated secret: %v", err)
+	}
+	expectedNewChain := append([]byte("NEW FAKE CERT PEM"), []byte("NEW FAKE CA PEM")...)
+	if !bytes.Equal(secret.Data[corev1.TLSCertKey], expectedNewChain) {
+		t.Errorf("updated cert data mismatch")
+	}
+}

--- a/pkg/minikube/certs/https/setup.go
+++ b/pkg/minikube/certs/https/setup.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"regexp"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/style"
+)
+
+// SetupHTTPS orchestrates the zero-configuration trusted HTTPS setup:
+// 1. Checks if CA and cert exist and IP hasn't changed.
+// 2. Generates in-memory CA and signs cluster TLS cert.
+// 3. Installs CA cert in user-level trust store.
+// 4. Persists CA cert & server cert/key in profile directory.
+// 5. Installs TLS secret (minikube-tls) in kube-system namespace.
+// 6. Discards CA key from memory.
+func SetupHTTPS(profile string, clusterIP net.IP, client kubernetes.Interface) error {
+	caPath := CACertPath(profile)
+	serverCertPath := ServerCertPath(profile)
+	serverKeyPath := ServerKeyPath(profile)
+
+	var caCertPEM, serverCertPEM, serverKeyPEM []byte
+	var err error
+
+	if CertificatesExist(profile) && IsCertValidForIP(profile, clusterIP) {
+		klog.Infof("Existing HTTPS certificates for profile %q are valid for IP %s; skipping cert generation", profile, clusterIP)
+		caCertPEM, err = os.ReadFile(caPath)
+		if err != nil {
+			return fmt.Errorf("failed to read CA cert: %w", err)
+		}
+		serverCertPEM, err = os.ReadFile(serverCertPath)
+		if err != nil {
+			return fmt.Errorf("failed to read server cert: %w", err)
+		}
+		serverKeyPEM, err = os.ReadFile(serverKeyPath)
+		if err != nil {
+			return fmt.Errorf("failed to read server key: %w", err)
+		}
+	} else {
+		ts := NewTrustStore()
+		// Remove stale CA from trust store if IP changed or regenerating
+		_ = ts.Remove(profile)
+
+		klog.Infof("Generating new HTTPS CA and TLS certificates for profile %q with IP %s", profile, clusterIP)
+		caCertPEM, serverCertPEM, serverKeyPEM, err = GenerateCerts(profile, clusterIP)
+		if err != nil {
+			return fmt.Errorf("failed to generate HTTPS certificates: %w", err)
+		}
+
+		if err := SaveCertificates(profile, caCertPEM, serverCertPEM, serverKeyPEM); err != nil {
+			return fmt.Errorf("failed to save HTTPS certificates: %w", err)
+		}
+
+	}
+
+	ts := NewTrustStore()
+	if err := ts.Install(caPath, profile); err != nil {
+		out.WarningT("Failed to install CA certificate into user trust store: {{.error}}", out.V{"error": err})
+	} else {
+		out.Step(style.Check, "Installed trusted CA {{.ca}} in the user trust store", out.V{"ca": CAName(profile)})
+	}
+
+	if client != nil {
+		if err := CreateOrUpdateTLSSecret(client, serverCertPEM, caCertPEM, serverKeyPEM); err != nil {
+			out.WarningT("Failed to create/update minikube-tls secret in cluster: {{.error}}", out.V{"error": err})
+		} else {
+			out.Step(style.Check, "Installed TLS certificate for {{.ip}} in the cluster", out.V{"ip": clusterIP})
+		}
+		_ = EnsureTraefikTLSStore(client)
+		_ = SyncIngressHosts(profile, clusterIP, client)
+	}
+
+	return nil
+}
+
+// EnsureTraefikTLSStore configures Traefik default TLSStore to use minikube-tls secret
+func EnsureTraefikTLSStore(client kubernetes.Interface) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = nil
+		}
+	}()
+	if client == nil || client.CoreV1() == nil || client.CoreV1().RESTClient() == nil {
+		return nil
+	}
+	body := []byte(`{
+		"apiVersion": "traefik.io/v1alpha1",
+		"kind": "TLSStore",
+		"metadata": {
+			"name": "default",
+			"namespace": "kube-system"
+		},
+		"spec": {
+			"defaultCertificate": {
+				"secretName": "minikube-tls"
+			}
+		}
+	}`)
+	restClient := client.CoreV1().RESTClient()
+	err = restClient.Post().
+		AbsPath("/apis/traefik.io/v1alpha1/namespaces/kube-system/tlsstores").
+		Body(body).
+		Do(context.Background()).
+		Error()
+	if err != nil {
+		klog.V(2).Infof("Traefik default TLSStore setup: %v", err)
+	}
+	return nil
+}
+
+// SyncIngressHosts scans all cluster Ingress resources, extracts hosts, re-issues certs if needed,
+// and syncs the minikube-tls secret into namespaces where Ingresses are deployed.
+func SyncIngressHosts(profile string, clusterIP net.IP, client kubernetes.Interface) error {
+	if client == nil {
+		return nil
+	}
+
+	ingresses, err := client.NetworkingV1().Ingresses("").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list ingresses for HTTPS host sync: %w", err)
+	}
+
+	caPath := CACertPath(profile)
+	serverCertPath := ServerCertPath(profile)
+	serverKeyPath := ServerKeyPath(profile)
+
+	caCertPEM, err := os.ReadFile(caPath)
+	if err != nil {
+		return fmt.Errorf("failed to read CA cert: %w", err)
+	}
+	serverCertPEM, err := os.ReadFile(serverCertPath)
+	if err != nil {
+		return fmt.Errorf("failed to read server cert: %w", err)
+	}
+	serverKeyPEM, err := os.ReadFile(serverKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to read server key: %w", err)
+	}
+
+	hostMap := make(map[string]bool)
+	namespaces := make(map[string]bool)
+	namespaces[SecretNamespace] = true
+
+	for _, ing := range ingresses.Items {
+		namespaces[ing.Namespace] = true
+		for _, rule := range ing.Spec.Rules {
+			if rule.Host != "" {
+				hostMap[rule.Host] = true
+			}
+		}
+	}
+
+	var hosts []string
+	for h := range hostMap {
+		hosts = append(hosts, h)
+	}
+
+	// Re-issue certificate if new hosts were discovered
+	if len(hosts) > 0 {
+		klog.Infof("Syncing %d Ingress host(s) into HTTPS TLS certificate for profile %q: %v", len(hosts), profile, hosts)
+		caCertPEM, serverCertPEM, serverKeyPEM, err = GenerateCerts(profile, clusterIP, hosts...)
+		if err == nil {
+			_ = SaveCertificates(profile, caCertPEM, serverCertPEM, serverKeyPEM)
+			ts := NewTrustStore()
+			_ = ts.Install(caPath, profile)
+		}
+	}
+
+	// Sync secret into all namespaces where ingresses exist
+	for ns := range namespaces {
+		if err := CreateOrUpdateTLSSecretInNamespace(client, ns, serverCertPEM, caCertPEM, serverKeyPEM); err != nil {
+			klog.Warningf("Failed to sync minikube-tls secret to namespace %s: %v", ns, err)
+		}
+	}
+
+	_ = SyncEtcHosts(clusterIP, hosts)
+
+	return nil
+}
+
+// SyncEtcHosts updates /etc/hosts with the cluster IP and discovered Ingress hosts
+func SyncEtcHosts(clusterIP net.IP, hosts []string) error {
+	if clusterIP == nil || len(hosts) == 0 {
+		return nil
+	}
+	hostsPath := "/etc/hosts"
+	content, err := os.ReadFile(hostsPath)
+	if err != nil {
+		return nil
+	}
+
+	startMarker := "# minikube-hosts-start"
+	endMarker := "# minikube-hosts-end"
+
+	var cleanHosts []string
+	for _, h := range hosts {
+		if h != "" && !strings.Contains(h, "*") {
+			cleanHosts = append(cleanHosts, h)
+		}
+	}
+	if len(cleanHosts) == 0 {
+		return nil
+	}
+
+	hostLine := fmt.Sprintf("%s %s", clusterIP.String(), strings.Join(cleanHosts, " "))
+	block := fmt.Sprintf("%s\n%s\n%s\n", startMarker, hostLine, endMarker)
+
+	strContent := string(content)
+	if strings.Contains(strContent, startMarker) {
+		re := regexp.MustCompile(fmt.Sprintf("(?s)%s.*?%s\n?", regexp.QuoteMeta(startMarker), regexp.QuoteMeta(endMarker)))
+		strContent = re.ReplaceAllString(strContent, block)
+	} else {
+		strContent += "\n" + block
+	}
+
+	if err := os.WriteFile(hostsPath, []byte(strContent), 0644); err != nil {
+		klog.V(2).Infof("Could not auto-update /etc/hosts (requires root privileges): %v", err)
+		return err
+	}
+	klog.Infof("Auto-updated /etc/hosts with %d Ingress host(s)", len(cleanHosts))
+	return nil
+}
+
+// CleanupHTTPS removes the CA cert from the user-level trust store on cluster deletion.
+func CleanupHTTPS(profile string) error {
+	ts := NewTrustStore()
+	return ts.Remove(profile)
+}

--- a/pkg/minikube/certs/https/setup_test.go
+++ b/pkg/minikube/certs/https/setup_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestSetupHTTPSAndCleanup(t *testing.T) {
+	profile := "test-https-profile"
+	ip1 := net.ParseIP("192.168.49.2")
+	ip2 := net.ParseIP("192.168.49.3")
+
+	client := fake.NewClientset()
+
+	// Clean up any left-over test files at the end
+	defer func() {
+		_ = os.RemoveAll(CACertPath(profile))
+		_ = os.RemoveAll(ServerCertPath(profile))
+		_ = os.RemoveAll(ServerKeyPath(profile))
+		_ = CleanupHTTPS(profile)
+	}()
+
+	// Step 1: Initial SetupHTTPS
+	if err := SetupHTTPS(profile, ip1, client); err != nil {
+		t.Fatalf("SetupHTTPS failed: %v", err)
+	}
+
+	// Verify certificate files exist on disk
+	if !CertificatesExist(profile) {
+		t.Errorf("expected certificate files to exist on disk for profile %s", profile)
+	}
+
+	// Verify IP validity check
+	if !IsCertValidForIP(profile, ip1) {
+		t.Errorf("expected cert to be valid for IP %s", ip1)
+	}
+	if IsCertValidForIP(profile, ip2) {
+		t.Errorf("expected cert NOT to be valid for IP %s yet", ip2)
+	}
+
+	// Verify Kubernetes secret in kube-system namespace
+	secret, err := client.CoreV1().Secrets(SecretNamespace).Get(context.Background(), SecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to retrieve TLS secret from cluster: %v", err)
+	}
+	if secret.Type != corev1.SecretTypeTLS {
+		t.Errorf("expected secret type %v, got %v", corev1.SecretTypeTLS, secret.Type)
+	}
+	if len(secret.Data[corev1.TLSCertKey]) == 0 || len(secret.Data[corev1.TLSPrivateKeyKey]) == 0 {
+		t.Errorf("secret data tls.crt or tls.key is empty")
+	}
+
+	// Verify OS trust store installation
+	verifyTrustStoreInstalled(t, profile)
+
+	// Step 2: Idempotent SetupHTTPS call with same IP
+	caModTime1, _ := os.Stat(CACertPath(profile))
+	if err := SetupHTTPS(profile, ip1, client); err != nil {
+		t.Fatalf("SetupHTTPS second call failed: %v", err)
+	}
+	caModTime2, _ := os.Stat(CACertPath(profile))
+	if caModTime1.ModTime() != caModTime2.ModTime() {
+		t.Errorf("expected certificate files to be preserved on identical IP call")
+	}
+
+	// Step 3: Call SetupHTTPS with new IP (ip2) -> triggers regeneration
+	if err := SetupHTTPS(profile, ip2, client); err != nil {
+		t.Fatalf("SetupHTTPS with new IP failed: %v", err)
+	}
+	if !IsCertValidForIP(profile, ip2) {
+		t.Errorf("expected regenerated cert to be valid for new IP %s", ip2)
+	}
+
+	// Step 4: CleanupHTTPS
+	if err := CleanupHTTPS(profile); err != nil {
+		t.Fatalf("CleanupHTTPS failed: %v", err)
+	}
+
+	// Verify removal from OS trust store
+	verifyTrustStoreRemoved(t, profile)
+}
+
+func TestSyncIngressHosts(t *testing.T) {
+	profile := "test-sync-ingress-profile"
+	ip := net.ParseIP("192.168.49.2")
+
+	client := fake.NewClientset()
+	defer func() {
+		_ = os.RemoveAll(CACertPath(profile))
+		_ = os.RemoveAll(ServerCertPath(profile))
+		_ = os.RemoveAll(ServerKeyPath(profile))
+		_ = CleanupHTTPS(profile)
+	}()
+
+	if err := SetupHTTPS(profile, ip, client); err != nil {
+		t.Fatalf("SetupHTTPS failed: %v", err)
+	}
+
+	// Create an Ingress in default namespace with host myapp.example
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ingress",
+			Namespace: "default",
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: "myapp.example",
+				},
+			},
+		},
+	}
+	_, err := client.NetworkingV1().Ingresses("default").Create(context.Background(), ing, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create fake ingress: %v", err)
+	}
+
+	if err := SyncIngressHosts(profile, ip, client); err != nil {
+		t.Fatalf("SyncIngressHosts failed: %v", err)
+	}
+
+	// Verify minikube-tls secret was created in default namespace
+	secret, err := client.CoreV1().Secrets("default").Get(context.Background(), SecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected minikube-tls secret to be synced to default namespace: %v", err)
+	}
+	if secret.Type != corev1.SecretTypeTLS {
+		t.Errorf("expected secret type %v, got %v", corev1.SecretTypeTLS, secret.Type)
+	}
+}

--- a/pkg/minikube/certs/https/truststore.go
+++ b/pkg/minikube/certs/https/truststore.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import "fmt"
+
+// TrustStore represents an OS-specific user certificate trust store.
+type TrustStore interface {
+	Install(caCertPath string, profile string) error
+	Remove(profile string) error
+}
+
+// NewTrustStore returns the TrustStore implementation for the current OS.
+func NewTrustStore() TrustStore {
+	return newTrustStore()
+}
+
+// CAName returns the canonical name of the CA certificate for a profile.
+func CAName(profile string) string {
+	return fmt.Sprintf("minikube-%s", profile)
+}

--- a/pkg/minikube/certs/https/truststore_darwin.go
+++ b/pkg/minikube/certs/https/truststore_darwin.go
@@ -1,0 +1,83 @@
+//go:build darwin
+
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"k8s.io/client-go/util/homedir"
+	"k8s.io/klog/v2"
+)
+
+type darwinTrustStore struct{}
+
+func newTrustStore() TrustStore {
+	return &darwinTrustStore{}
+}
+
+func (s *darwinTrustStore) getKeychainPath() string {
+	loginDb := filepath.Join(homedir.HomeDir(), "Library", "Keychains", "login.keychain-db")
+	if _, err := os.Stat(loginDb); err == nil {
+		return loginDb
+	}
+	return filepath.Join(homedir.HomeDir(), "Library", "Keychains", "login.keychain")
+}
+
+func (s *darwinTrustStore) Install(caCertPath string, profile string) error {
+	securityPath, err := exec.LookPath("security")
+	if err != nil {
+		return fmt.Errorf("security CLI tool not found: %w", err)
+	}
+
+	keychain := s.getKeychainPath()
+	caName := CAName(profile)
+
+	// Remove existing cert if any
+	_ = exec.Command(securityPath, "delete-certificate", "-c", caName, keychain).Run()
+
+	// Add to login keychain as trusted root
+	cmd := exec.Command(securityPath, "add-trusted-cert", "-d", "-r", "trustRoot", "-k", keychain, caCertPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to add CA to macOS keychain: %s: %w", string(out), err)
+	}
+
+	klog.Infof("Successfully installed CA %q into macOS Login Keychain", caName)
+	return nil
+}
+
+func (s *darwinTrustStore) Remove(profile string) error {
+	securityPath, err := exec.LookPath("security")
+	if err != nil {
+		return nil
+	}
+
+	keychain := s.getKeychainPath()
+	caName := CAName(profile)
+
+	cmd := exec.Command(securityPath, "delete-certificate", "-c", caName, keychain)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		klog.Warningf("Failed to remove CA %q from macOS keychain: %s", caName, string(out))
+	} else {
+		klog.Infof("Successfully removed CA %q from macOS Login Keychain", caName)
+	}
+	return nil
+}

--- a/pkg/minikube/certs/https/truststore_darwin_test.go
+++ b/pkg/minikube/certs/https/truststore_darwin_test.go
@@ -1,0 +1,46 @@
+//go:build darwin
+
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func verifyTrustStoreInstalled(t *testing.T, profile string) {
+	if _, err := exec.LookPath("security"); err == nil {
+		keychain := (&darwinTrustStore{}).getKeychainPath()
+		caName := CAName(profile)
+		cmd := exec.Command("security", "find-certificate", "-c", caName, keychain)
+		if err := cmd.Run(); err != nil {
+			t.Errorf("expected CA certificate %s to be found in macOS keychain: %v", caName, err)
+		}
+	}
+}
+
+func verifyTrustStoreRemoved(t *testing.T, profile string) {
+	if _, err := exec.LookPath("security"); err == nil {
+		keychain := (&darwinTrustStore{}).getKeychainPath()
+		caName := CAName(profile)
+		cmd := exec.Command("security", "find-certificate", "-c", caName, keychain)
+		if err := cmd.Run(); err == nil {
+			t.Errorf("expected CA certificate %s to be removed from macOS keychain after CleanupHTTPS", caName)
+		}
+	}
+}

--- a/pkg/minikube/certs/https/truststore_linux.go
+++ b/pkg/minikube/certs/https/truststore_linux.go
@@ -1,0 +1,101 @@
+//go:build linux
+
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"k8s.io/client-go/util/homedir"
+	"k8s.io/klog/v2"
+)
+
+type linuxTrustStore struct{}
+
+func newTrustStore() TrustStore {
+	return &linuxTrustStore{}
+}
+
+func (s *linuxTrustStore) getNSSDBDir() string {
+	return filepath.Join(homedir.HomeDir(), ".pki", "nssdb")
+}
+
+func (s *linuxTrustStore) ensureNSSDB() error {
+	dbDir := s.getNSSDBDir()
+	if _, err := os.Stat(dbDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(dbDir, 0700); err != nil {
+			return fmt.Errorf("failed to create NSS DB directory %s: %w", dbDir, err)
+		}
+		// Initialize empty NSS DB without password
+		dbPath := fmt.Sprintf("sql:%s", dbDir)
+		cmd := exec.Command("certutil", "-d", dbPath, "-N", "--empty-password")
+		if err := cmd.Run(); err != nil {
+			klog.Warningf("Failed to initialize NSS database at %s: %v", dbDir, err)
+		}
+	}
+	return nil
+}
+
+func (s *linuxTrustStore) Install(caCertPath string, profile string) error {
+	certutilPath, err := exec.LookPath("certutil")
+	if err != nil {
+		return fmt.Errorf("certutil not found in PATH (please install libnss3-tools / nss-tools): %w", err)
+	}
+
+	if err := s.ensureNSSDB(); err != nil {
+		return err
+	}
+
+	dbDir := s.getNSSDBDir()
+	dbPath := fmt.Sprintf("sql:%s", dbDir)
+	caName := CAName(profile)
+
+	// Remove existing cert if any
+	_ = exec.Command(certutilPath, "-d", dbPath, "-D", "-n", caName).Run()
+
+	// Add cert to NSS database with trust flags for SSL/TLS ("TCu,cu,cu")
+	cmd := exec.Command(certutilPath, "-d", dbPath, "-A", "-t", "TCu,cu,cu", "-n", caName, "-i", caCertPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to add CA to NSS trust store: %s: %w", string(out), err)
+	}
+
+	klog.Infof("Successfully installed CA %q into Linux NSS trust store (%s)", caName, dbDir)
+	return nil
+}
+
+func (s *linuxTrustStore) Remove(profile string) error {
+	certutilPath, err := exec.LookPath("certutil")
+	if err != nil {
+		return nil // If certutil is not installed, nothing to remove
+	}
+
+	dbDir := s.getNSSDBDir()
+	dbPath := fmt.Sprintf("sql:%s", dbDir)
+	caName := CAName(profile)
+
+	cmd := exec.Command(certutilPath, "-d", dbPath, "-D", "-n", caName)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		klog.Warningf("Failed to remove CA %q from NSS trust store: %s", caName, string(out))
+	} else {
+		klog.Infof("Successfully removed CA %q from Linux NSS trust store", caName)
+	}
+	return nil
+}

--- a/pkg/minikube/certs/https/truststore_linux_test.go
+++ b/pkg/minikube/certs/https/truststore_linux_test.go
@@ -1,0 +1,46 @@
+//go:build linux
+
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func verifyTrustStoreInstalled(t *testing.T, profile string) {
+	if _, err := exec.LookPath("certutil"); err == nil {
+		dbPath := "sql:" + (&linuxTrustStore{}).getNSSDBDir()
+		caName := CAName(profile)
+		cmd := exec.Command("certutil", "-d", dbPath, "-L", "-n", caName)
+		if err := cmd.Run(); err != nil {
+			t.Errorf("expected CA certificate %s to be found in NSS trust store: %v", caName, err)
+		}
+	}
+}
+
+func verifyTrustStoreRemoved(t *testing.T, profile string) {
+	if _, err := exec.LookPath("certutil"); err == nil {
+		dbPath := "sql:" + (&linuxTrustStore{}).getNSSDBDir()
+		caName := CAName(profile)
+		cmd := exec.Command("certutil", "-d", dbPath, "-L", "-n", caName)
+		if err := cmd.Run(); err == nil {
+			t.Errorf("expected CA certificate %s to be removed from NSS trust store after CleanupHTTPS", caName)
+		}
+	}
+}

--- a/pkg/minikube/certs/https/truststore_other.go
+++ b/pkg/minikube/certs/https/truststore_other.go
@@ -1,0 +1,35 @@
+//go:build !linux && !darwin && !windows
+
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import "fmt"
+
+type unsupportedTrustStore struct{}
+
+func newTrustStore() TrustStore {
+	return &unsupportedTrustStore{}
+}
+
+func (s *unsupportedTrustStore) Install(caCertPath string, profile string) error {
+	return fmt.Errorf("trust store integration is not supported on this operating system")
+}
+
+func (s *unsupportedTrustStore) Remove(profile string) error {
+	return nil
+}

--- a/pkg/minikube/certs/https/truststore_other_test.go
+++ b/pkg/minikube/certs/https/truststore_other_test.go
@@ -1,0 +1,24 @@
+//go:build !linux && !darwin
+
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import "testing"
+
+func verifyTrustStoreInstalled(t *testing.T, profile string) {}
+func verifyTrustStoreRemoved(t *testing.T, profile string)   {}

--- a/pkg/minikube/certs/https/truststore_windows.go
+++ b/pkg/minikube/certs/https/truststore_windows.go
@@ -1,0 +1,70 @@
+//go:build windows
+
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import (
+	"fmt"
+	"os/exec"
+
+	"k8s.io/klog/v2"
+)
+
+type windowsTrustStore struct{}
+
+func newTrustStore() TrustStore {
+	return &windowsTrustStore{}
+}
+
+func (s *windowsTrustStore) Install(caCertPath string, profile string) error {
+	certutilPath, err := exec.LookPath("certutil.exe")
+	if err != nil {
+		certutilPath = "certutil.exe"
+	}
+
+	caName := CAName(profile)
+
+	// Delete existing if any
+	_ = exec.Command(certutilPath, "-user", "-delstore", "Root", caName).Run()
+
+	// Add to user store Root
+	cmd := exec.Command(certutilPath, "-user", "-addstore", "Root", caCertPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to add CA to Windows user certificate store: %s: %w", string(out), err)
+	}
+
+	klog.Infof("Successfully installed CA %q into Windows user certificate store", caName)
+	return nil
+}
+
+func (s *windowsTrustStore) Remove(profile string) error {
+	certutilPath, err := exec.LookPath("certutil.exe")
+	if err != nil {
+		certutilPath = "certutil.exe"
+	}
+
+	caName := CAName(profile)
+
+	cmd := exec.Command(certutilPath, "-user", "-delstore", "Root", caName)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		klog.Warningf("Failed to remove CA %q from Windows user certificate store: %s", caName, string(out))
+	} else {
+		klog.Infof("Successfully removed CA %q from Windows user certificate store", caName)
+	}
+	return nil
+}

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -114,6 +114,7 @@ type ClusterConfig struct {
 	VmnetOffloading         bool          // Only used by krunkit driver
 	DNSServers              []netip.Addr  // Static DNS servers for the VM (VM drivers only)
 	MDNS                    bool          // Enable mDNS (.local) resolution via systemd-resolved
+	HTTPS                   bool          // Install trusted TLS certificate and CA in user trust store
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -63,6 +63,7 @@ minikube start [flags]
       --host-dns-resolver                 Enable host resolver for NAT DNS requests (virtualbox driver only) (default true)
       --host-only-cidr string             The CIDR to be used for the minikube VM (virtualbox driver only) (default "192.168.59.1/24")
       --host-only-nic-type string         NIC Type used for host only network. One of Am79C970A, Am79C973, 82540EM, 82543GC, 82545EM, or virtio (virtualbox driver only) (default "virtio")
+      --https                             Install a trusted TLS certificate in the cluster and add the CA to the browser trust store. Enables HTTPS access to minikube services without security warnings.
       --hyperkit-vpnkit-sock string       Location of the VPNKit socket used for networking. If empty, disables Hyperkit VPNKitSock, if 'auto' uses Docker for Mac VPNKit connection, otherwise uses the specified VSock (hyperkit driver only)
       --hyperkit-vsock-ports strings      List of guest VSock ports that should be exposed as sockets on the host (hyperkit driver only)
       --hyperv-external-adapter string    External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)

--- a/site/content/en/docs/tutorials/trusted_https.md
+++ b/site/content/en/docs/tutorials/trusted_https.md
@@ -1,0 +1,110 @@
+---
+title: "Zero-Configuration Trusted HTTPS with minikube"
+linkTitle: "Trusted HTTPS Setup"
+weight: 1
+---
+
+## Overview
+
+minikube provides zero-configuration trusted HTTPS access for Kubernetes applications running in your local cluster.
+
+When starting minikube with the `--https` flag:
+1. **Root CA Generation**: An in-memory Certificate Authority (CA) is generated (`minikube-<profile>`) and signs a server TLS certificate for the cluster's IP address and Subject Alternative Names (SANs).
+2. **Host OS Trust Store Integration**: The Root CA is automatically installed into your operating system's trust store (Linux NSS database `~/.pki/nssdb` with `TCu,cu,cu`, macOS Keychain, Windows Certificate Store) so web browsers and tools trust the cluster certificates without security warnings.
+3. **Cluster TLS Secret Provisioning**: A standard Kubernetes TLS Secret named `minikube-tls` (containing `tls.crt` and `tls.key`) is created in `kube-system` and automatically synced into target namespaces.
+4. **Ingress Host Discovery**: minikube automatically discovers hostnames in cluster `Ingress` resources, re-issues server certificates with all disovered SANs, updates `/etc/hosts`, and configures Traefik's default `TLSStore`.
+
+---
+
+## Complete Tutorial & Workflow Guide
+
+### Step 1: Start minikube with `--https`
+
+```bash
+minikube start --https
+```
+
+Output:
+```text
+✅ Installed trusted CA minikube-minikube in the user trust store
+✅ Installed TLS certificate for 192.168.49.2 in the cluster
+```
+
+> **Note for Web Browsers**: Browsers (Chrome / Edge) cache NSS trust databases in memory while running. Restart your browser once after cluster startup to reload the updated trust store.
+
+---
+
+### Step 2: Enable the Traefik Ingress Addon
+
+Enable Traefik as the cluster Ingress Controller:
+
+```bash
+minikube addons enable traefik
+```
+
+---
+
+### Step 3: Deploy an Application and Ingress
+
+Deploy an example application and expose it with a standard Kubernetes `Ingress` resource:
+
+```bash
+cat << 'EOF' | kubectl apply -f -
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp-ingress
+  namespace: default
+spec:
+  ingressClassName: traefik
+  rules:
+  - host: traefik.example
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: podinfo-ui-svc
+            port:
+              number: 9898
+EOF
+```
+
+> **Note**: You do not even need to specify a `tls:` section in your Ingress manifest! minikube configures Traefik's default `TLSStore` to automatically serve the trusted `minikube-tls` certificate for all HTTPS traffic.
+
+---
+
+### Step 4: Verify Trusted HTTPS Access
+
+Minikube automatically syncs discovered Ingress hostnames to `/etc/hosts`. You can test access via `curl` or in your web browser:
+
+```bash
+curl -v https://traefik.example
+```
+
+Example Output:
+```text
+* Hostname traefik.example was found in DNS cache
+* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
+* Server certificate:
+*   subject: O=minikube; CN=minikube-minikube-server
+*   issuer: O=minikube; CN=minikube-minikube
+*   subjectAltName: "traefik.example" matches cert's "traefik.example"
+* SSL certificate verified via OpenSSL.
+* Established connection to traefik.example (192.168.49.2 port 443) using HTTP/2
+
+< HTTP/2 200 OK
+```
+
+Open [**https://traefik.example**](https://traefik.example) in your browser — it connects securely with a valid green lock and zero security warnings.
+
+---
+
+### Step 5: Profile Deletion & Cleanup
+
+When deleting the cluster profile, minikube automatically removes the CA certificate from your host operating system's trust store to leave your host clean:
+
+```bash
+minikube delete
+```


### PR DESCRIPTION
### Draft Prototype: Zero-Configuration Trusted HTTPS (`--https`)                                                                                                                                         
                                                                                                                                                                                                                 
This is an initial draft prototype for **Zero-Configuration Trusted HTTPS (`--https`)** in minikube. It is intended for early testing, feedback, and discussion.                                             

                                                                                                                                                                                                  
###  What Works                                                                                                                                                                                        - **Zero-Config Root CA & Host Trust**:                                                                                                                                                                      - Automatically generates an in-memory Root CA (`minikube-<profile>`).                                                                                                                                     
- Automatically registers the CA in host trust stores:                                                                                                                                                     
        - **Linux**: NSS DB (`~/.pki/nssdb`) with `TCu,cu,cu` trust flags for Chrome/Chromium.                                                                                                                   
        - **macOS**: Login Keychain (`security add-trusted-cert`).                                                                                                                                               
        - **Windows**: User Root Certificate Store (`certutil.exe -user -addstore Root`).                                                                                                                        
- **Dynamic Ingress Discovery & SAN Re-Issuance**:                                                                                                                                                           
      - Automatically scans cluster `Ingress` resources, extracts hostnames (e.g. `traefik.example`, `myapp.example`), re-issues server certs containing all discovered SANs, and syncs `minikube-tls` secrets across namespaces.                                                                                                                                                                                             
- **Traefik Addon TLSStore Provisioning**:                                                                                                                                                                   
      - Configures Traefik's default `TLSStore` CRD to point to `minikube-tls` so all deployed Ingresses are served over trusted HTTPS without requiring manual `tls:` fields in user manifests.                 
- **Automated `/etc/hosts` Synchronization**:                                                                                                                                                                
      - Syncs discovered Ingress hostnames to `/etc/hosts` mapping to `minikube ip`.                                                                                                                             
                                                                                                                                                                                                                 
    ---                                                                                                                                                                                                          
                                                                                                                                                                                                                 
###  Known Issues / Open Questions for Feedback                                                                                                                                                            
1. **Host Resolver Driver**:                                                                                                                                                                                 
       - Exploring native integration with `ingress-dns` / `systemd-resolved` / macOS `/etc/resolver` to avoid `/etc/hosts` modifications.                                                                       
2. **Cluster Addon Interface**:                                                                                                                                                                              
       - Evaluating exposing `minikube addons enable https` so users with existing running clusters can toggle trusted HTTPS on the fly.                                                                         
3. **Browser Cache Behaviour **:                                                                                                                                                                               
       - Web browsers (Chrome/Edge) cache NSS trust databases in memory while open; restarting the browser is required after CA registration.                                                                    
  
Fixes #23385
                                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                 
###  How to Try It                                                                                                                                                                                         
                                                                                                                                                                                                                 
```bash                                                                                                                                                                                                      
    make out/minikube                                                                                                                                                                                            
    ./out/minikube start --https                                                                                                                                                                                 
    ./out/minikube addons enable traefik                                                                                                                                                                         
                                                                                                                                                                                                                 
    # Apply any standard ingress (e.g. host: traefik.example)                                                                                                                                                    
    kubectl apply -f example-ingress.yaml                                                                                                                                                                        
                                                                                                                                                                                                                 
    # Test HTTPS connection in browser or terminal                                                                                                                                                               
    curl -v https://traefik.example    