### PR TITLE
Add bobsira as reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,7 @@ reviewers:
   - prezha
   - comradeprogrammer
   - nirs
+  - bobsira
 approvers:
   - medyagh
   - prezha


### PR DESCRIPTION
## What this PR does

Adds myself (`bobsira`) to the `reviewers` list in `OWNERS`, per [Kubernetes community reviewer requirements](https://github.com/kubernetes/community/blob/main/community-membership.md#reviewer).

Self-nominating at the suggestion of @nirs.

## Requirements checklist

- [x] Member for at least 3 months
- [x] Primary reviewer for at least 5 PRs to the codebase
- [x] Reviewed or merged at least 20 substantial PRs to the codebase
- [x] Knowledgeable about the codebase

## Supporting evidence

### Authored & merged PRs (25+ merged)

- #23512 — Sync `pkg/minikube/cni/flannel.yaml` with upstream flannel manifest
- #23319 — refactor: add NodeProvisioner interface with linuxNodeProvisioner
- #22659 — fix: PowerShell curl alias on Windows to check registry.k8s.io connectivity
- #22503 — Windows node support in minikube (open, large feature)
- #18707 — [Multi-OS Cluster]: Windows Node Support in minikube Proposal (open)
- #22528, #22527, #22525, #22522, #22521, #22507, #22500, #22479, #22468, #22467, #22278, #22268, #22248, #22244, #22234, #22197, #22026, #21848, #21845, #21738, #21737, #21426 — Windows CI unit test fixes

### Primary reviewer on PRs by others (5+)

- #23324 — vmware windows registry path (@jxsl13)
- #23225 — Traefik Helm-based addon (@Roslaan001)
- #22512 — Kurdish translation (@medyagh)
- #21329 — skip tests not relevant for windows (@prezha)
- #20921 — Fix minikube image load on windows (@james-world)

/cc @nirs  @afbjorklund 