### PR TITLE
start: add --node-os flag for mixed-OS clusters

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -193,6 +193,7 @@ func runStart(cmd *cobra.Command, _ []string) {
 		out.WarningT("Profile name '{{.name}}' is not valid", out.V{"name": ClusterFlagValue()})
 		exit.Message(reason.Usage, "Only alphanumeric and dashes '-' are permitted. Minimum 2 characters, starting with alphanumeric.")
 	}
+
 	existing, err := config.Load(ClusterFlagValue())
 	if err != nil && !config.IsNotExist(err) {
 		kind := reason.HostConfigLoad
@@ -206,6 +207,10 @@ func runStart(cmd *cobra.Command, _ []string) {
 		upgradeExistingConfig(cmd, existing)
 	} else {
 		validateProfileName()
+	}
+
+	if cmd.Flags().Changed(nodeOS) {
+		applyMixedOSDefaults(cmd, existing)
 	}
 
 	validateSpecifiedDriver(existing, options)
@@ -1357,6 +1362,16 @@ func validateFlags(cmd *cobra.Command, drvName string) { //nolint:gocyclo
 		}
 	}
 
+	if cmd.Flags().Changed(nodeOS) {
+		if err := validMultiNodeOS(viper.GetString(nodeOS)); err != nil {
+			exit.Message(reason.Usage, "{{.err}}", out.V{"err": err})
+		}
+
+		if viper.GetInt(nodes) != 2 {
+			exit.Message(reason.Usage, "The --nodes flag must be set to 2 when using --node-os")
+		}
+	}
+
 	if cmd.Flags().Changed(gpus) {
 		if err := validateGPUs(viper.GetString(gpus), drvName, viper.GetString(containerRuntime)); err != nil {
 			exit.Message(reason.Usage, "{{.err}}", out.V{"err": err})
@@ -1976,6 +1991,73 @@ func validateDockerStorageDriver(drvName string) {
 	}
 	out.WarningT("{{.Driver}} is currently using the {{.StorageDriver}} storage driver, setting preload=false", out.V{"StorageDriver": si.StorageDriver, "Driver": drvName})
 	viper.Set(preload, false)
+}
+
+// validMultiNodeOS validates the --node-os value for a mixed-OS cluster.
+// Only a single linux control-plane node plus a single windows worker node
+// is currently supported, so the value must be exactly "[linux,windows]"
+// (whitespace after the comma is tolerated).
+func validMultiNodeOS(osString string) error {
+	if !strings.HasPrefix(osString, "[") || !strings.HasSuffix(osString, "]") {
+		return errors.New("invalid OS string format: must be enclosed in [ ]")
+	}
+
+	osString = strings.TrimPrefix(osString, "[")
+	osString = strings.TrimSuffix(osString, "]")
+	osString = strings.ReplaceAll(osString, " ", "")
+
+	osValues := strings.Split(osString, ",")
+
+	if len(osValues) != 2 || osValues[0] != "linux" || osValues[1] != "windows" {
+		return errors.New("invalid OS string format: must be [linux,windows]")
+	}
+
+	return nil
+}
+
+// applyMixedOSDefaults fills in the driver/cni/container-runtime a mixed-OS
+// cluster requires, but only for a brand-new profile: converting an existing
+// profile to mixed-OS isn't supported yet (its persisted runtime/CNI could
+// silently drift from what --node-os requires, since updateExistingConfigFromFlags
+// only touches fields for flags the user actually passed), so require a fresh
+// profile instead.
+func applyMixedOSDefaults(cmd *cobra.Command, existing *config.ClusterConfig) {
+	if existing != nil {
+		exit.Message(reason.Usage, "--node-os cannot be used with an existing profile; delete it first with 'minikube delete -p {{.profile}}' or start a new profile with --profile", out.V{"profile": ClusterFlagValue()})
+	}
+
+	required := []struct {
+		flagName, want, label string
+	}{
+		{"driver", driver.HyperV, "driver"},
+		{cniFlag, "flannel", "CNI"},
+		{containerRuntime, constants.Containerd, "container runtime"},
+	}
+
+	for _, r := range required {
+		changed := cmd.Flags().Changed(r.flagName)
+		got := viper.GetString(r.flagName)
+		if err := mixedOSFlagConflict(changed, got, r.want, r.flagName, r.label); err != nil {
+			exit.Message(reason.Usage, "{{.err}}", out.V{"err": err})
+		}
+		if !changed {
+			viper.Set(r.flagName, r.want)
+			out.Infof("--node-os: automatically selecting {{.want}} as the {{.label}}", out.V{"want": r.want, "label": r.label})
+		}
+	}
+}
+
+// mixedOSFlagConflict reports a usage error if the user explicitly passed
+// flagName with a value other than want. want is only ever applied as a
+// default (by the caller) when the flag was not explicitly changed - an
+// explicit, conflicting value must be rejected rather than silently
+// overridden, since viper.Set() takes precedence over an explicit flag and
+// would otherwise discard the user's choice without telling them.
+func mixedOSFlagConflict(changed bool, got, want, flagName, label string) error {
+	if changed && got != want {
+		return fmt.Errorf("--node-os requires the %s %s, but --%s=%s was specified", want, label, flagName, got)
+	}
+	return nil
 }
 
 // validateSubnet checks that the subnet provided has a private IP

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -149,6 +149,7 @@ const (
 	staticIP                = "static-ip"
 	gpus                    = "gpus"
 	autoPauseInterval       = "auto-pause-interval"
+	nodeOS                  = "node-os"
 	preloadSrc              = "preload-source"
 	rosetta                 = "rosetta"
 	vmnetOffloading         = "vmnet-offloading"
@@ -219,6 +220,14 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(staticIP, "", "Set a static IP for the minikube cluster, the IP must be: private, IPv4, and the last octet must be between 2 and 254, for example 192.168.200.200 (Docker and Podman drivers only)")
 	startCmd.Flags().StringP(gpus, "g", "", "Allow pods to use your GPUs. Options include: [all,nvidia,amd] (Docker driver with Docker container-runtime only)")
 	startCmd.Flags().Duration(autoPauseInterval, time.Minute*1, "Duration of inactivity before the minikube VM is paused (default 1m0s)")
+	startCmd.Flags().String(nodeOS, "", "Experimental: the OS to use for each node in a mixed-OS cluster, e.g. '[linux,windows]'. Requires --nodes=2. Currently only a single linux control-plane node plus a single windows worker node is supported.")
+	// --node-os is scaffolding: it validates and forces driver/cni/runtime, but nothing
+	// yet routes the Windows worker through a Windows-specific node-creation path, so a
+	// mixed-OS cluster requested today still comes up as two Linux nodes. Keep it hidden
+	// until the follow-up PR (kubernetes/minikube#23209) wires up node topology.
+	if err := startCmd.Flags().MarkHidden(nodeOS); err != nil {
+		klog.Warningf("Failed to hide node-os flag: %v\n", err)
+	}
 	startCmd.Flags().String(preloadSrc, "auto", "Which source to download the preload from (valid options: gcs, github, auto). Defaults to auto (try github first, then gcs as failover).")
 }
 
@@ -757,6 +766,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 		MultiNodeRequested: viper.GetInt(nodes) > 1 || viper.GetBool(ha),
 		GPUs:               viper.GetString(gpus),
 		AutoPauseInterval:  viper.GetDuration(autoPauseInterval),
+		NodeOS:             viper.GetString(nodeOS),
 		Rosetta:            getRosetta(drvName),
 		VmnetOffloading:    getVmnetOffloading(drvName),
 		DNSServers:         getDNSServers(cmd, drvName),
@@ -991,6 +1001,7 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 	updateStringFromFlag(cmd, &cc.SocketVMnetClientPath, socketVMnetClientPath)
 	updateStringFromFlag(cmd, &cc.SocketVMnetPath, socketVMnetPath)
 	updateDurationFromFlag(cmd, &cc.AutoPauseInterval, autoPauseInterval)
+	updateStringFromFlag(cmd, &cc.NodeOS, nodeOS)
 	updateBoolFromFlag(cmd, &cc.Rosetta, rosetta)
 	updateBoolFromFlag(cmd, &cc.VmnetOffloading, vmnetOffloading)
 

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -471,6 +471,96 @@ func TestValidateRuntime(t *testing.T) {
 	}
 }
 
+func TestValidMultiNodeOS(t *testing.T) {
+	var tests = []struct {
+		osString string
+		errorMsg string
+	}{
+		{
+			osString: "[linux,windows]",
+			errorMsg: "",
+		},
+		{
+			osString: "[linux, windows]",
+			errorMsg: "",
+		},
+		{
+			osString: "[windows,linux]",
+			errorMsg: "invalid OS string format: must be [linux,windows]",
+		},
+		{
+			osString: "[linux]",
+			errorMsg: "invalid OS string format: must be [linux,windows]",
+		},
+		{
+			osString: "[linux,windows,mac]",
+			errorMsg: "invalid OS string format: must be [linux,windows]",
+		},
+		{
+			osString: "linux,windows",
+			errorMsg: "invalid OS string format: must be enclosed in [ ]",
+		},
+		{
+			osString: "[[linux,windows]]",
+			errorMsg: "invalid OS string format: must be [linux,windows]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.osString, func(t *testing.T) {
+			got := validMultiNodeOS(test.osString)
+			gotError := ""
+			if got != nil {
+				gotError = got.Error()
+			}
+			if gotError != test.errorMsg {
+				t.Errorf("validMultiNodeOS(osString=%v): got %v, expected %v", test.osString, gotError, test.errorMsg)
+			}
+		})
+	}
+}
+
+func TestMixedOSFlagConflict(t *testing.T) {
+	var tests = []struct {
+		description string
+		changed     bool
+		got         string
+		errorMsg    string
+	}{
+		{
+			description: "flag not passed, no conflict",
+			changed:     false,
+			got:         "docker",
+			errorMsg:    "",
+		},
+		{
+			description: "flag explicitly matches the required value",
+			changed:     true,
+			got:         "hyperv",
+			errorMsg:    "",
+		},
+		{
+			description: "flag explicitly conflicts with the required value",
+			changed:     true,
+			got:         "docker",
+			errorMsg:    "--node-os requires the hyperv driver, but --driver=docker was specified",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got := mixedOSFlagConflict(test.changed, test.got, "hyperv", "driver", "driver")
+			gotError := ""
+			if got != nil {
+				gotError = got.Error()
+			}
+			if gotError != test.errorMsg {
+				t.Errorf("mixedOSFlagConflict(changed=%v, got=%v): got %v, expected %v", test.changed, test.got, gotError, test.errorMsg)
+			}
+		})
+	}
+}
+
 func TestIsTwoDigitSemver(t *testing.T) {
 	var tcs = []struct {
 		desc     string

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -110,6 +110,7 @@ type ClusterConfig struct {
 	SSHAgentPID             int
 	GPUs                    string
 	AutoPauseInterval       time.Duration // Specifies interval of time to wait before checking if cluster should be paused
+	NodeOS                  string        // Raw --node-os flag value (e.g. "[linux,windows]"), set when a mixed-OS cluster was requested
 	Rosetta                 bool          // Only used by vfkit driver
 	VmnetOffloading         bool          // Only used by krunkit driver
 	DNSServers              []netip.Addr  // Static DNS servers for the VM (VM drivers only)


### PR DESCRIPTION
## Summary

Introduces the CLI entry point for mixed-OS cluster support: the `--node-os` flag, its validation (must be `[linux,windows]`, `--nodes` must be 2), and the `ClusterConfig.NodeOS` field it populates.

- When `--node-os` is set on a **new** profile, the driver/cni/container-runtime are defaulted to `hyperv`/`flannel`/`containerd` — the only combination validated for a Windows worker node's kubeadm join and networking setup — but only for flags the user didn't explicitly pass. An explicit conflicting value (e.g. `--node-os=... --driver=docker`) is rejected with a clear usage error rather than silently overridden.
- Reusing `--node-os` with an **existing** profile is rejected: converting one isn't supported yet, and its persisted runtime/CNI could otherwise drift from what `--node-os` requires.
- The flag is hidden from `--help`: nothing yet consumes `NodeOS` to change node topology, so a mixed-OS cluster requested today still comes up as two Linux nodes. That follows in a subsequent PR, as part of an incremental `NodeProvisioner`-based rollout (tracking issue: kubernetes/minikube#23209).

This is intentionally scaffolding-only and behavior-preserving for existing users — no consuming logic is added yet, keeping this PR small and reviewable ahead of the node-topology and provisioner work that builds on it.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/minikube/cmd/... ./pkg/minikube/config/...`
- [x] `go test ./cmd/minikube/cmd/...` — includes new `TestValidMultiNodeOS` (format validation, incl. `[[linux,windows]]` rejection) and `TestMixedOSFlagConflict` (explicit-flag conflict detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)