### PR TITLE
 ci: migrate workflows to ubuntu-latest runner image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   build_minikube:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1
@@ -50,7 +50,7 @@ jobs:
           name: minikube_binaries
           path: out
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1
@@ -73,7 +73,7 @@ jobs:
         run: make test
         continue-on-error: false
   unit_test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/dependabot-gomodtidy.yml
+++ b/.github/workflows/dependabot-gomodtidy.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   dependabot-gomodtidy:
     if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == 'kubernetes/minikube'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   generate-docs:
     if: github.repository == 'kubernetes/minikube'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/hide-minikube-bot-comments.yml
+++ b/.github/workflows/hide-minikube-bot-comments.yml
@@ -6,7 +6,7 @@ permissions:
 jobs:
   hide-comments:
     if: ${{ github.event.issue.pull_request }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: spowelljr/hide-minikube-bot-comments@6ef419ab40a17cf0bdc1f98f2442bf19b72d911d
         timeout-minutes: 1

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   update-leaderboard:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ permissions:
   contents: read
 jobs:
     Lint:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
           timeout-minutes: 1
@@ -47,7 +47,7 @@ jobs:
           run: make test
           continue-on-error: false
     Boilerplate:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
           timeout-minutes: 1
@@ -63,7 +63,7 @@ jobs:
           run: make test
           continue-on-error: false
     Housekeeping:
-       runs-on: ubuntu-22.04
+       runs-on: ubuntu-latest
        steps:
         - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
           timeout-minutes: 1

--- a/.github/workflows/minikube-image-benchmark.yml
+++ b/.github/workflows/minikube-image-benchmark.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   image-benchmark:
     if: github.repository == 'kubernetes/minikube'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/time-to-k8s-public-chart.yml
+++ b/.github/workflows/time-to-k8s-public-chart.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   time-to-k8s-public-chart-docker:
     if: github.repository == 'kubernetes/minikube'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/time-to-k8s.yml
+++ b/.github/workflows/time-to-k8s.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   unit_test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/twitter-bot.yml
+++ b/.github/workflows/twitter-bot.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 jobs:
   twitter-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: ethomson/send-tweet-action@288f9339e0412e3038dce350e0da5ecdf12133a6
         timeout-minutes: 1

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,7 +45,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-22.04, macos-15, windows-2022]
+                os: [ubuntu-latest, macos-15, windows-2022]
         runs-on: ${{ matrix.os }}
         steps:
         - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/update-all.yml
+++ b/.github/workflows/update-all.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 jobs:
   update-all:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-amd-gpu-device-plugin-version.yml
+++ b/.github/workflows/update-amd-gpu-device-plugin-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-amd-gpu-device-plugin-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-buildkit-version.yml
+++ b/.github/workflows/update-buildkit-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-buildkit-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 2

--- a/.github/workflows/update-calico-version.yml
+++ b/.github/workflows/update-calico-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-calico-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-cilium-version.yml
+++ b/.github/workflows/update-cilium-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-cilium-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-cloud-spanner-emulator-version.yml
+++ b/.github/workflows/update-cloud-spanner-emulator-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-cloud-spanner-emulator-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-cni-plugins-version.yml
+++ b/.github/workflows/update-cni-plugins-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-cni-plugins-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-containerd-version.yml
+++ b/.github/workflows/update-containerd-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-containerd-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-cri-dockerd-version.yml
+++ b/.github/workflows/update-cri-dockerd-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-cri-dockerd-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-cri-o-version.yml
+++ b/.github/workflows/update-cri-o-version.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   bump-cri-o-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-crictl-version.yml
+++ b/.github/workflows/update-crictl-version.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   bump-crictl-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-crun-version.yml
+++ b/.github/workflows/update-crun-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-crun-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-debian-version.yml
+++ b/.github/workflows/update-debian-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-ubuntu-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-docker-buildx-version.yml
+++ b/.github/workflows/update-docker-buildx-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-docker-buildx-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-docker-version.yml
+++ b/.github/workflows/update-docker-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-docker-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-docsy-version.yml
+++ b/.github/workflows/update-docsy-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-docsy-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-flannel-version.yml
+++ b/.github/workflows/update-flannel-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-flannel-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-gcp-auth-version.yml
+++ b/.github/workflows/update-gcp-auth-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-gcp-auth-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-gh-version.yml
+++ b/.github/workflows/update-gh-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-gh-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-go-github-version.yml
+++ b/.github/workflows/update-go-github-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-go-github-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-golang-version.yml
+++ b/.github/workflows/update-golang-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-golang-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-golint-version.yml
+++ b/.github/workflows/update-golint-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-golint-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-gopogh-version.yml
+++ b/.github/workflows/update-gopogh-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-gopogh-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-gotestsum-version.yml
+++ b/.github/workflows/update-gotestsum-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-gotestsum-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-headlamp-version.yml
+++ b/.github/workflows/update-headlamp-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-headlamp-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-hugo-version.yml
+++ b/.github/workflows/update-hugo-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-hugo-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-ingress-version.yml
+++ b/.github/workflows/update-ingress-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-ingress-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-inspektor-gadget-version.yml
+++ b/.github/workflows/update-inspektor-gadget-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-inspektor-gadget-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-iso-image-versions.yml
+++ b/.github/workflows/update-iso-image-versions.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 jobs:
   update-all:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-istio-operator.yml
+++ b/.github/workflows/update-istio-operator.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-istio-operator-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-k8s-versions.yml
+++ b/.github/workflows/update-k8s-versions.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-k8s-versions:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-kindnetd-version.yml
+++ b/.github/workflows/update-kindnetd-version.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 jobs:
   bump-kindnetd-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-kong-ingress-controller-version.yml
+++ b/.github/workflows/update-kong-ingress-controller-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-kong-ingress-controller-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-kong-version.yml
+++ b/.github/workflows/update-kong-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-kong-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-kube-vip-version.yml
+++ b/.github/workflows/update-kube-vip-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-kube-vip-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-kubeadm-constants.yml
+++ b/.github/workflows/update-kubeadm-constants.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-k8s-versions:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-kubectl-version.yml
+++ b/.github/workflows/update-kubectl-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-kubectl-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-kubernetes-versions-list.yml
+++ b/.github/workflows/update-kubernetes-versions-list.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   update-kubernetes-versions-list:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-kubevirt-version.yml
+++ b/.github/workflows/update-kubevirt-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-kubevirt-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-metrics-server-version.yml
+++ b/.github/workflows/update-metrics-server-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-metrics-server-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-nerdctl-version.yml
+++ b/.github/workflows/update-nerdctl-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-nerdctl-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-nerdctld-version.yml
+++ b/.github/workflows/update-nerdctld-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-nerdctld-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-nvidia-device-plugin-version.yml
+++ b/.github/workflows/update-nvidia-device-plugin-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-nvidia-device-plugin-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-portainer-version.yml
+++ b/.github/workflows/update-portainer-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-portainer-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-registry-version.yml
+++ b/.github/workflows/update-registry-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-registry-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-runc-version.yml
+++ b/.github/workflows/update-runc-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-runc-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 3

--- a/.github/workflows/update-site-node-version.yml
+++ b/.github/workflows/update-site-node-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-site-node-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-volcano-version.yml
+++ b/.github/workflows/update-volcano-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-volcano-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/update-yakd-version.yml
+++ b/.github/workflows/update-yakd-version.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   bump-yakd-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         timeout-minutes: 1

--- a/.github/workflows/vex.yml
+++ b/.github/workflows/vex.yml
@@ -5,7 +5,7 @@ on:
       - 'v*.*.*'
 jobs:
   vexctl:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/yearly-leaderboard.yml
+++ b/.github/workflows/yearly-leaderboard.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   update-yearly-leaderboard:
     if: github.repository == 'kubernetes/minikube'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Description                                                                        
GitHub Actions is deprecating `ubuntu-22.04` runner images. This PR updates all workflows pinned to `ubuntu-22.04` to `ubuntu-latest`.                                  
                                                                                          
### Changes:                                                                          
- Migrated all 49 `.github/workflows/update-*.yml` workflows to `runs-on: ubuntu-latest`.                                                                                
- Migrated build, test, and utility workflows (`build.yml`, `lint.yml`, `unit-test.yml`, `docs.yml`, `dependabot-gomodtidy.yml`, `translations.yml`, `vex.yml`,`leaderboard.yml`, etc.) to `ubuntu-latest`.                                            
                                                                                          
Fixes #23525                                                                        
