### PR TITLE
Sync pkg/minikube/cni/flannel.yaml with upstream flannel manifest

### DIFF
--- a/pkg/minikube/cni/flannel.yaml
+++ b/pkg/minikube/cni/flannel.yaml
@@ -133,7 +133,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni-plugin
-        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.9.1-flannel1
+        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.9.1-flannel3
         command:
         - cp
         args:
@@ -144,11 +144,10 @@ spec:
         - name: cni-plugin
           mountPath: /opt/cni/bin
       - name: install-cni
-        image: ghcr.io/flannel-io/flannel:v0.28.5
+        image: ghcr.io/flannel-io/flannel:v0.28.9
         command:
-        - cp
+        - /opt/bin/install-conf
         args:
-        - -f
         - /etc/kube-flannel/cni-conf.json
         - /etc/cni/net.d/10-flannel.conflist
         volumeMounts:
@@ -158,12 +157,29 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: ghcr.io/flannel-io/flannel:v0.28.5
+        image: ghcr.io/flannel-io/flannel:v0.28.9
         command:
         - /opt/bin/flanneld
         args:
         - --ip-masq
         - --kube-subnet-mgr
+        - --healthz-port=8081
+        ports:
+        - name: healthz
+          containerPort: 8081
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+          initialDelaySeconds: 5
+          periodSeconds: 10
         resources:
           requests:
             cpu: "100m"


### PR DESCRIPTION

flannel-io/flannel has updated their [official manifest](flannel-io/flannel/master/Documentation/kube-flannel.yml) at
https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml
since we last vendored it. This PR brings our bundled `pkg/minikube/cni/flannel.yaml`
back in line with that upstream source.

### Changes
- `flannel-cni-plugin`: `v1.9.1-flannel1` → `v1.9.1-flannel3`
- `flannel`: `v0.28.5` → `v0.28.9`
- `install-cni` init container: switched from `cp -f <conf> <dest>` to the
  `/opt/bin/install-conf` entrypoint now used upstream
- `net-conf.json` backend: explicit `VNI` (4096) and `Port` (4789) added to
  the vxlan backend config, matching upstream defaults
- `kube-flannel` container: added `--healthz-port=8081` plus liveness
  (`/healthz`) and readiness (`/readyz`) probes, matching upstream's health
  check wiring

### Why
Keeping our bundled manifest in sync with upstream avoids drift from
flannel's supported configuration and picks up their liveness/readiness
probes, which should make pod startup/health more observable under
`kubectl get pods -n kube-flannel`.

### Testing
`minikube start --cni=flannel` and confirm flannel pods become Ready, verify probes report healthy 