### PR TITLE
test: dedupe kubernetes versions in download-only test

### DIFF
--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -31,6 +31,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -67,10 +68,15 @@ func TestDownloadOnly(t *testing.T) { // nolint:gocyclo
 		constants.NewestKubernetesVersion,
 	}
 
-	// Small optimization, don't run the exact same set of tests twice
-	if constants.DefaultKubernetesVersion == constants.NewestKubernetesVersion {
-		versions = versions[:len(versions)-1]
+	// Remove duplicate versions, preserving order. Right now Default and
+	// Newest are the same, so we would otherwise run the same test twice.
+	deduped := make([]string, 0, len(versions))
+	for _, v := range versions {
+		if !slices.Contains(deduped, v) {
+			deduped = append(deduped, v)
+		}
 	}
+	versions = deduped
 
 	for _, v := range versions {
 		t.Run(v, func(t *testing.T) {


### PR DESCRIPTION
## What this PR does

`test/integration/aaa_download_only_test.go` builds a versions list as:

```go
versions := []string{
    constants.OldestKubernetesVersion,
    constants.DefaultKubernetesVersion,
    constants.NewestKubernetesVersion,
}
```

Today `DefaultKubernetesVersion` and `NewestKubernetesVersion` are both `v1.36.2` (see `pkg/minikube/constants/constants.go`), so the same test scenario runs twice.

The existing code only handled the `Default == Newest` case with an ad-hoc trim of the last element. This PR replaces that with a general order-preserving dedupe (using `slices.Contains`) so the test is robust to any future combination of the constants coinciding (e.g. `Oldest == Default`), and is easier to read.

### Why
- Removes a duplicate test run today (minor CI time saving).
- Prevents silent duplicate runs from coming back if the constants drift again in a different combination.

Fixes #21483