### PR TITLE
contrib: add Agent Skill for Kubernetes commit messages

### DIFF
--- a/.agents/skills/commit-message/SKILL.md
+++ b/.agents/skills/commit-message/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: commit-message
+description: >-
+  Write or improve git commit messages for this repository. Use when the user
+  asks for a commit message, is creating a commit, amending a message,
+  reviewing whether a commit message is good enough, or drafting an example
+  message for a pull request contributor.
+license: Apache-2.0
+metadata:
+  audience: contributors
+  style: kubernetes-community
+---
+
+# Commit messages
+
+Follow the Kubernetes
+[Commit Message Guidelines](https://www.kubernetes.dev/docs/guide/pull-requests/#commit-message-guidelines).
+The rules below summarize that guide for agents; prefer this skill text over
+fetching the web page.
+
+Commits are the permanent record of a change. `git log` must explain **why**
+the change is needed (the problem) and **what** you did about it (the
+solution), in that order. AI agents may draft messages; the text must still
+match the diff — do not invent intent or files.
+
+## When to use
+
+1. Read the change (`git diff`, staged files, or PR commits). Do not guess.
+2. Draft a message using the format below.
+3. If asked for a *contributor example*, keep it copy-paste ready.
+4. Do not run `git commit` unless the user explicitly asked to commit.
+
+## Format
+
+```text
+area: Imperative summary in ~50 characters (max 72)
+
+Explain the problem first. Who is hurt, when it shows up, why the current
+behavior is wrong. User-visible impact beats implementation trivia.
+
+Then describe what the change does about it in plain English — enough that
+a reviewer can verify the diff matches the intent. Mention important
+non-obvious trade-offs or limits (what this does *not* change).
+```
+
+### Subject
+
+From the Kubernetes guide:
+
+- Prefer ≤**50** characters; never exceed **72**.
+- **Imperative mood** (a command): “Fix …”, “Add …”, “Remove …”.
+  Not “Fixed”, “Adding”, “This commit”, or “I …”.
+  Test: “If applied, this commit will <subject>”.
+- **No trailing period**.
+- Capitalize the first word **unless** the subject starts with a lowercase
+  area/kind prefix (`site:`, `etcd:`, …).
+- Optional `area:` / `kind:` prefix for context, e.g. `site:`, `addons:`,
+  `cmd/minikube:`, `pkg/drivers:`, `deploy/iso:`.
+- Must make sense alone in `git log --oneline`.
+
+### Body
+
+- One blank line after the subject.
+- Wrap at **72** characters.
+- Explain the **problem**, then the **solution** (why, then what). Self-contained:
+  readers should not need the PR thread.
+- One logical change per commit. If the body needs an unrelated “also…”, split.
+- Do not narrate the diff line-by-line; describe behavior and rationale.
+- Quantify performance claims; call out trade-offs when relevant.
+- You may link related discussion with a plain URL. Do **not** use GitHub
+  closing keywords with an issue number (see below).
+
+### Do not use GitHub keywords or @mentions in commits
+
+Kubernetes applies `do-not-merge/invalid-commit-message` when a commit message
+uses [GitHub closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) followed by an `#` issue number.
+
+**Do not use in commit messages** (with an issue reference):
+
+`close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`,
+`resolved`
+
+Also avoid `@mentions` in commit messages (they notify on every PR update).
+
+Put issue linkage in the **pull request description** instead, e.g. `Fixes #123`.
+
+Do not add `Signed-off-by:` unless a reviewer or process asks for it (minikube
+uses the Kubernetes CLA).
+
+## Quality bar
+
+- [ ] `git log --oneline` explains the change at a glance
+- [ ] Body states the **problem** / why the change is needed
+- [ ] Body states the **solution** / what the change does
+- [ ] Message matches the actual diff
+- [ ] No GitHub closing keywords + `#N`, and no `@mentions`
+- [ ] Residual limitations called out when relevant
+
+Reject or rewrite: title-only messages with no why, empty bodies under noisy
+prefixes (`fix(ui): …`), or “Address review comments”.
+
+## Examples
+
+**Too weak**
+
+```text
+bugfix(ui):copy button and code block overlap
+```
+
+**Better**
+
+```text
+site: fix copy button overlapping code in docs
+
+On narrow viewports, long lines in Prism code blocks scroll under the
+floating Copy button. Prism styles that button with a translucent
+background, so the code shows through the muted "Copy" label and both
+become hard to read.
+
+Override the button background in the project SCSS to Prism's solid
+fallback color (#f5f2f0) so the label stays readable when text sits
+underneath. Use the same selector as Prism's toolbar CSS so the override
+targets the copy control clearly.
+
+This keeps Prism's toolbar behavior (show on hover, Copied! label); it
+only disables the translucent fill.
+```
+
+More examples: [examples.md](examples.md)
+
+## For reviewers
+
+When a PR commit message is weak:
+
+1. Say what is wrong (title-only, missing what/why, keyword+#N, mismatches diff).
+2. Paste an example the author can adapt.
+3. Point them at this skill and the Kubernetes guide linked above.
+4. AI drafting is fine if the result meets the quality bar.

--- a/.agents/skills/commit-message/examples.md
+++ b/.agents/skills/commit-message/examples.md
@@ -1,0 +1,63 @@
+# Commit message examples
+
+## Bug fix
+
+```text
+kvm: avoid nil deref when VM IP is not yet assigned
+
+During early start, GetIP can run before the lease exists. Callers treated
+a missing address as a fatal error and crashed the start path.
+
+Return ErrNotFound when the lease is absent and let the existing retry
+loop wait for the address. Log at V(1) so quiet starts stay quiet.
+```
+
+## Docs
+
+```text
+docs: document WSL2 service access for the Docker driver
+
+WSL2 users hit connection refused when curling NodePort services from
+Windows and assumed minikube was broken. The missing piece is how Windows
+reaches the WSL2 VM IP.
+
+Add a short handbook section with the working patterns and known
+limitations. No code changes.
+```
+
+## Refactor (still explain why)
+
+```text
+pkg/minikube/command: split SSH runner deadline handling
+
+Deadline logic was inlined in three call paths and drifted: one path
+ignored the parent context on retry. Tests could not cover the edge cases
+without copying the same stubs.
+
+Extract waitWithDeadline and use it from all three paths. Behavior should
+be unchanged except retries now honor cancellation consistently.
+```
+
+## Performance (quantify)
+
+```text
+start: stream preload tarballs instead of buffering whole file
+
+Buffering the full preload in memory OOMs mid-start on large images over
+slow links.
+
+Stream with a capped 32MiB buffer. Peak RSS returns to the pre-regression
+range; LAN cold-start time is unchanged within noise.
+```
+
+## Rewrite these
+
+| Weak | Why |
+|------|-----|
+| `fix bug` | No area, problem, or solution |
+| `Updated styles` | No why |
+| `fix(ui): improve UX` | Prefix without meaning; empty body |
+| `Address review comments` | Useless months later in `git log` |
+| `WIP` | Not mergeable as a final message |
+| `Fixes: #123` / `fixes #123` in the commit | Triggers `do-not-merge/invalid-commit-message`; put `Fixes #123` in the PR description |
+| `@someone` in the commit | Mentions notify on every PR update; avoid |

--- a/site/content/en/docs/contrib/guide.en.md
+++ b/site/content/en/docs/contrib/guide.en.md
@@ -56,6 +56,27 @@ To get feedback on a larger, more ambitious changes, create a PR containing your
 
 If you send out a large change without a MEP, prepare to be asked by other contributors for one to be included within the PR.
 
+### Commit messages
+
+Follow the Kubernetes
+[Commit Message Guidelines](https://www.kubernetes.dev/docs/guide/pull-requests/#commit-message-guidelines):
+imperative subject, body that explains the **problem** then the **solution**,
+wrap at 72 columns. Title-only commits are not enough unless the problem and
+solution fit in one line.
+
+Do **not** use GitHub closing keywords (`fixes`, `closes`, …) with `#N` in the
+**commit message** — that applies `do-not-merge/invalid-commit-message`. Put
+`Fixes #N` in the **pull request description** instead. Avoid `@mentions` in
+commits.
+
+If you use a coding agent (Cursor, Claude Code, Copilot, Codex, and others that
+support [Agent Skills](https://agentskills.io/)), point it at:
+
+[`.agents/skills/commit-message/`](https://github.com/kubernetes/minikube/tree/master/.agents/skills/commit-message)
+
+Ask the agent to draft or revise the commit message from your diff. AI drafts
+are fine when they accurately describe the change.
+
 ### Style Guides
 
 For coding, refer to the [Kubernetes Coding Conventions](https://github.com/kubernetes/community/blob/master/contributors/guide/coding-conventions.md#code-conventions)


### PR DESCRIPTION
Contributors and reviewers often get title-only commit messages that omit what and why, so git log is not enough to understand a change. Coding agents can draft better messages, but without shared guidance they guess conventions and may add GitHub closing keywords that trigger do-not-merge/invalid-commit-message.

Add an Agent Skills package under .agents/skills/commit-message/ aligned with the Kubernetes community commit message guidelines, plus AGENTS.md and a short contributor-guide section that links to the skill and the upstream docs.