### PR TITLE
Fix nerdctl-bin package files to use tabs instead of spaces

### DIFF
--- a/deploy/iso/minikube-iso/arch/aarch64/package/nerdctl-bin-aarch64/Config.in
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/nerdctl-bin-aarch64/Config.in
@@ -1,4 +1,4 @@
 config BR2_PACKAGE_NERDCTL_BIN_AARCH64
-        bool "nerdctl-bin"
-        default y
-        depends on BR2_aarch64
+	bool "nerdctl-bin"
+	default y
+	depends on BR2_aarch64

--- a/deploy/iso/minikube-iso/arch/aarch64/package/nerdctl-bin-aarch64/nerdctl-bin.mk
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/nerdctl-bin-aarch64/nerdctl-bin.mk
@@ -11,9 +11,9 @@ NERDCTL_BIN_AARCH64_SOURCE = nerdctl-$(NERDCTL_BIN_AARCH64_VERSION)-linux-arm64.
 NERDCTL_BIN_AARCH64_STRIP_COMPONENTS = 0
 
 define NERDCTL_BIN_AARCH64_INSTALL_TARGET_CMDS
-        $(INSTALL) -D -m 0755 \
-                $(@D)/nerdctl \
-                $(TARGET_DIR)/usr/bin/nerdctl
+	$(INSTALL) -D -m 0755 \
+		$(@D)/nerdctl \
+		$(TARGET_DIR)/usr/bin/nerdctl
 endef
 
 $(eval $(generic-package))

--- a/deploy/iso/minikube-iso/arch/x86_64/package/nerdctl-bin/Config.in
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/nerdctl-bin/Config.in
@@ -1,4 +1,4 @@
 config BR2_PACKAGE_NERDCTL_BIN
-        bool "nerdctl-bin"
-        default y
-        depends on BR2_x86_64
+	bool "nerdctl-bin"
+	default y
+	depends on BR2_x86_64

--- a/deploy/iso/minikube-iso/arch/x86_64/package/nerdctl-bin/nerdctl-bin.mk
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/nerdctl-bin/nerdctl-bin.mk
@@ -11,9 +11,9 @@ NERDCTL_BIN_SOURCE = nerdctl-$(NERDCTL_BIN_AARCH64_VERSION)-linux-amd64.tar.gz
 NERDCTL_BIN_STRIP_COMPONENTS = 0
 
 define NERDCTL_BIN_INSTALL_TARGET_CMDS
-        $(INSTALL) -D -m 0755 \
-                $(@D)/nerdctl \
-                $(TARGET_DIR)/usr/bin/nerdctl
+	$(INSTALL) -D -m 0755 \
+		$(@D)/nerdctl \
+		$(TARGET_DIR)/usr/bin/nerdctl
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
## Problem

The nerdctl-bin Buildroot package files use spaces for indentation where tabs are required by Buildroot/Kconfig/Make conventions. Other packages (e.g. `crictl-bin`, `helm-bin`) correctly use tabs.

## Fix

Replaced leading spaces with tabs in:
- `deploy/iso/minikube-iso/arch/aarch64/package/nerdctl-bin-aarch64/Config.in`
- `deploy/iso/minikube-iso/arch/aarch64/package/nerdctl-bin-aarch64/nerdctl-bin.mk`
- `deploy/iso/minikube-iso/arch/x86_64/package/nerdctl-bin/Config.in`
- `deploy/iso/minikube-iso/arch/x86_64/package/nerdctl-bin/nerdctl-bin.mk`

Whitespace-only change, matches the style of `crictl-bin`. CRLF line endings preserved.

Related to #23437