### PR TITLE
ssh_runner: support stdin in RunCmd

### DIFF
--- a/pkg/minikube/command/ssh_runner.go
+++ b/pkg/minikube/command/ssh_runner.go
@@ -154,8 +154,9 @@ func (s *SSHRunner) Remove(f assets.CopyableFile) error {
 	return sess.Run(fmt.Sprintf("sudo rm %s", dst))
 }
 
-// teeSSH runs an SSH command, streaming stdout, stderr to logs
-func teeSSH(s *ssh.Session, cmd string, outB io.Writer, errB io.Writer) error {
+// teeSSH runs an SSH command, streaming stdout, stderr to logs, and inR (when
+// non-nil) to the remote command's stdin.
+func teeSSH(s *ssh.Session, cmd string, outB io.Writer, errB io.Writer, inR io.Reader) error {
 	outPipe, err := s.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("stdout: %w", err)
@@ -165,6 +166,26 @@ func teeSSH(s *ssh.Session, cmd string, outB io.Writer, errB io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("stderr: %w", err)
 	}
+
+	// Errors writing stdin are returned rather than only logged: a truncated
+	// stdin silently corrupts what the remote command consumes.
+	var g errgroup.Group
+	if inR != nil {
+		inPipe, err := s.StdinPipe()
+		if err != nil {
+			return fmt.Errorf("stdin: %w", err)
+		}
+		g.Go(func() error {
+			// Closing signals EOF, without which commands reading until EOF
+			// (docker load, podman load) never terminate.
+			defer inPipe.Close()
+			if _, err := io.Copy(inPipe, inR); err != nil {
+				return fmt.Errorf("copy stdin: %w", err)
+			}
+			return nil
+		})
+	}
+
 	var wg sync.WaitGroup
 	wg.Go(func() {
 		if err := teePrefix(ErrPrefix, errPipe, errB, klog.V(8).Infof); err != nil {
@@ -178,15 +199,17 @@ func teeSSH(s *ssh.Session, cmd string, outB io.Writer, errB io.Writer) error {
 	})
 	err = s.Run(cmd)
 	wg.Wait()
-	return err
+
+	// Report the command's own failure first: if it exited early, the stdin
+	// copy failing with a closed pipe is a symptom, not the cause.
+	if err != nil {
+		return err
+	}
+	return g.Wait()
 }
 
 // RunCmd implements the Command Runner interface to run a exec.Cmd object
 func (s *SSHRunner) RunCmd(cmd *exec.Cmd) (*RunResult, error) {
-	if cmd.Stdin != nil {
-		return nil, errors.New("SSHRunner does not support stdin - you could be the first to add it")
-	}
-
 	rr := &RunResult{Args: cmd.Args}
 	klog.Infof("Run: %v", rr.Command())
 
@@ -220,7 +243,7 @@ func (s *SSHRunner) RunCmd(cmd *exec.Cmd) (*RunResult, error) {
 		}
 	}()
 
-	err = teeSSH(sess, shellquote.Join(cmd.Args...), outb, errb)
+	err = teeSSH(sess, shellquote.Join(cmd.Args...), outb, errb, cmd.Stdin)
 	elapsed := time.Since(start)
 
 	rr.ExitCode = s.exitCode(err)

--- a/pkg/minikube/command/ssh_runner_test.go
+++ b/pkg/minikube/command/ssh_runner_test.go
@@ -122,3 +122,84 @@ func TestSSHRunner(t *testing.T) {
 		}
 	})
 }
+
+// TestSSHRunnerStdin verifies that data on cmd.Stdin reaches the remote command,
+// which is what lets callers pipe an image straight into "docker load" instead of
+// staging a temporary copy on the host.
+func TestSSHRunnerStdin(t *testing.T) {
+	commands := map[string]tests.CommandResult{
+		"echo-stdin":      {EchoStdin: true},
+		"echo-stdin-fail": {EchoStdin: true, ExitCode: 1},
+	}
+
+	s, err := tests.NewSSHServer(t, commands)
+	if err != nil {
+		t.Fatalf("NewSSHServer: %v", err)
+	}
+	if err := s.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer s.Stop()
+
+	client, err := s.Dial()
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer client.Close()
+
+	runner := &SSHRunner{c: client}
+
+	t.Run("streams stdin to the remote command", func(t *testing.T) {
+		cmd := exec.Command("echo-stdin")
+		cmd.Stdin = strings.NewReader("piped payload")
+
+		rr, err := runner.RunCmd(cmd)
+		if err != nil {
+			t.Fatalf("RunCmd: %v", err)
+		}
+		if rr.Stdout.String() != "piped payload" {
+			t.Errorf("Stdout = %q, want %q", rr.Stdout.String(), "piped payload")
+		}
+	})
+
+	t.Run("large input is streamed whole", func(t *testing.T) {
+		// Bigger than a single SSH channel window, so a partial write would show up here.
+		want := strings.Repeat("abcdefgh", 128*1024) // 1 MiB
+		cmd := exec.Command("echo-stdin")
+		cmd.Stdin = strings.NewReader(want)
+
+		rr, err := runner.RunCmd(cmd)
+		if err != nil {
+			t.Fatalf("RunCmd: %v", err)
+		}
+		if got := rr.Stdout.String(); got != want {
+			t.Errorf("Stdout length = %d, want %d", len(got), len(want))
+		}
+	})
+
+	t.Run("command failure still reports the exit code", func(t *testing.T) {
+		cmd := exec.Command("echo-stdin-fail")
+		cmd.Stdin = strings.NewReader("payload")
+
+		rr, err := runner.RunCmd(cmd)
+		if err == nil {
+			t.Errorf("err = nil, want error")
+		}
+		if rr == nil {
+			t.Fatalf("RunResult = nil, want a result carrying the exit code")
+		}
+		if rr.ExitCode != 1 {
+			t.Errorf("ExitCode = %d, want 1", rr.ExitCode)
+		}
+	})
+
+	t.Run("nil stdin still works", func(t *testing.T) {
+		rr, err := runner.RunCmd(exec.Command("echo-stdin"))
+		if err != nil {
+			t.Fatalf("RunCmd: %v", err)
+		}
+		if rr.Stdout.String() != "" {
+			t.Errorf("Stdout = %q, want empty", rr.Stdout.String())
+		}
+	})
+}

--- a/pkg/minikube/tests/ssh_mock.go
+++ b/pkg/minikube/tests/ssh_mock.go
@@ -23,6 +23,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"net"
 	"sync/atomic"
@@ -37,6 +38,10 @@ type CommandResult struct {
 	Stdout   string
 	Stderr   string
 	ExitCode int
+
+	// EchoStdin makes the command copy anything it receives on stdin to stdout,
+	// so tests can assert that input reached the remote side.
+	EchoStdin bool
 }
 
 // SSHServer is a test SSH server returning preconfigured responses.
@@ -202,6 +207,13 @@ func (s *SSHServer) doExec(channel ssh.Channel, req *ssh.Request) {
 		result = CommandResult{
 			Stderr:   fmt.Sprintf("%s: command not found", cmd.Command),
 			ExitCode: 127,
+		}
+	}
+
+	if result.EchoStdin {
+		if _, err := io.Copy(channel, channel); err != nil {
+			s.t.Errorf("Failed to echo stdin: %v", err)
+			return
 		}
 	}
 


### PR DESCRIPTION
This is piece 1 of the three-way split agreed with @nirs on #23115. It lands the blocker on its own so the two load-path changes can follow independently.

## Problem

`SSHRunner.RunCmd` rejected any command with stdin set:

```go
if cmd.Stdin != nil {
	return nil, errors.New("SSHRunner does not support stdin - you could be the first to add it")
}
```

That is what forces `minikube image load` to stage a temporary copy on the host before sending it to the VM, since nothing can be piped into `docker load` on the remote side.

This is a gap between the two runners rather than a new capability: `kicRunner.RunCmd` already supports stdin (`kic_runner.go:60` appends `-i`, line 87 assigns `oc.Stdin`). Only the SSH-based drivers lacked it, so this brings `SSHRunner` up to parity.

## Change

`teeSSH` takes an `io.Reader` alongside the two output writers and, when it is non-nil, copies it into `sess.StdinPipe()` from an `errgroup` goroutine. This follows the pattern `SSHRunner.Copy` already uses at `ssh_runner.go:369`, including the `defer inPipe.Close()` that gives the remote its EOF. Without it, commands that read until EOF (`docker load`, `podman load`) never terminate.

Two deliberate choices worth flagging for review:

- **Stdin copy errors are returned, not just logged.** A truncated stdin silently corrupts what the remote command consumes, which is a much worse failure than a noisy one. The existing stdout/stderr tee goroutines only log, because a lost log line is cosmetic.
- **The command's own error takes precedence over the stdin error.** If the remote command exits early, the stdin copy fails on a closed pipe as a *symptom*. Reporting that instead of the real exit would point review at the wrong end of the pipe.

Behavior for every existing caller is unchanged: `cmd.Stdin` is nil for all of them, so no stdin pipe is requested and `teeSSH` runs exactly as before.

## Test

New `TestSSHRunnerStdin` against the existing SSH mock server, which gains an `EchoStdin` command result that copies its input back to stdout:

- stdin reaches the remote command
- 1 MiB of input arrives whole (larger than a single SSH channel window, so a partial write shows up)
- a failing command still reports its exit code rather than the stdin-side error
- nil stdin still works, covering the unchanged path

```
$ go test -count=1 ./pkg/minikube/command/
ok  	k8s.io/minikube/pkg/minikube/command	0.134s
```

Refs #23115

