### PR TITLE
tests: Fix TestISOImage memory and HelmVersion path

### DIFF
--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -500,6 +500,29 @@ func showPodLogs(ctx context.Context, t *testing.T, profile string, ns string, n
 	}
 }
 
+// RepoRoot returns the module root by walking up from cwd until go.mod is
+// found. The compiled e2e binary is invoked from the project root (hit on
+// the first try). `go test` sets cwd to the test package, including
+// test/integration and any nested or future test package.
+func RepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	start := dir
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("failed to find go.mod from %s", start)
+		}
+		dir = parent
+	}
+}
+
 // MaybeParallel sets that the test should run in parallel
 func MaybeParallel(t *testing.T) {
 	t.Helper()

--- a/test/integration/iso_test.go
+++ b/test/integration/iso_test.go
@@ -184,7 +184,7 @@ func TestISOImage(t *testing.T) {
 func helmPackageVersion(t *testing.T) string {
 	t.Helper()
 
-	isoArchDir := "deploy/iso/minikube-iso/arch"
+	isoArchDir := filepath.Join(RepoRoot(t), "deploy/iso/minikube-iso/arch")
 	packageFile := filepath.Join(isoArchDir, "x86_64/package/helm-bin/helm-bin.mk")
 	versionName := "HELM_BIN_VERSION"
 	if runtime.GOARCH == "arm64" {

--- a/test/integration/iso_test.go
+++ b/test/integration/iso_test.go
@@ -46,7 +46,7 @@ func TestISOImage(t *testing.T) {
 	defer CleanupWithLogs(t, profile, cancel)
 
 	t.Run("Setup", func(t *testing.T) {
-		args := append([]string{"start", "-p", profile, "--no-kubernetes", "--memory=2500mb"}, StartArgs()...)
+		args := append([]string{"start", "-p", profile, "--no-kubernetes", "--memory=3072"}, StartArgs()...)
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 		if err != nil {
 			t.Errorf("failed to start minikube: args %q: %v", rr.Command(), err)


### PR DESCRIPTION
## Summary
- Raise TestISOImage `--memory` from 2500 to 3072 so the VM starts with the current ISO (needed after #23518; 3072 is the allocation used by the rest of the integration suite).
- Resolve the helm package makefile from the module root instead of cwd. `HelmVersion` only passed in Prow, where [`hack/prow/common.sh`](https://github.com/kubernetes/minikube/blob/master/hack/prow/common.sh) runs the compiled e2e binary from the git checkout root. Locally, `make integration` runs `go test ./test/integration`, so cwd is the test package and the makefile was not found.

`RepoRoot` walks up from cwd until it finds `go.mod`, so both `go test` and the compiled e2e binary can locate `deploy/iso/minikube-iso/arch`.