### PR TITLE
Fix iso build on Fedora

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ KIC_VERSION ?= $(shell grep -E "Version =" pkg/drivers/kic/types.go | cut -d \" 
 HUGO_VERSION ?= $(shell grep -E "HUGO_VERSION = \"" netlify.toml | cut -d \" -f2)
 
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
-ISO_VERSION ?= v1.39.0
+ISO_VERSION ?= v1.39.0-1788569502-23546
 
 # Dashes are valid in semver, but not Linux packaging. Use ~ to delimit alpha/beta
 DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))

--- a/deploy/iso/minikube-iso/board/minikube/aarch64/post-image.sh
+++ b/deploy/iso/minikube-iso/board/minikube/aarch64/post-image.sh
@@ -28,12 +28,12 @@ mkdir -p root/EFI/BOOT
 cp efi-part/EFI/BOOT/* root/EFI/BOOT/
 cp efiboot.img root/EFI/BOOT/
 
-mkisofs \
+xorriso -as mkisofs \
    -o boot.iso \
    -R -J -v -d -N \
    -hide-rr-moved \
    -no-emul-boot \
-   -eltorito-platform=efi \
+   -eltorito-platform efi \
    -eltorito-boot EFI/BOOT/efiboot.img \
    -V "EFIBOOTISO" \
    -A "EFI Boot ISO" \

--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -60,7 +60,7 @@ source ./hack/jenkins/installers/check_install_linux_crons.sh
 
 # Make sure all required packages are installed
 sudo apt-get update
-sudo apt-get -y install build-essential unzip rsync bc python3 p7zip-full cmake
+sudo apt-get -y install build-essential unzip rsync bc python3 p7zip-full cmake xorriso
 
 # Log Cmake version
 CMAKE_VERSION=$(cmake --version | head -n1 | awk '{print $3}')

--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -41,7 +41,7 @@ const fileScheme = "file"
 // DefaultISOURLs returns a list of ISO URL's to consult by default, in priority order
 func DefaultISOURLs() []string {
 	v := version.GetISOVersion()
-	isoBucket := "minikube/iso"
+	isoBucket := "minikube-builds/iso/23546"
 
 	return []string{
 		fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s-%s.iso", isoBucket, v, runtime.GOARCH),

--- a/site/content/en/docs/contrib/building/iso.md
+++ b/site/content/en/docs/contrib/building/iso.md
@@ -57,7 +57,6 @@ sudo apt-get install \
     build-essential \
     cpio \
     gcc-multilib \
-    genisoimage \
     git \
     gnupg2 \
     libtool \
@@ -66,6 +65,7 @@ sudo apt-get install \
     python2 \
     unzip \
     wget \
+    xorriso
 ```
 
 Install Go using these instructions:


### PR DESCRIPTION
Pack the aarch64 ISO with xorriso -as mkisofs instead of mkisofs. On Fedora, mkisofs is xorriso in genisofs mode and rejects -eltorito-platform=efi. Keep the original mkisofs flags (-eltorito-platform efi) so the ISO layout stays compatible with vfkit. Install xorriso on ISO builders and in the contrib docs. There is no change in the x86_64 image  (using buildroot builtin iso9960).

Tested on macOS vith vfkit and krunkit.

```
% hyperfine -r 20 --conclude "minikube delete" "minikube start -d vfkit"
Benchmark 1: minikube start -d vfkit
  Time (mean ± σ):     15.471 s ±  0.592 s    [User: 0.556 s, System: 0.914 s]
  Range (min … max):   14.644 s … 16.885 s    20 runs
 
% hyperfine -r 20 --conclude "minikube delete" "minikube start -d krunkit"
Benchmark 1: minikube start -d krunkit
  Time (mean ± σ):     14.778 s ±  0.740 s    [User: 0.522 s, System: 0.657 s]
  Range (min … max):   13.367 s … 15.989 s    20 runs
```

Fixes #22056