### PR TITLE
virtiofs: build and test the package only on darwin

### DIFF
--- a/pkg/drivers/common/virtiofs/virtiofs.go
+++ b/pkg/drivers/common/virtiofs/virtiofs.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 /*
 Copyright 2025 The Kubernetes Authors All rights reserved.
 

--- a/pkg/drivers/common/virtiofs/virtiofs_test.go
+++ b/pkg/drivers/common/virtiofs/virtiofs_test.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 /*
 Copyright 2025 The Kubernetes Authors All rights reserved.
 


### PR DESCRIPTION
virtiofs is only used from the vfkit/krunkit drivers (macOS). I tagged the package `//go:build darwin` so the tests don't try to parse Windows paths they never see.

The mount page now says the same thing.

Fixes #23222