### PR TITLE
Super small fix - annoying typo in validatePersistentVolumeClaim section

### DIFF
--- a/site/content/en/docs/contrib/tests.en.md
+++ b/site/content/en/docs/contrib/tests.en.md
@@ -454,7 +454,7 @@ for the platforms that support it, we're testing:
 #### validatePersistentVolumeClaim
 makes sure PVCs work properly
 verifies at least one StorageClass exists
-Applies a PVC manifest (pvc.yaml) and verfies PVC named myclaim reaches phase Bound.
+Applies a PVC manifest (pvc.yaml) and verifies PVC named myclaim reaches phase Bound.
 Creates a test pod (sp-pod) that mounts the claim (via createPVTestPod).
 Writes a file foo to the mounted volume at /tmp/mount/foo.
 Deletes the pod, recreates it, and verifies the file foo still exists by listing /tmp/mount, proving data persists across pod restarts.


### PR DESCRIPTION
Hi guys, annoying typo in your wiki :)

https://minikube.sigs.k8s.io/docs/contrib/tests/

<img width="1093" height="273" alt="image" src="https://github.com/user-attachments/assets/e6aadb36-f2c6-4c06-b347-30636f4ea6c6" />
