### PR TITLE
ci: use go.mod toolchain as the single source of the Go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ on:
       - "!site/**"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -26,7 +25,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 1
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Download Dependencies
         timeout-minutes: 1
         run: go mod download
@@ -57,7 +56,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 1
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Install libvirt
         timeout-minutes: 2
         run: |
@@ -80,7 +79,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 1
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Install libvirt
         timeout-minutes: 2
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,6 @@ on:
       - master
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -20,7 +19,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Generate Docs
         id: gendocs
         timeout-minutes: 7

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -27,7 +27,6 @@ concurrency:
   cancel-in-progress: true
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 jobs:
@@ -53,7 +52,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
           cache: true      
       - name: Download Dependencies
         timeout-minutes: 1
@@ -155,7 +154,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
           cache: true      
       - name: Install gopogh
         timeout-minutes: 1

--- a/.github/workflows/go-housekeeping.yml
+++ b/.github/workflows/go-housekeeping.yml
@@ -8,7 +8,6 @@ on:
       - 'site/**'
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -23,7 +22,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
           cache: true
       - name: Tidy Go Modules
         id: gmodtidy

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -6,7 +6,6 @@ on:
       - 'v*-beta.*'
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 1
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Update Leaderboard
         id: leaderboard
         timeout-minutes: 34

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,6 @@ concurrency:
   cancel-in-progress: true
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 jobs:
@@ -28,7 +27,7 @@ jobs:
         - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
           timeout-minutes: 1
           with:
-            go-version: ${{env.GO_VERSION}}
+            go-version-file: go.mod
             cache: true      
         - name: Download Dependencies
           timeout-minutes: 1
@@ -54,7 +53,7 @@ jobs:
         - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
           timeout-minutes: 1
           with:
-            go-version: ${{env.GO_VERSION}}
+            go-version-file: go.mod
             cache: true  
         - name: Boilerplate check
           timeout-minutes: 1
@@ -70,7 +69,7 @@ jobs:
         - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
           timeout-minutes: 1
           with:
-            go-version: ${{env.GO_VERSION}}
+            go-version-file: go.mod
             cache: true
         - name: Install goimports
           timeout-minutes: 1

--- a/.github/workflows/minikube-image-benchmark.yml
+++ b/.github/workflows/minikube-image-benchmark.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 2,14 * * *"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -24,7 +23,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 1
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Run Benchmark
         timeout-minutes: 69
         run: |

--- a/.github/workflows/sync-minikube.yml
+++ b/.github/workflows/sync-minikube.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 2,14 * * *"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -27,7 +26,7 @@ jobs:
         timeout-minutes: 1
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Build
         timeout-minutes: 1
         run: make

--- a/.github/workflows/time-to-k8s-public-chart.yml
+++ b/.github/workflows/time-to-k8s-public-chart.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 2,14 * * *"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -22,7 +21,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Benchmark time-to-k8s for Docker driver with Docker runtime
         run: |
           ./hack/benchmark/time-to-k8s/public-chart/public-chart.sh docker docker
@@ -46,7 +45,7 @@ jobs:
           kubectl version --client=true
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Disable firewall
         run: |
           sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off

--- a/.github/workflows/time-to-k8s.yml
+++ b/.github/workflows/time-to-k8s.yml
@@ -5,7 +5,6 @@ on:
     types: [released]
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -21,7 +20,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 1
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: time-to-k8s Benchmark
         timeout-minutes: 79
         id: timeToK8sBenchmark

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -6,7 +6,6 @@ on:
       - "translations/**"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 1
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Install libvirt
         timeout-minutes: 2
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -37,7 +37,6 @@ concurrency:
   cancel-in-progress: true
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 jobs:
@@ -53,7 +52,7 @@ jobs:
         - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
           timeout-minutes: 7
           with:
-            go-version: ${{env.GO_VERSION}}
+            go-version-file: go.mod
             cache: true
         - name: Download Dependencies
           timeout-minutes: 3

--- a/.github/workflows/update-all.yml
+++ b/.github/workflows/update-all.yml
@@ -3,7 +3,6 @@ on:
   workflow_dispatch:
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 jobs:
@@ -15,7 +14,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 1
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump versions
         id: bumpVersions
         timeout-minutes: 3

--- a/.github/workflows/update-amd-gpu-device-plugin-version.yml
+++ b/.github/workflows/update-amd-gpu-device-plugin-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump amd-gpu-device-plugin version
         id: bumpAmdDevicePlugin
         timeout-minutes: 1

--- a/.github/workflows/update-buildkit-version.yml
+++ b/.github/workflows/update-buildkit-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 10 * * 3"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 1
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump buildkit Version
         timeout-minutes: 1
         id: bumpBuildkit

--- a/.github/workflows/update-calico-version.yml
+++ b/.github/workflows/update-calico-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump calico version
         id: bumpCalico
         timeout-minutes: 1

--- a/.github/workflows/update-cilium-version.yml
+++ b/.github/workflows/update-cilium-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump cilium version
         id: bumpCilium
         timeout-minutes: 1

--- a/.github/workflows/update-cloud-spanner-emulator-version.yml
+++ b/.github/workflows/update-cloud-spanner-emulator-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump cloud-spanner-emulator version
         id: bumpCloudSpannerEmulator
         timeout-minutes: 1

--- a/.github/workflows/update-cni-plugins-version.yml
+++ b/.github/workflows/update-cni-plugins-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump cni-plugins Version
         timeout-minutes: 1
         id: bumpCNIPlugins

--- a/.github/workflows/update-containerd-version.yml
+++ b/.github/workflows/update-containerd-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump containerd Version
         timeout-minutes: 1
         id: bumpContainerd

--- a/.github/workflows/update-cri-dockerd-version.yml
+++ b/.github/workflows/update-cri-dockerd-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump cri-dockerd version
         timeout-minutes: 1
         id: bumpCriDockerd

--- a/.github/workflows/update-cri-o-version.yml
+++ b/.github/workflows/update-cri-o-version.yml
@@ -7,7 +7,6 @@ on:
     # - cron: "0 10 * * 5"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -20,7 +19,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump cri-o Version
         timeout-minutes: 1
         id: bumpCrio

--- a/.github/workflows/update-crictl-version.yml
+++ b/.github/workflows/update-crictl-version.yml
@@ -7,7 +7,6 @@ on:
     # - cron: "0 10 * * 3"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -20,7 +19,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump crictl Version
         timeout-minutes: 1
         id: bumpCrictl

--- a/.github/workflows/update-crun-version.yml
+++ b/.github/workflows/update-crun-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 10 * * 3"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 1
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump crun Version
         timeout-minutes: 1
         id: bumpCrun

--- a/.github/workflows/update-debian-version.yml
+++ b/.github/workflows/update-debian-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump Ubuntu version
         timeout-minutes: 1
         id: bumpBaseOsImage

--- a/.github/workflows/update-docker-buildx-version.yml
+++ b/.github/workflows/update-docker-buildx-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump docker-buildx Version
         timeout-minutes: 1
         id: bumpDockerBuildx

--- a/.github/workflows/update-docker-version.yml
+++ b/.github/workflows/update-docker-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 10 * * 4"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 1
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump docker Version
         timeout-minutes: 1
         id: bumpDocker

--- a/.github/workflows/update-docsy-version.yml
+++ b/.github/workflows/update-docsy-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump Docsy version
         id: bumpDocsy
         timeout-minutes: 1

--- a/.github/workflows/update-flannel-version.yml
+++ b/.github/workflows/update-flannel-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump flannel version
         id: bumpFlannel
         timeout-minutes: 1

--- a/.github/workflows/update-gcp-auth-version.yml
+++ b/.github/workflows/update-gcp-auth-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump gcp-auth version
         id: bumpGCPAuth
         timeout-minutes: 1

--- a/.github/workflows/update-gh-version.yml
+++ b/.github/workflows/update-gh-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump gh version
         id: bumpGh
         timeout-minutes: 1

--- a/.github/workflows/update-go-github-version.yml
+++ b/.github/workflows/update-go-github-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump go-github version
         id: bumpGoGithub
         timeout-minutes: 1

--- a/.github/workflows/update-golang-version.yml
+++ b/.github/workflows/update-golang-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 9 * * 1"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump Golang Versions
         timeout-minutes: 2
         id: bumpGolang

--- a/.github/workflows/update-golint-version.yml
+++ b/.github/workflows/update-golint-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump Golint Versions
         id: bumpGolint
         timeout-minutes: 1

--- a/.github/workflows/update-gopogh-version.yml
+++ b/.github/workflows/update-gopogh-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 9 * * 1"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump gopogh Versions
         id: bumpGopogh
         timeout-minutes: 1

--- a/.github/workflows/update-gotestsum-version.yml
+++ b/.github/workflows/update-gotestsum-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump Gotestsum Versions
         id: bumpGotestsum
         timeout-minutes: 1

--- a/.github/workflows/update-headlamp-version.yml
+++ b/.github/workflows/update-headlamp-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump Headlamp version
         id: bumpHeadlamp
         timeout-minutes: 1

--- a/.github/workflows/update-hugo-version.yml
+++ b/.github/workflows/update-hugo-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump Hugo version
         id: bumpHugo
         timeout-minutes: 1

--- a/.github/workflows/update-ingress-version.yml
+++ b/.github/workflows/update-ingress-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump ingress version
         id: bumpIngress
         timeout-minutes: 1

--- a/.github/workflows/update-inspektor-gadget-version.yml
+++ b/.github/workflows/update-inspektor-gadget-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump inspektor-gadget version
         id: bumpInspektorGadget
         timeout-minutes: 1

--- a/.github/workflows/update-iso-image-versions.yml
+++ b/.github/workflows/update-iso-image-versions.yml
@@ -11,7 +11,6 @@ on:
         default: "update-buildkit-version,update-cni-plugins-version,update-crun-version,update-docker-version,update-golang-version,update-runc-version,update-debian-version"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 jobs:
@@ -23,7 +22,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump versions
         timeout-minutes: 2
         id: bumpVersions

--- a/.github/workflows/update-istio-operator.yml
+++ b/.github/workflows/update-istio-operator.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump istio-operator version
         id: bumpIstioOperator
         timeout-minutes: 1

--- a/.github/workflows/update-k8s-versions.yml
+++ b/.github/workflows/update-k8s-versions.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 1"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump Kubernetes Versions
         id: bumpk8s
         timeout-minutes: 1

--- a/.github/workflows/update-kindnetd-version.yml
+++ b/.github/workflows/update-kindnetd-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 jobs:
@@ -18,7 +17,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump kindnetd version
         id: bumpKindnetd
         timeout-minutes: 1

--- a/.github/workflows/update-kong-ingress-controller-version.yml
+++ b/.github/workflows/update-kong-ingress-controller-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump kong-ingress-controller version
         id: bumpKongIngressController
         timeout-minutes: 1

--- a/.github/workflows/update-kong-version.yml
+++ b/.github/workflows/update-kong-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump kong version
         id: bumpKong
         timeout-minutes: 1

--- a/.github/workflows/update-kube-vip-version.yml
+++ b/.github/workflows/update-kube-vip-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump kube-vip version
         timeout-minutes: 1
         id: bumpKubeVip

--- a/.github/workflows/update-kubeadm-constants.yml
+++ b/.github/workflows/update-kubeadm-constants.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 6 * * 1"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump Kubeadm Constants for Kubernetes Images
         timeout-minutes: 4
         id: bumpKubeadmConsts

--- a/.github/workflows/update-kubectl-version.yml
+++ b/.github/workflows/update-kubectl-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump Kubectl version
         timeout-minutes: 1
         id: bumpKubectl

--- a/.github/workflows/update-kubernetes-versions-list.yml
+++ b/.github/workflows/update-kubernetes-versions-list.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 6 * * 1"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump Kubernetes versions list
         timeout-minutes: 1
         id: bumpKubernetesVersionsList

--- a/.github/workflows/update-kubevirt-version.yml
+++ b/.github/workflows/update-kubevirt-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 9 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump KubeVirt version
         timeout-minutes: 1
         id: bumpKubevirt

--- a/.github/workflows/update-metrics-server-version.yml
+++ b/.github/workflows/update-metrics-server-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump metrics-server version
         timeout-minutes: 1
         id: bumpMetricsServer

--- a/.github/workflows/update-nerdctl-version.yml
+++ b/.github/workflows/update-nerdctl-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump nerdctl Version
         timeout-minutes: 1
         id: bumpNerdctl

--- a/.github/workflows/update-nerdctld-version.yml
+++ b/.github/workflows/update-nerdctld-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump nerdctld Version
         timeout-minutes: 1
         id: bumpNerdctld

--- a/.github/workflows/update-nvidia-device-plugin-version.yml
+++ b/.github/workflows/update-nvidia-device-plugin-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump nvidia-device-plugin version
         timeout-minutes: 1
         id: bumpNvidiaDevicePlugin

--- a/.github/workflows/update-portainer-version.yml
+++ b/.github/workflows/update-portainer-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 10 * * 1"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump portainer version
         timeout-minutes: 1
         id: bumpPortainer

--- a/.github/workflows/update-registry-version.yml
+++ b/.github/workflows/update-registry-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump registry version
         timeout-minutes: 1
         id: bumpRegistry

--- a/.github/workflows/update-runc-version.yml
+++ b/.github/workflows/update-runc-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 10 * * 2"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 1
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump runc Version
         timeout-minutes: 1
         id: bumpRunc

--- a/.github/workflows/update-site-node-version.yml
+++ b/.github/workflows/update-site-node-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump site node version
         timeout-minutes: 1
         id: bumpSiteNode

--- a/.github/workflows/update-volcano-version.yml
+++ b/.github/workflows/update-volcano-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
           cache-dependency-path: ./go.sum
       - name: Bump volcano version
         timeout-minutes: 1

--- a/.github/workflows/update-yakd-version.yml
+++ b/.github/workflows/update-yakd-version.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 8 * * 6"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 2
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Bump yakd version
         timeout-minutes: 1
         id: bumpYakd

--- a/.github/workflows/yearly-leaderboard.yml
+++ b/.github/workflows/yearly-leaderboard.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 0 2 * *"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.26.5'
 permissions:
   contents: read
 
@@ -24,7 +23,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         timeout-minutes: 1
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.mod
       - name: Update Yearly Leaderboard
         id: yearlyLeaderboard
         timeout-minutes: 9

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,11 @@ RPM_VERSION ?= $(DEB_VERSION)
 RPM_REVISION ?= 0
 
 # used by hack/jenkins/release_build_and_upload.sh, see also BUILD_IMAGE below
-# update this only by running `make update-golang-version`
-GO_VERSION ?= 1.26.5
-# set GOTOOLCHAIN to GO_VERSION to override any toolchain version specified in
-# go.mod (ref: https://go.dev/doc/toolchain#GOTOOLCHAIN)
+# the toolchain directive in go.mod is the single source of the Go version,
+# update it only by running `make update-golang-version`
+GO_VERSION ?= $(shell sed -n -e 's/^toolchain go//p' go.mod)
+# set GOTOOLCHAIN to GO_VERSION so the build does not silently pick up a newer
+# locally installed toolchain (ref: https://go.dev/doc/toolchain#GOTOOLCHAIN)
 export GOTOOLCHAIN := go$(GO_VERSION)
 # update this only by running `make update-golang-version`
 GO_K8S_VERSION_PREFIX ?= v1.37.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module k8s.io/minikube
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	cloud.google.com/go/storage v1.63.1
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.32.0

--- a/hack/update/get_version/get_version.go
+++ b/hack/update/get_version/get_version.go
@@ -52,7 +52,7 @@ var dependencies = map[string]dependency{
 	"flannel":                 {"pkg/minikube/cni/flannel.yaml", `flannel:(.*)`},
 	"gcp-auth":                {addonsFile, `k8s-minikube/gcp-auth-webhook:(.*)@`},
 	"gh":                      {"hack/jenkins/installers/check_install_gh.sh", `GH_VERSION="(.*)"`},
-	"golang":                  {"Makefile", `\nGO_VERSION \?= (.*)`},
+	"golang":                  {"go.mod", `\ntoolchain go(.*)`},
 	"go-github":               {"go.mod", `github\.com\/google\/go-github\/.* (.*)`},
 	"golint":                  {"Makefile", `GOLINT_VERSION \?= (.*)`},
 	"gopogh":                  {"hack/jenkins/installers/check_install_gopogh.sh", `github.com/medyagh/gopogh/cmd/gopogh@(.*)`},

--- a/hack/update/golang_version/golang_version.go
+++ b/hack/update/golang_version/golang_version.go
@@ -29,22 +29,19 @@ import (
 )
 
 var (
-	workflowReplace = update.Item{
-		Replace: map[string]string{
-			`GO_VERSION: .*`: `GO_VERSION: '{{.StableVersion}}'`,
-		},
-	}
-
 	schema = map[string]update.Item{
+		// go.mod is the single source of the Go version: the "go" directive is the
+		// minimum language version, the "toolchain" directive is the exact version
+		// used to build and test. Everything else reads it from here, either via
+		// setup-go's go-version-file or via the Makefile's GO_VERSION.
 		"go.mod": {
 			Replace: map[string]string{
-				`go 1\.\d+\.\d+`: `go {{.MajorMinor}}`, // Match and replace only the major.minor Go version
+				`go 1\.\d+\.\d+`:          `go {{.MajorMinor}}`, // Match and replace only the major.minor Go version
+				`toolchain go1\.\d+\.\d+`: `toolchain go{{.StableVersion}}`,
 			},
 		},
 		"Makefile": {
 			Replace: map[string]string{
-				// searching for 1.* so it does NOT match "KVM_GO_VERSION ?= $(GO_VERSION:.0=)" in the Makefile
-				`GO_VERSION \?= 1.*`:             `GO_VERSION ?= {{.StableVersion}}`,
 				`GO_K8S_VERSION_PREFIX \?= v1.*`: `GO_K8S_VERSION_PREFIX ?= {{.K8SVersion}}`,
 			},
 		},
@@ -84,8 +81,6 @@ type Data struct {
 }
 
 func main() {
-	addGitHubWorkflowFiles()
-
 	// get Golang stable version
 	stable, k8sVersion, err := goVersions()
 	if err != nil || stable == "" {
@@ -163,15 +158,4 @@ func updateGoHashFile(version string) error {
 		}
 	}
 	return nil
-}
-
-func addGitHubWorkflowFiles() {
-	files, err := os.ReadDir("../.github/workflows")
-	if err != nil {
-		klog.Fatalf("failed to read workflows dir: %v", err)
-	}
-	for _, f := range files {
-		filename := ".github/workflows/" + f.Name()
-		schema[filename] = workflowReplace
-	}
 }


### PR DESCRIPTION
Closes #23526

Reworked after review feedback from @Roslaan001, @nirs and @Labeeb2339 — this now implements the issue rather than documenting the existing behaviour. The earlier docs-only version has been dropped, including the `site/content/` page.

### The change

`go.mod` gains a `toolchain` directive, so it carries both versions the project needs:

| Directive | Value | Meaning |
| --- | --- | --- |
| `go` | `1.26.0` | minimum language version |
| `toolchain` | `go1.26.5` | exact toolchain used to build and test |

Since actions/setup-go v6, `go-version-file` honours the `toolchain` directive, so the workflows read the version straight from `go.mod` and no longer need a `GO_VERSION` env var. Thanks @Roslaan001 for pointing at the `check-latest`/`go-version-file` behaviour — adding the toolchain directive is what makes it resolve to 1.26.5 rather than the 1.26.0 floor I was worried about.

- Added `toolchain go1.26.5` to `go.mod`.
- `hack/update/golang_version` now rewrites the `toolchain` directive; `addGitHubWorkflowFiles()` and the `GO_VERSION: .*` workflow rewrite are gone.
- All 62 workflows: `GO_VERSION` env var removed, `go-version: ${{env.GO_VERSION}}` → `go-version-file: go.mod` (68 occurrences), matching the existing `smoke-test.yml`.
- `Makefile`: `GO_VERSION` is derived from the toolchain directive instead of being a second copy, so `GOTOOLCHAIN`, `BUILD_IMAGE` and the buildroot `GOLANG_OPTIONS` all trace back to `go.mod`.
- `hack/update/get_version`: `DEP=golang` reads `go.mod` instead of the `Makefile`.

A Go bump is now a one-line change to `go.mod` instead of a 62-file PR.

### Verification

- All 70 workflow files still parse as YAML; no `GO_VERSION` reference remains anywhere in `.github/`.
- `GO_VERSION`, `GOTOOLCHAIN`, `BUILD_IMAGE` and `GOLANG_OPTIONS` expand to exactly the same values as before (`1.26.5`, `go1.26.5`, `registry.k8s.io/build-image/kube-cross:v1.37.0-go1.26.5-bullseye.0`, `GOWORK=off GO_VERSION=1.26.5`).
- `DEP=golang make get-dependency-version` prints `1.26.5`.
- Simulated a bump to 1.27.3 against the updater's new `go.mod` rules: exactly two lines change, `go 1.27.0` and `toolchain go1.27.3`, in either map iteration order.

### Notes for reviewers

- The `Makefile` change is the one item not in the issue's checklist. I included it because leaving `GO_VERSION ?= 1.26.5` there would keep a second copy of the version, which is the thing @nirs asked to get rid of. Happy to split it out if you'd rather keep this PR to the listed tasks.
- `hack/go.mod` deliberately has no `toolchain` directive; the `update-*` jobs run under the root `GOTOOLCHAIN` and `make ... GOTOOLCHAIN=auto` still overrides it as before.
