### PR TITLE
docs: recommend Homebrew vmnet-helper install on macOS 26

### DIFF
--- a/site/content/en/docs/drivers/includes/vmnet_helper.inc
+++ b/site/content/en/docs/drivers/includes/vmnet_helper.inc
@@ -1,18 +1,29 @@
 ### Install vmnet-helper
 
+On macOS 26 or later, install vmnet-helper using [Homebrew](https://brew.sh/):
+
+```shell
+brew tap nirs/vmnet-helper
+brew trust nirs/vmnet-helper
+brew install vmnet-helper
+```
+
+On macOS 15 or earlier, install the latest version using the install script:
+
 ```shell
 curl -fsSL https://github.com/minikube-machine/vmnet-helper/releases/latest/download/install.sh | bash
 ```
 
-The command downloads the latest release from github and installs it to
-`/opt/vmnet-helper`.
+The command downloads the latest release from GitHub and installs it to
+`/opt/vmnet-helper`, and configures a sudoers rule to allow running
+vmnet-helper without a password.
 
-### Grant permission to run vmnet-helper manually (if said no to script above)
+### Grant permission to run vmnet-helper manually on macOS 15 or earlier
 
-vmnet-helper must run as root to create a vmnet interface. To let users in the
-staff group run it without a password, install the default sudoers rule. The
-install script offers to add this automatically; if you declined, run the command
-below manually:
+On macOS 15 or earlier, vmnet-helper must run as root to create a vmnet
+interface. To let users in the staff group run it without a password, install the
+default sudoers rule. The install script offers to add this automatically; if you
+declined, run the command below manually:
 
 ```shell
 sudo install -m 0640 /opt/vmnet-helper/share/doc/vmnet-helper/sudoers.d/vmnet-helper /etc/sudoers.d/
@@ -21,6 +32,6 @@ sudo install -m 0640 /opt/vmnet-helper/share/doc/vmnet-helper/sudoers.d/vmnet-he
 You can change the sudoers configuration to allow access to specific
 users or other groups.
 
-**IMPORTANT**: The vmnet-helper executable and the directory where it is
-installed must be owned by root and may not be modifiable by
-unprivileged users.
+**IMPORTANT**: On macOS 15 or earlier, the vmnet-helper executable and the
+directory where it is installed must be owned by root and may not be modifiable
+by unprivileged users.

--- a/site/content/en/docs/drivers/includes/vmnet_helper.inc
+++ b/site/content/en/docs/drivers/includes/vmnet_helper.inc
@@ -1,0 +1,26 @@
+### Install vmnet-helper
+
+```shell
+curl -fsSL https://github.com/minikube-machine/vmnet-helper/releases/latest/download/install.sh | bash
+```
+
+The command downloads the latest release from github and installs it to
+`/opt/vmnet-helper`.
+
+### Grant permission to run vmnet-helper manually (if said no to script above)
+
+vmnet-helper must run as root to create a vmnet interface. To let users in the
+staff group run it without a password, install the default sudoers rule. The
+install script offers to add this automatically; if you declined, run the command
+below manually:
+
+```shell
+sudo install -m 0640 /opt/vmnet-helper/share/doc/vmnet-helper/sudoers.d/vmnet-helper /etc/sudoers.d/
+```
+
+You can change the sudoers configuration to allow access to specific
+users or other groups.
+
+**IMPORTANT**: The vmnet-helper executable and the directory where it is
+installed must be owned by root and may not be modifiable by
+unprivileged users.

--- a/site/content/en/docs/drivers/krunkit.md
+++ b/site/content/en/docs/drivers/krunkit.md
@@ -39,37 +39,7 @@ To use the krunkit driver you must install
 [vmnet-helper](https://github.com/nirs/vmnet-helper), see installation
 instructions below.
 
-### Install vment-helper
-
-```shell
-    curl -fsSL https://github.com/minikube-machine/vmnet-helper/releases/latest/download/install.sh | bash
-```
-
-The command downloads the latest release from github and installs it to
-`/opt/vmnet-helper`.
-
-{{% alert title="Note" color="primary" %}}
-The vmnet-helper executable and the directory where it is installed
-must be owned by root and may not be modifiable by unprivileged users.
-{{% /alert %}}
-
-### Grant permission to run vmnet-helper manually (if said no to script above)
-
-
-The vment-helper process must run as root to create a vmnet interface.
-To allow users in the `staff` group to run the vmnet helper without a
-password, you can install the default sudoers rule:
-
-The installation script will ask your permission to add to the sudoers but if you say no and prefer to do manually here is the command:
-
-```shell
-sudo install -m 0640 /opt/vmnet-helper/share/doc/vmnet-helper/sudoers.d/vmnet-helper /etc/sudoers.d/
-```
-
-You can change the sudoers configuration to allow access to specific
-users or other groups.
-
-
+{{% readfile file="/docs/drivers/includes/vmnet_helper.inc" %}}
 
 ### Usage
 

--- a/site/content/en/docs/drivers/krunkit.md
+++ b/site/content/en/docs/drivers/krunkit.md
@@ -85,7 +85,7 @@ Run `minikube start --driver krunkit --alsologtostderr -v=7` to debug crashes
 
 ### Troubleshooting vmnet-helper
 
-Check for errors in vment-helper log:
+Check for errors in vmnet-helper log:
 
 ```shell
 $MINIKUBE_HOME/.minikube/machines/MACHINE-NAME/vmnet-helper.log
@@ -99,5 +99,5 @@ ps au | grep vmnet-helper | grep -v grep
 
 If the helper is not running restart the minikube cluster.
 
-For help with vment-helper please use the
+For help with vmnet-helper please use the
 [discussions](https://github.com/nirs/vmnet-helper/discussions).

--- a/site/content/en/docs/drivers/vfkit.md
+++ b/site/content/en/docs/drivers/vfkit.md
@@ -32,31 +32,7 @@ installation instructions below.
 
 - Requires [vmnet-helper](https://github.com/nirs/vmnet-helper).
 
-### Install vmnet-helper
-
-```shell
-curl -fsSL https://github.com/minikube-machine/vmnet-helper/releases/latest/download/install.sh | bash
-```
-
-The command downloads the latest release from github and installs it to
-`/opt/vmnet-helper`.
-
-### Grant permission to run vmnet-helper manually (if said no to script above)
-
-vmnet-helper must run as root to create a vmnet interface. To let users in the staff group run it without a password, install the default sudoers rule. The install script offers to add this automatically; if you declined, run the command below manually:
-
-```shell
-sudo install -m 0640 /opt/vmnet-helper/share/doc/vmnet-helper/sudoers.d/vmnet-helper /etc/sudoers.d/
-```
-
-You can change the sudoers configuration to allow access to specific
-users or other groups.
-
-
-**IMPORTANT**: The vmnet-helper executable and the directory where it is
-installed must be owned by root and may not be modifiable by
-unprivileged users.
-
+{{% readfile file="/docs/drivers/includes/vmnet_helper.inc" %}}
 
 ### Usage
 


### PR DESCRIPTION
Fixes #22516

This updates the vfkit and krunkit driver docs for vmnet-helper installation.

Changes:
- Move duplicated vmnet-helper installation instructions into a shared include.
- Recommend Homebrew installation for vmnet-helper on macOS 26 and later.
- Keep the install script and sudoers instructions for macOS 15 and earlier.
- Fix a couple of vmnet-helper typos in the krunkit troubleshooting section.

The work is split into two commits as requested in the issue discussion.

Tested with:

```shell
git diff --check upstream/master..HEAD
```