### PR TITLE
image load: stream images into docker and cri-o instead of copying them into the guest first

### DIFF
--- a/pkg/minikube/command/ssh_runner.go
+++ b/pkg/minikube/command/ssh_runner.go
@@ -154,8 +154,9 @@ func (s *SSHRunner) Remove(f assets.CopyableFile) error {
 	return sess.Run(fmt.Sprintf("sudo rm %s", dst))
 }
 
-// teeSSH runs an SSH command, streaming stdout, stderr to logs
-func teeSSH(s *ssh.Session, cmd string, outB io.Writer, errB io.Writer) error {
+// teeSSH runs an SSH command, streaming stdout, stderr to logs, and inR (when
+// non-nil) to the remote command's stdin.
+func teeSSH(s *ssh.Session, cmd string, outB io.Writer, errB io.Writer, inR io.Reader) error {
 	outPipe, err := s.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("stdout: %w", err)
@@ -165,6 +166,26 @@ func teeSSH(s *ssh.Session, cmd string, outB io.Writer, errB io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("stderr: %w", err)
 	}
+
+	// Errors writing stdin are returned rather than only logged: a truncated
+	// stdin silently corrupts what the remote command consumes.
+	var g errgroup.Group
+	if inR != nil {
+		inPipe, err := s.StdinPipe()
+		if err != nil {
+			return fmt.Errorf("stdin: %w", err)
+		}
+		g.Go(func() error {
+			// Closing signals EOF, without which commands reading until EOF
+			// (docker load, podman load) never terminate.
+			defer inPipe.Close()
+			if _, err := io.Copy(inPipe, inR); err != nil {
+				return fmt.Errorf("copy stdin: %w", err)
+			}
+			return nil
+		})
+	}
+
 	var wg sync.WaitGroup
 	wg.Go(func() {
 		if err := teePrefix(ErrPrefix, errPipe, errB, klog.V(8).Infof); err != nil {
@@ -178,15 +199,17 @@ func teeSSH(s *ssh.Session, cmd string, outB io.Writer, errB io.Writer) error {
 	})
 	err = s.Run(cmd)
 	wg.Wait()
-	return err
+
+	// Report the command's own failure first: if it exited early, the stdin
+	// copy failing with a closed pipe is a symptom, not the cause.
+	if err != nil {
+		return err
+	}
+	return g.Wait()
 }
 
 // RunCmd implements the Command Runner interface to run a exec.Cmd object
 func (s *SSHRunner) RunCmd(cmd *exec.Cmd) (*RunResult, error) {
-	if cmd.Stdin != nil {
-		return nil, errors.New("SSHRunner does not support stdin - you could be the first to add it")
-	}
-
 	rr := &RunResult{Args: cmd.Args}
 	klog.Infof("Run: %v", rr.Command())
 
@@ -220,7 +243,7 @@ func (s *SSHRunner) RunCmd(cmd *exec.Cmd) (*RunResult, error) {
 		}
 	}()
 
-	err = teeSSH(sess, shellquote.Join(cmd.Args...), outb, errb)
+	err = teeSSH(sess, shellquote.Join(cmd.Args...), outb, errb, cmd.Stdin)
 	elapsed := time.Since(start)
 
 	rr.ExitCode = s.exitCode(err)

--- a/pkg/minikube/command/ssh_runner_test.go
+++ b/pkg/minikube/command/ssh_runner_test.go
@@ -122,3 +122,84 @@ func TestSSHRunner(t *testing.T) {
 		}
 	})
 }
+
+// TestSSHRunnerStdin verifies that data on cmd.Stdin reaches the remote command,
+// which is what lets callers pipe an image straight into "docker load" instead of
+// staging a temporary copy on the host.
+func TestSSHRunnerStdin(t *testing.T) {
+	commands := map[string]tests.CommandResult{
+		"echo-stdin":      {EchoStdin: true},
+		"echo-stdin-fail": {EchoStdin: true, ExitCode: 1},
+	}
+
+	s, err := tests.NewSSHServer(t, commands)
+	if err != nil {
+		t.Fatalf("NewSSHServer: %v", err)
+	}
+	if err := s.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer s.Stop()
+
+	client, err := s.Dial()
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer client.Close()
+
+	runner := &SSHRunner{c: client}
+
+	t.Run("streams stdin to the remote command", func(t *testing.T) {
+		cmd := exec.Command("echo-stdin")
+		cmd.Stdin = strings.NewReader("piped payload")
+
+		rr, err := runner.RunCmd(cmd)
+		if err != nil {
+			t.Fatalf("RunCmd: %v", err)
+		}
+		if rr.Stdout.String() != "piped payload" {
+			t.Errorf("Stdout = %q, want %q", rr.Stdout.String(), "piped payload")
+		}
+	})
+
+	t.Run("large input is streamed whole", func(t *testing.T) {
+		// Bigger than a single SSH channel window, so a partial write would show up here.
+		want := strings.Repeat("abcdefgh", 128*1024) // 1 MiB
+		cmd := exec.Command("echo-stdin")
+		cmd.Stdin = strings.NewReader(want)
+
+		rr, err := runner.RunCmd(cmd)
+		if err != nil {
+			t.Fatalf("RunCmd: %v", err)
+		}
+		if got := rr.Stdout.String(); got != want {
+			t.Errorf("Stdout length = %d, want %d", len(got), len(want))
+		}
+	})
+
+	t.Run("command failure still reports the exit code", func(t *testing.T) {
+		cmd := exec.Command("echo-stdin-fail")
+		cmd.Stdin = strings.NewReader("payload")
+
+		rr, err := runner.RunCmd(cmd)
+		if err == nil {
+			t.Errorf("err = nil, want error")
+		}
+		if rr == nil {
+			t.Fatalf("RunResult = nil, want a result carrying the exit code")
+		}
+		if rr.ExitCode != 1 {
+			t.Errorf("ExitCode = %d, want 1", rr.ExitCode)
+		}
+	})
+
+	t.Run("nil stdin still works", func(t *testing.T) {
+		rr, err := runner.RunCmd(exec.Command("echo-stdin"))
+		if err != nil {
+			t.Fatalf("RunCmd: %v", err)
+		}
+		if rr.Stdout.String() != "" {
+			t.Errorf("Stdout = %q, want empty", rr.Stdout.String())
+		}
+	})
+}

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -19,6 +19,7 @@ package cruntime
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -273,6 +274,20 @@ func (r *CRIO) ListImages(ListImagesOptions) ([]ListImage, error) {
 func (r *CRIO) LoadImage(imgPath string) error {
 	klog.Infof("Loading image: %s", imgPath)
 	c := exec.Command("sudo", "podman", "load", "-i", imgPath)
+	if _, err := r.Runner.RunCmd(c); err != nil {
+		return fmt.Errorf("crio load image: %w", err)
+	}
+	return nil
+}
+
+// LoadImageStream loads an image into this runtime, reading it from img.
+//
+// podman load reads stdin when -i is absent, so this is the command above with
+// its -i dropped.
+func (r *CRIO) LoadImageStream(img io.Reader) error {
+	klog.Info("Loading image from stream")
+	c := exec.Command("sudo", "podman", "load")
+	c.Stdin = img
 	if _, err := r.Runner.RunCmd(c); err != nil {
 		return fmt.Errorf("crio load image: %w", err)
 	}

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -19,6 +19,7 @@ package cruntime
 
 import (
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
 
@@ -99,7 +100,9 @@ type Manager interface {
 	// SocketPath returns the path to the socket file for a given runtime
 	SocketPath() string
 
-	// Load an image idempotently into the runtime on a host
+	// Load an image idempotently into the runtime on a host.
+	// Runtimes whose load command also accepts the image on stdin implement
+	// StreamLoader, letting callers skip the copy into the guest entirely.
 	LoadImage(string) error
 	// Pull an image to the runtime from the container registry
 	PullImage(string) error
@@ -138,6 +141,20 @@ type Manager interface {
 	Preload(config.ClusterConfig) error
 	// ImagesPreloaded returns true if all images have been preloaded
 	ImagesPreloaded([]string) bool
+}
+
+// StreamLoader is implemented by runtimes whose load command reads the image
+// from stdin. A caller that already holds the image on the host can then pipe
+// it straight in, rather than copying it into the guest and loading it from a
+// path there, which puts a second full copy of the image on the node's disk for
+// the duration of the load.
+//
+// It is deliberately kept out of Manager: a runtime that cannot stream stays
+// correct by simply not implementing it, and callers choose the path with a
+// type assertion.
+type StreamLoader interface {
+	// LoadImageStream loads an image into the runtime, reading it from r.
+	LoadImageStream(r io.Reader) error
 }
 
 // Config is runtime configuration

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
 	"testing"
@@ -192,7 +193,11 @@ const (
 
 // FakeRunner is a command runner that isn't very smart.
 type FakeRunner struct {
-	cmds       []string
+	cmds []string
+	// stdin is what the last RunCmd was handed on stdin. A command that loads an
+	// image from a stream carries the entire payload here, so asserting on cmds
+	// alone would not notice the image itself failing to arrive.
+	stdin      string
 	services   map[string]serviceState
 	containers map[string]string
 	images     map[string]string
@@ -229,6 +234,13 @@ func buffer(s string, err error) (*command.RunResult, error) {
 func (f *FakeRunner) RunCmd(cmd *exec.Cmd) (*command.RunResult, error) {
 	xargs := cmd.Args
 	f.cmds = append(f.cmds, xargs...)
+	if cmd.Stdin != nil {
+		b, err := io.ReadAll(cmd.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("reading stdin: %w", err)
+		}
+		f.stdin = string(b)
+	}
 	root := false
 	bin, args := xargs[0], xargs[1:]
 	f.t.Logf("bin=%s args=%v", bin, args)

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -307,6 +308,22 @@ func (r *Docker) ListImages(ListImagesOptions) ([]ListImage, error) {
 func (r *Docker) LoadImage(imgPath string) error {
 	klog.Infof("Loading image: %s", imgPath)
 	c := exec.Command("/bin/bash", "-c", fmt.Sprintf("sudo cat %s | docker load", imgPath))
+	if _, err := r.Runner.RunCmd(c); err != nil {
+		return fmt.Errorf("loadimage docker: %w", err)
+	}
+	return nil
+}
+
+// LoadImageStream loads an image into this runtime, reading it from img.
+//
+// docker load has always taken the tarball on stdin here: the file-based
+// LoadImage above exists only to produce that stdin, via "sudo cat FILE". Only
+// the source of the bytes changes. The sudo goes with it, since reading the
+// guest-side file was what needed it, not docker load.
+func (r *Docker) LoadImageStream(img io.Reader) error {
+	klog.Info("Loading image from stream")
+	c := exec.Command("docker", "load")
+	c.Stdin = img
 	if _, err := r.Runner.RunCmd(c); err != nil {
 		return fmt.Errorf("loadimage docker: %w", err)
 	}

--- a/pkg/minikube/cruntime/stream_load_test.go
+++ b/pkg/minikube/cruntime/stream_load_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cruntime
+
+import (
+	"strings"
+	"testing"
+)
+
+// payload stands in for an image tarball. Its contents do not matter, only that
+// every byte reaches the runtime's load command on stdin.
+const payload = "fake image tarball"
+
+func TestLoadImageStream(t *testing.T) {
+	tests := []struct {
+		runtime string
+		want    string
+	}{
+		{"docker", "docker load"},
+		{"crio", "sudo podman load"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.runtime, func(t *testing.T) {
+			runner := NewFakeRunner(t)
+			r, err := New(Config{Type: tc.runtime, Runner: runner})
+			if err != nil {
+				t.Fatalf("New(%q): %v", tc.runtime, err)
+			}
+			sl, ok := r.(StreamLoader)
+			if !ok {
+				t.Fatalf("%s does not implement StreamLoader", r.Name())
+			}
+			// New may run commands of its own; only the load matters here.
+			runner.cmds = []string{}
+
+			if err := sl.LoadImageStream(strings.NewReader(payload)); err != nil {
+				t.Fatalf("LoadImageStream: %v", err)
+			}
+
+			if got := strings.Join(runner.cmds, " "); got != tc.want {
+				t.Errorf("command = %q, want %q", got, tc.want)
+			}
+			// The whole point of the change: the image arrives as bytes on stdin
+			// rather than as a path to a file already copied into the guest. A
+			// command that looks right but receives nothing still loads nothing.
+			if runner.stdin != payload {
+				t.Errorf("stdin = %q, want %q", runner.stdin, payload)
+			}
+		})
+	}
+}
+
+// containerd is deliberately left out of this PR: swapping ctr for nerdctl also
+// means removing the #22309 retry, which needs its own thread. Until then it
+// must keep working through the file-based path, so it must NOT satisfy
+// StreamLoader, or transferAndLoadImage would route it to a method it lacks.
+func TestContainerdDoesNotStreamYet(t *testing.T) {
+	r, err := New(Config{Type: "containerd", Runner: NewFakeRunner(t)})
+	if err != nil {
+		t.Fatalf("New(containerd): %v", err)
+	}
+	if _, ok := r.(StreamLoader); ok {
+		t.Error("containerd implements StreamLoader; if that is intentional, " +
+			"the ctr retry in LoadImage needs to be resolved in the same change")
+	}
+}

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -288,6 +288,14 @@ func transferAndLoadImage(cr command.Runner, k8s config.KubernetesConfig, src st
 		return err
 	}
 
+	// A runtime that can take the image on stdin gets it piped in over the
+	// connection we already have. Copying it to the guest first would put a
+	// second full copy of the image on the node's disk for the length of the
+	// load, on top of the one the runtime is about to unpack.
+	if sl, ok := r.(cruntime.StreamLoader); ok {
+		return streamAndLoadImage(sl, r, src, imgName)
+	}
+
 	dst := path.Join(loadRoot, filename)
 	f, err := assets.NewFileAsset(src, loadRoot, filename, "0644")
 	if err != nil {
@@ -306,16 +314,45 @@ func transferAndLoadImage(cr command.Runner, k8s config.KubernetesConfig, src st
 	loadImageLock.Lock()
 	defer loadImageLock.Unlock()
 
-	err = r.LoadImage(dst)
-	if err != nil {
-		if strings.Contains(err.Error(), "ctr: image might be filtered out") {
-			out.WarningT("The image '{{.imageName}}' does not match arch of the container runtime, use a multi-arch image instead", out.V{"imageName": imgName})
-		}
-		return fmt.Errorf("%s load %s: %w", r.Name(), dst, err)
+	if err := r.LoadImage(dst); err != nil {
+		return loadImageErr(r, imgName, dst, err)
 	}
 
 	klog.Infof("Transferred and loaded %s from cache", src)
 	return nil
+}
+
+// streamAndLoadImage pipes src into the runtime's load command, so the image is
+// never written to the guest's disk on the way in.
+func streamAndLoadImage(sl cruntime.StreamLoader, r cruntime.Manager, src string, imgName string) error {
+	f, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("opening image to stream: %w", err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			klog.Warningf("error closing the file %s: %v", src, err)
+		}
+	}()
+
+	loadImageLock.Lock()
+	defer loadImageLock.Unlock()
+
+	if err := sl.LoadImageStream(f); err != nil {
+		return loadImageErr(r, imgName, "stdin", err)
+	}
+
+	klog.Infof("Streamed and loaded %s from cache", src)
+	return nil
+}
+
+// loadImageErr wraps a failed load, translating the one runtime error that has a
+// cause a user can act on.
+func loadImageErr(r cruntime.Manager, imgName string, dst string, err error) error {
+	if strings.Contains(err.Error(), "ctr: image might be filtered out") {
+		out.WarningT("The image '{{.imageName}}' does not match arch of the container runtime, use a multi-arch image instead", out.V{"imageName": imgName})
+	}
+	return fmt.Errorf("%s load %s: %w", r.Name(), dst, err)
 }
 
 // SaveCachedImages saves from the container runtime to the cache

--- a/pkg/minikube/machine/cache_images_stream_test.go
+++ b/pkg/minikube/machine/cache_images_stream_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"k8s.io/minikube/pkg/minikube/assets"
+	"k8s.io/minikube/pkg/minikube/command"
+	"k8s.io/minikube/pkg/minikube/config"
+)
+
+// streamRunner records what transferAndLoadImage did rather than emulating a
+// host: the question under test is which path it took, not what the runtime
+// replied.
+type streamRunner struct {
+	copied []string
+	cmds   []string
+	stdin  string
+}
+
+func (r *streamRunner) RunCmd(cmd *exec.Cmd) (*command.RunResult, error) {
+	r.cmds = append(r.cmds, strings.Join(cmd.Args, " "))
+	if cmd.Stdin != nil {
+		b, err := io.ReadAll(cmd.Stdin)
+		if err != nil {
+			return &command.RunResult{}, err
+		}
+		r.stdin = string(b)
+	}
+	return &command.RunResult{}, nil
+}
+
+func (r *streamRunner) StartCmd(*exec.Cmd) (*command.StartedCmd, error) {
+	return &command.StartedCmd{}, nil
+}
+
+func (r *streamRunner) WaitCmd(*command.StartedCmd) (*command.RunResult, error) {
+	return &command.RunResult{}, nil
+}
+
+func (r *streamRunner) Copy(f assets.CopyableFile) error {
+	r.copied = append(r.copied, f.GetTargetName())
+	return nil
+}
+
+func (r *streamRunner) CopyFrom(assets.CopyableFile) error { return nil }
+
+func (r *streamRunner) Remove(assets.CopyableFile) error { return nil }
+
+func (r *streamRunner) ReadableFile(string) (assets.ReadableFile, error) { return nil, nil }
+
+// TestTransferAndLoadImageStreams is the behavioural claim of this change: for a
+// runtime that can read the image from stdin, nothing is written to the guest's
+// disk on the way in. The image reaching the runtime intact is asserted too,
+// because "no copy happened" is also true of a path that loads nothing at all.
+func TestTransferAndLoadImageStreams(t *testing.T) {
+	const payload = "fake image tarball"
+
+	tests := []struct {
+		runtime  string
+		wantCopy bool
+	}{
+		{"docker", false},
+		{"crio", false},
+		// containerd keeps the copy until the ctr/nerdctl swap lands.
+		{"containerd", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.runtime, func(t *testing.T) {
+			src := filepath.Join(t.TempDir(), "image.tar")
+			if err := os.WriteFile(src, []byte(payload), 0o644); err != nil {
+				t.Fatalf("writing image: %v", err)
+			}
+			runner := &streamRunner{}
+
+			k8s := config.KubernetesConfig{ContainerRuntime: tc.runtime}
+			if err := transferAndLoadImage(runner, k8s, src, "image.tar"); err != nil {
+				t.Fatalf("transferAndLoadImage: %v", err)
+			}
+
+			if gotCopy := len(runner.copied) > 0; gotCopy != tc.wantCopy {
+				t.Errorf("copied to guest = %v (%v), want %v",
+					gotCopy, runner.copied, tc.wantCopy)
+			}
+			if tc.wantCopy {
+				return
+			}
+			if runner.stdin != payload {
+				t.Errorf("stdin = %q, want %q", runner.stdin, payload)
+			}
+			// A streamed load must not name a guest path it never created.
+			if got := strings.Join(runner.cmds, " "); strings.Contains(got, loadRoot) {
+				t.Errorf("command %q still refers to %s", got, loadRoot)
+			}
+		})
+	}
+}

--- a/pkg/minikube/tests/ssh_mock.go
+++ b/pkg/minikube/tests/ssh_mock.go
@@ -23,6 +23,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"net"
 	"sync/atomic"
@@ -37,6 +38,10 @@ type CommandResult struct {
 	Stdout   string
 	Stderr   string
 	ExitCode int
+
+	// EchoStdin makes the command copy anything it receives on stdin to stdout,
+	// so tests can assert that input reached the remote side.
+	EchoStdin bool
 }
 
 // SSHServer is a test SSH server returning preconfigured responses.
@@ -202,6 +207,13 @@ func (s *SSHServer) doExec(channel ssh.Channel, req *ssh.Request) {
 		result = CommandResult{
 			Stderr:   fmt.Sprintf("%s: command not found", cmd.Command),
 			ExitCode: 127,
+		}
+	}
+
+	if result.EchoStdin {
+		if _, err := io.Copy(channel, channel); err != nil {
+			s.t.Errorf("Failed to echo stdin: %v", err)
+			return
 		}
 	}
 


### PR DESCRIPTION

Part of #23115. Piece 2 of the three-way split agreed on that thread.

**Depends on #23449.** That PR adds stdin support to `SSHRunner.RunCmd`, which this one needs. See the verification section for what happens without it.

### What this changes

`transferAndLoadImage` copies the image tarball into the guest at `/var/lib/minikube/images/<name>` and then tells the runtime to load it from that path. Both docker and cri-o can take the tarball on stdin instead, so this pipes it in over the connection minikube already has and skips the copy.

Docker's `LoadImage` already ran `sudo cat FILE | docker load`, so the file only ever existed to produce that stdin. `podman load` reads stdin whenever `-i` is absent. Neither runtime needed a new capability, only a different source for the bytes.

The change is a `StreamLoader` interface for runtimes whose load command accepts stdin, implemented by `Docker` and `CRIO`, with `transferAndLoadImage` selecting it by type assertion. Runtimes that do not implement it keep the existing path with no change in behaviour.

**containerd is deliberately not included.** Swapping `ctr images import` for `nerdctl load` also means resolving the retry added for issue 22309, and that deserves its own thread. It keeps the file-based path here, and there is a test asserting it does not satisfy `StreamLoader` so the two do not get out of step.

### Why: the guest keeps a full second copy of every image, permanently

This is the part I would lead with, because it is larger and more certain than the speed argument.

Nothing ever deletes what gets copied into `/var/lib/minikube/images/`. `loadRoot` is written in `transferAndLoadImage` and read nowhere else in the tree, and `/var/lib/minikube` is the guest's persistent path, not tmpfs, so the tarballs survive restarts. Loading two images on a fresh cluster:

```
$ docker exec streamtest ls -la /var/lib/minikube/images/
-rw-r--r-- 1 root root  4206592 Aug 10 00:30 alpine_latest
-rw-r--r-- 1 root root 49068544 Aug 10 00:31 redis_7.2
$ docker exec streamtest du -sh /var/lib/minikube/images/
51M	/var/lib/minikube/images/
```

With this change that directory stays empty, on both runtimes.

### On performance: I could not measure a reliable speedup, and I think that is expected

The issue is filed under area/performance, so I want to be straight about what I measured rather than let the framing imply a win I did not see.

Timing the phase this actually touches, docker driver, 5 runs each, median:

| image | base | streamed |
|---|---|---|
| alpine (8 MB) | 549 ms | 501 ms |
| redis:7.2 (112 MB) | 3555 ms | 3474 ms |

The run-to-run ranges overlap in both cases (redis: 3380-3684 vs 3397-3750), so I would not claim a speedup from this data. A single `-v=3` breakdown shows why:

| | base | streamed |
|---|---|---|
| scp to guest | 353 ms | gone |
| load command | 3038 ms | 3012 ms |
| **LoadCachedImages total** | **3430 ms** | **3048 ms** |

The scp does not disappear so much as move: both flows push the same bytes over the same ssh connection, and the streamed load pays inside `docker load` what the file flow paid in scp. What is actually saved is the double write and the serialization, which is real but small.

Zooming out further, the whole `minikube image load redis:7.2` command takes ~17.5 s on my machine, of which ~14.4 s (82%) is the host-side cache write in `image/cache.go` gzipping every layer. That is what #23083 removes, and it is much the larger number. This change and that one are complementary: #23083 removes the host-side compression, this removes the guest-side file.

### Verification

Built from this branch and from #23449's branch as the baseline, so the only difference is this commit. Docker driver, real clusters, kicbase v0.0.50.

**docker runtime**, `-v=3`:

```
base:     scp .../alpine_latest --> /var/lib/minikube/images/alpine_latest (4206592 bytes)
          Run: /bin/bash -c "sudo cat /var/lib/minikube/images/alpine_latest | docker load"
          -> guest holds alpine_latest (4.2 MB) afterwards

streamed: Loading image from stream
          Run: docker load
          -> no scp line, guest images dir empty afterwards
```

**cri-o runtime**, same profile shape:

```
base:     scp .../alpine_latest --> /var/lib/minikube/images/alpine_latest
          sudo podman load -i /var/lib/minikube/images/alpine_latest
          -> guest holds alpine_latest afterwards

streamed: Loading image from stream
          sudo podman load
          -> no scp line, guest images dir empty afterwards
```

Image present in the runtime after every run (`docker images` / `crictl images`), which the benchmark harness also asserts, so a load that silently did nothing cannot read as a fast load.

**The dependency on #23449 is not theoretical.** Note that the docker driver reaches the node over ssh here, not just the VM drivers. Cherry-picking this commit onto master without #23449 builds fine and then fails at runtime:

```
Failed to load cached images for "criotest": LoadCachedImages:
CRI-O load stdin: crio load image: SSHRunner does not support stdin - you could be the first to add it
```

It fails cleanly rather than corrupting anything, but it does fail, so #23449 needs to land first.

### Tests

- `TestLoadImageStream` covers docker and cri-o: asserts the command shape and that the payload actually arrives on stdin. Asserting the command alone would not notice the image failing to arrive.
- `TestContainerdDoesNotStreamYet` pins the deliberate omission above.
- `TestTransferAndLoadImageStreams` covers the routing: docker and cri-o take the stream and never call `Copy`, containerd still copies. Verified this fails if the type assertion is removed.
- `go test ./pkg/minikube/cruntime/ ./pkg/minikube/machine/ ./pkg/minikube/command/` green.