### PR TITLE
virtualbox: strip surrounding quotes before parsing hostOnlyCIDR

### DIFF
--- a/pkg/drivers/virtualbox/virtualbox.go
+++ b/pkg/drivers/virtualbox/virtualbox.go
@@ -1271,6 +1271,7 @@ func getDHCPAddressRange(dhcpAddr net.IP, network *net.IPNet) (lowerIP net.IP, u
 }
 
 func parseAndValidateCIDR(hostOnlyCIDR string) (net.IP, *net.IPNet, error) {
+	hostOnlyCIDR = strings.Trim(hostOnlyCIDR, "\"'")
 	ip, network, err := net.ParseCIDR(hostOnlyCIDR)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/drivers/virtualbox/virtualbox_test.go
+++ b/pkg/drivers/virtualbox/virtualbox_test.go
@@ -274,6 +274,29 @@ func TestParseValidCIDR(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestParseQuotedCIDR(t *testing.T) {
+	expectedIP, expectedNetwork, err := parseAndValidateCIDR("192.168.99.1/24")
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name string
+		cidr string
+	}{
+		{name: "single quotes", cidr: "'192.168.99.1/24'"},
+		{name: "double quotes", cidr: `"192.168.99.1/24"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ip, network, err := parseAndValidateCIDR(tc.cidr)
+
+			assert.Equal(t, expectedIP, ip)
+			assert.Equal(t, expectedNetwork, network)
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func TestInvalidCIDR(t *testing.T) {
 	ip, network, err := parseAndValidateCIDR("192.168.100.1")
 


### PR DESCRIPTION
fixes #7063

## Problem

Some shells/configs pass `--host-only-cidr` with the quote characters embedded literally in the flag value (e.g. `'192.168.99.1/24'` with the single quotes as part of the string), which `net.ParseCIDR` rejects outright:

```
invalid CIDR address: '192.168.99.1/24'
```

## Fix

Trim wrapping single/double quotes in `parseAndValidateCIDR` (`pkg/drivers/virtualbox/virtualbox.go`), the single choke point already used by both driver call sites (`checkHostOnlyAdapter` and `setupHostOnlyNetwork`). This fixes both paths with a one-line change instead of duplicating validation logic across `cmd/minikube/cmd/start_flags.go` and the registry driver init.

## Prior attempt

A previous PR (#9975) attempted this fix but had issues: it introduced a syntax error (mismatched parens) in `start_flags.go`, only stripped single quotes (not double), and duplicated validation across two unrelated files. It was closed for inactivity/needing rebase, not for a rejected approach. This PR takes a different, minimal path confined to the existing validation helper.

## Testing

- `go build ./...`
- `go test ./pkg/drivers/virtualbox/... -run CIDR -v` — added `TestParseQuotedCIDR` covering single- and double-quoted CIDR strings, plus existing valid/invalid CIDR tests still pass.
- `gofmt -l` clean on changed files.