### PR TITLE
smoke test: Use macos-26-intel

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -41,14 +41,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: qemu-docker-macos-15-x86
+          - name: qemu-docker-macos-26-x86
             driver: qemu
-            os: macos-15-intel
+            os: macos-26-intel
             start_flags: --network socket_vmnet --force
             sudo: "sudo"
-          - name: vfkit-docker-macos-15-x86
+          - name: vfkit-docker-macos-26-x86
             driver: vfkit
-            os: macos-15-intel
+            os: macos-26-intel
             start_flags: --network vmnet-shared --force
             sudo: "sudo"
           - name: docker-docker-ubuntu-24.04-x86
@@ -95,11 +95,12 @@ jobs:
         if: contains(matrix.os, 'macos')
         run: brew install tree
       - name: Install vfkit and vmnet-helper (macos)
-        timeout-minutes: 1
+        timeout-minutes: 3
         if: matrix.driver == 'vfkit'
         run: |
-          brew install vfkit
-          curl -fsSL https://github.com/minikube-machine/vmnet-helper/releases/latest/download/install.sh | sudo VMNET_INTERACTIVE=0 bash
+          brew tap nirs/vmnet-helper
+          brew trust nirs/vmnet-helper
+          brew install vfkit vmnet-helper
       - name: Install qemu and socket_vmnet (macos)
         timeout-minutes: 6
         if: contains(matrix.os, 'macos') && matrix.driver == 'qemu'

--- a/pkg/drivers/common/privileges/privileges.go
+++ b/pkg/drivers/common/privileges/privileges.go
@@ -1,0 +1,72 @@
+//go:build darwin
+
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package privileges provides helpers for running child processes as the real
+// (unprivileged) user when minikube is invoked via sudo. This is needed for CI
+// testing on GitHub runners where sudo is required due to Local Network Privacy
+// on headless macOS machines. Running minikube as root is not supported.
+package privileges
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"k8s.io/minikube/pkg/libmachine/log"
+)
+
+// Credential returns the real user's credentials when running under sudo, or
+// nil if not running as root or SUDO_UID/SUDO_GID are not set.
+func Credential() *syscall.Credential {
+	if os.Getuid() != 0 {
+		return nil
+	}
+	uidStr := os.Getenv("SUDO_UID")
+	gidStr := os.Getenv("SUDO_GID")
+	if uidStr == "" || gidStr == "" {
+		return nil
+	}
+	uid, err := strconv.Atoi(uidStr)
+	if err != nil {
+		return nil
+	}
+	gid, err := strconv.Atoi(gidStr)
+	if err != nil {
+		return nil
+	}
+	return &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}
+}
+
+// ChownDirAll recursively changes ownership of a directory and all its contents
+// to the real user. Returns nil immediately if not running under sudo.
+func ChownDirAll(dir string) error {
+	cred := Credential()
+	if cred == nil {
+		return nil
+	}
+	uid := int(cred.Uid)
+	gid := int(cred.Gid)
+	log.Infof("Chown %s to %d:%d (running under sudo)", dir, uid, gid)
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chown(path, uid, gid)
+	})
+}

--- a/pkg/drivers/common/vmnet/vmnet.go
+++ b/pkg/drivers/common/vmnet/vmnet.go
@@ -35,6 +35,7 @@ import (
 	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v2"
 
+	"k8s.io/minikube/pkg/drivers/common/privileges"
 	"k8s.io/minikube/pkg/libmachine/log"
 	"k8s.io/minikube/pkg/libmachine/state"
 	"k8s.io/minikube/pkg/minikube/detect"
@@ -200,6 +201,12 @@ func (h *Helper) Start(socketPath string) error {
 	// Create vmnet-helper in a new process group so it is not harmed when
 	// terminating the minikube process group.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// When running under sudo, start vmnet-helper as the real user rather than
+	// relying on its internal privilege drop.
+	if cred := privileges.Credential(); cred != nil {
+		cmd.SysProcAttr.Credential = cred
+	}
 
 	logfile, err := h.openLogfile()
 	if err != nil {

--- a/pkg/drivers/common/vmnet/vmnet.go
+++ b/pkg/drivers/common/vmnet/vmnet.go
@@ -69,6 +69,14 @@ type Helper struct {
 	// Offloading is required for krunkit, does not work with vfkit.
 	Offloading bool
 
+	// Subnet configuration. When set, vmnet-helper uses a custom subnet
+	// instead of letting vmnet select the next available network (defaults to
+	// 192.168.64.0/24 in shared mode). All three must be set together or all
+	// omitted. See https://github.com/nirs/vmnet-helper/blob/main/docs/integration.md
+	StartAddress string
+	EndAddress   string
+	SubnetMask   string
+
 	// Set when vmnet interface is started.
 	macAddress string
 
@@ -194,6 +202,16 @@ func (h *Helper) Start(socketPath string) error {
 
 	if h.Offloading {
 		args = append(args, "--enable-tso", "--enable-checksum-offload")
+	}
+
+	if h.StartAddress != "" {
+		args = append(args, "--start-address", h.StartAddress)
+	}
+	if h.EndAddress != "" {
+		args = append(args, "--end-address", h.EndAddress)
+	}
+	if h.SubnetMask != "" {
+		args = append(args, "--subnet-mask", h.SubnetMask)
 	}
 
 	cmd := exec.Command(executable, args...)

--- a/pkg/drivers/vfkit/vfkit.go
+++ b/pkg/drivers/vfkit/vfkit.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/drivers/common"
 	"k8s.io/minikube/pkg/drivers/common/dhcp"
+	"k8s.io/minikube/pkg/drivers/common/privileges"
 	"k8s.io/minikube/pkg/drivers/common/virtiofs"
 	"k8s.io/minikube/pkg/drivers/common/vmnet"
 	"k8s.io/minikube/pkg/minikube/exit"
@@ -240,6 +241,13 @@ func (d *Driver) extractKernel() error {
 }
 
 func (d *Driver) Start() error {
+	// Fix file ownership to allow vmnet-helper and vfkit to access the machine
+	// directory after vmnet-helper drops privileges. No-op when not under sudo.
+	machineDir := filepath.Join(d.StorePath, "machines", d.GetMachineName())
+	if err := privileges.ChownDirAll(machineDir); err != nil {
+		return fmt.Errorf("failed to fix machine dir ownership: %w", err)
+	}
+
 	var socketPath string
 
 	if d.VmnetHelper != nil {
@@ -348,6 +356,12 @@ func (d *Driver) startVfkit(socketPath string) error {
 	// Create vfkit in a new process group, so minikube caller can use killpg
 	// to terminate the entire process group without harming the vfkit process.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// When running under sudo, start vfkit as the real user so its socket is
+	// accessible by vmnet-helper after it drops privileges.
+	if cred := privileges.Credential(); cred != nil {
+		cmd.SysProcAttr.Credential = cred
+	}
 
 	logfile, err := d.openLogfile()
 	if err != nil {

--- a/pkg/minikube/registry/drvs/vfkit/vfkit.go
+++ b/pkg/minikube/registry/drvs/vfkit/vfkit.go
@@ -76,6 +76,12 @@ func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
 	case "vmnet-shared":
 		helper = &vmnet.Helper{
 			MachineDir: filepath.Join(storePath, "machines", machineName),
+			// TODO: Remove hardcoded subnet once proper flag support is added.
+			// Workaround for GitHub runners where the host network uses the
+			// vmnet default subnet (192.168.64.0/24), causing routing conflicts.
+			StartAddress: "192.168.200.1",
+			EndAddress:   "192.168.200.127",
+			SubnetMask:   "255.255.255.0",
 		}
 	default:
 		return nil, fmt.Errorf("unsupported network: %q", cfg.Network)


### PR DESCRIPTION
## Summary

Switch the smoke test to macOS 26 runners and fix the vfkit/vmnet-helper
permission and networking issues that prevented it from working.

**Three problems solved:**

1. **Socket permissions:** When minikube runs under sudo (required for Local
   Network Privacy on headless runners), all files are root-owned. vmnet-helper
   drops privileges and can't create its socket; vfkit creates root-owned
   sockets vmnet-helper can't connect to. Fix: add
   `pkg/drivers/common/privileges` package that chowns the machine directory
   and starts child processes as the real user via `SUDO_UID`/`SUDO_GID`.

2. **Subnet collision:** macOS 26 runners use 192.168.64.0/24 for their host
   network — the same subnet vmnet selects by default in shared mode. This
   causes routing conflicts. Fix: hardcode 192.168.200.0/24.

3. **Install timeout:** Building vmnet-helper from source via brew takes ~60s.
   Fix: increase timeout from 1 to 3 minutes.

## Not ready to merge

The subnet addresses are hardcoded. This PR depends on adding proper `--vmnet-start-address`, `--vmnet-end-address`, `--vmnet-subnet-mask` flags: #23273

## Tesing

- [x] vfkit smoke test passes on macos-26-intel
- [x] qemu smoke test passes on macos-26-intel