### PR TITLE
Validate VM driver memory minimums

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1103,8 +1103,10 @@ func validateUser(drvName string) {
 	}
 }
 
-// memoryLimits returns the amount of memory allocated to the system and hypervisor, the return value is in MiB
-func memoryLimits(drvName string) (int, int, error) {
+var memoryLimits = detectMemoryLimits
+
+// detectMemoryLimits returns the amount of memory allocated to the system and hypervisor, the return value is in MiB
+func detectMemoryLimits(drvName string) (int, int, error) {
 	info, cpuErr, memErr, diskErr := machine.LocalHostInfo()
 	if cpuErr != nil {
 		klog.Warningf("could not get system cpu info while verifying memory limits, which might be okay: %v", cpuErr)
@@ -1170,6 +1172,13 @@ func suggestMemoryAllocation(sysLimit, containerLimit, nodes int) int {
 	return suggested
 }
 
+func memoryRequirements(drvName string) (minimum, recommended int) {
+	if driver.IsVM(drvName) && !driver.IsSSH(drvName) {
+		return minVMUsableMem, minVMRecommendedMem
+	}
+	return minUsableMem, minRecommendedMem
+}
+
 // validateRequestedMemorySize validates the memory size matches the minimum recommended
 func validateRequestedMemorySize(req int, drvName string) {
 	// TODO: Fix MB vs MiB confusion
@@ -1177,21 +1186,22 @@ func validateRequestedMemorySize(req int, drvName string) {
 	if err != nil {
 		klog.Warningf("Unable to query memory limits: %v", err)
 	}
+	minimumMemory, recommendedMemory := memoryRequirements(drvName)
 
 	// Detect if their system doesn't have enough memory to work with.
-	if driver.IsKIC(drvName) && containerLimit < minUsableMem {
+	if driver.IsKIC(drvName) && containerLimit < minimumMemory {
 		if driver.IsDockerDesktop(drvName) {
 			if runtime.GOOS == "darwin" {
-				exitIfNotForced(reason.RsrcInsufficientDarwinDockerMemory, "Docker Desktop only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": containerLimit, "req": minUsableMem, "recommend": "2.25 GB"})
+				exitIfNotForced(reason.RsrcInsufficientDarwinDockerMemory, "Docker Desktop only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": containerLimit, "req": minimumMemory, "recommend": "2.25 GB"})
 			} else {
-				exitIfNotForced(reason.RsrcInsufficientWindowsDockerMemory, "Docker Desktop only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": containerLimit, "req": minUsableMem, "recommend": "2.25 GB"})
+				exitIfNotForced(reason.RsrcInsufficientWindowsDockerMemory, "Docker Desktop only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": containerLimit, "req": minimumMemory, "recommend": "2.25 GB"})
 			}
 		}
-		exitIfNotForced(reason.RsrcInsufficientContainerMemory, "{{.driver}} only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": containerLimit, "driver": drvName, "req": minUsableMem})
+		exitIfNotForced(reason.RsrcInsufficientContainerMemory, "{{.driver}} only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": containerLimit, "driver": drvName, "req": minimumMemory})
 	}
 
-	if sysLimit < minUsableMem {
-		exitIfNotForced(reason.RsrcInsufficientSysMemory, "System only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": sysLimit, "req": minUsableMem})
+	if sysLimit < minimumMemory {
+		exitIfNotForced(reason.RsrcInsufficientSysMemory, "System only has {{.size}}MiB available, less than the required {{.req}}MiB for Kubernetes", out.V{"size": sysLimit, "req": minimumMemory})
 	}
 
 	// if --memory=no-limit, ignore remaining checks
@@ -1199,18 +1209,18 @@ func validateRequestedMemorySize(req int, drvName string) {
 		return
 	}
 
-	if req < minUsableMem {
-		exitIfNotForced(reason.RsrcInsufficientReqMemory, "Requested memory allocation {{.requested}}MiB is less than the usable minimum of {{.minimum_memory}}MB", out.V{"requested": req, "minimum_memory": minUsableMem})
+	if req < minimumMemory {
+		exitIfNotForced(reason.RsrcInsufficientReqMemory, "Requested memory allocation {{.requested}}MiB is less than the usable minimum of {{.minimum_memory}}MB", out.V{"requested": req, "minimum_memory": minimumMemory})
 	}
-	if req < minRecommendedMem {
+	if req < recommendedMemory {
 		if driver.IsDockerDesktop(drvName) {
 			if runtime.GOOS == "darwin" {
-				out.WarnReason(reason.RsrcInsufficientDarwinDockerMemory, "Docker Desktop only has {{.size}}MiB available, you may encounter application deployment failures.", out.V{"size": containerLimit, "req": minUsableMem, "recommend": "2.25 GB"})
+				out.WarnReason(reason.RsrcInsufficientDarwinDockerMemory, "Docker Desktop only has {{.size}}MiB available, you may encounter application deployment failures.", out.V{"size": containerLimit, "req": minimumMemory, "recommend": "2.25 GB"})
 			} else {
-				out.WarnReason(reason.RsrcInsufficientWindowsDockerMemory, "Docker Desktop only has {{.size}}MiB available, you may encounter application deployment failures.", out.V{"size": containerLimit, "req": minUsableMem, "recommend": "2.25 GB"})
+				out.WarnReason(reason.RsrcInsufficientWindowsDockerMemory, "Docker Desktop only has {{.size}}MiB available, you may encounter application deployment failures.", out.V{"size": containerLimit, "req": minimumMemory, "recommend": "2.25 GB"})
 			}
 		} else {
-			out.WarnReason(reason.RsrcInsufficientReqMemory, "Requested memory allocation ({{.requested}}MB) is less than the recommended minimum {{.recommend}}MB. Deployments may fail.", out.V{"requested": req, "recommend": minRecommendedMem})
+			out.WarnReason(reason.RsrcInsufficientReqMemory, "Requested memory allocation ({{.requested}}MB) is less than the recommended minimum {{.recommend}}MB. Deployments may fail.", out.V{"requested": req, "recommend": recommendedMemory})
 		}
 	}
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -114,6 +114,8 @@ const (
 	nativeSSH               = "native-ssh"
 	minUsableMem            = 1800 // Kubernetes (kubeadm) will not start with less
 	minRecommendedMem       = 1900 // Warn at no lower than existing configurations
+	minVMUsableMem          = 2500 // VM drivers fail to boot reliably below this limit. See #23317.
+	minVMRecommendedMem     = 3072 // Warn VM users below the tested default allocation. See #23317.
 	minimumCPUS             = 2
 	minimumDiskSize         = 2000
 	autoUpdate              = "auto-update-drivers"

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -32,8 +33,10 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/cruntime"
 	"k8s.io/minikube/pkg/minikube/driver"
+	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/proxy"
 	"k8s.io/minikube/pkg/minikube/run"
+	"k8s.io/minikube/pkg/minikube/tests"
 )
 
 func TestGetKubernetesVersion(t *testing.T) {
@@ -299,6 +302,70 @@ func TestSuggestMemoryAllocation(t *testing.T) {
 			got := suggestMemoryAllocation(test.sysLimit, test.containerLimit, test.nodes)
 			if got != test.want {
 				t.Errorf("defaultMemorySize(sys=%d, container=%d) = %d, want: %d", test.sysLimit, test.containerLimit, got, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateRequestedMemorySizeForVMDrivers(t *testing.T) {
+	oldMemoryLimits := memoryLimits
+	memoryLimits = func(_ string) (int, int, error) {
+		return 8192, 0, nil
+	}
+	viper.Set(force, true)
+	t.Cleanup(func() {
+		memoryLimits = oldMemoryLimits
+		viper.Set(force, false)
+		out.SetErrFile(os.Stderr)
+	})
+
+	tests := []struct {
+		name        string
+		driver      string
+		memory      int
+		want        string
+		doesNotWant string
+	}{
+		{
+			name:   "VM driver rejects below minimum",
+			driver: driver.KVM2,
+			memory: 2400,
+			want:   "less than the usable minimum of 2500MB",
+		},
+		{
+			name:        "VM driver warns below recommendation",
+			driver:      driver.KVM2,
+			memory:      3000,
+			want:        "less than the recommended minimum 3072MB",
+			doesNotWant: "less than the usable minimum",
+		},
+		{
+			name:        "VM driver accepts recommended memory without low memory warning",
+			driver:      driver.KVM2,
+			memory:      3072,
+			doesNotWant: "less than the recommended minimum",
+		},
+		{
+			name:        "SSH driver keeps non-VM memory requirements",
+			driver:      driver.SSH,
+			memory:      2400,
+			doesNotWant: "2500MB",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			errFile := tests.NewFakeFile()
+			out.SetErrFile(errFile)
+
+			validateRequestedMemorySize(test.memory, test.driver)
+
+			got := errFile.String()
+			if test.want != "" && !strings.Contains(got, test.want) {
+				t.Fatalf("validateRequestedMemorySize(%d, %q) output = %q, want to contain %q", test.memory, test.driver, got, test.want)
+			}
+			if test.doesNotWant != "" && strings.Contains(got, test.doesNotWant) {
+				t.Fatalf("validateRequestedMemorySize(%d, %q) output = %q, should not contain %q", test.memory, test.driver, got, test.doesNotWant)
 			}
 		})
 	}


### PR DESCRIPTION
## What changed

- Add VM-driver-specific memory validation thresholds.
- Reject VM driver requests below 2500 MiB before provisioning starts.
- Warn VM driver users below the tested 3072 MiB allocation.
- Preserve the existing 1800/1900 MiB thresholds for container, none, and SSH drivers.
- Add a focused unit test for VM-driver memory validation behavior.

## Why

VM drivers can fail before Kubernetes starts when using the general memory minimum. In #23317, `minikube start --driver kvm2 --memory 2048` reached VM provisioning and then timed out waiting for an IP. The issue discussion establishes 2500 MiB as the practical VM boot minimum and 3072 MiB as the tested/default recommendation.

Fixes #23317

## Validation

- `git diff --check`
- Added `TestValidateRequestedMemorySizeForVMDrivers`

I attempted to run `go test ./cmd/minikube/cmd -run TestValidateRequestedMemorySizeForVMDrivers -count=1 -timeout=5m`, but this local sandbox cannot write to the Go telemetry/cache locations under `AppData`, and the rerun with workspace cache paths still did not complete after several minutes.
