### PR TITLE
start: add hidden experimental --node-os flag for mixed-OS clusters

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -208,6 +208,19 @@ func runStart(cmd *cobra.Command, _ []string) {
 		validateProfileName()
 	}
 
+	if cmd.Flags().Changed(nodeOS) {
+		if runtime.GOOS != "windows" {
+			exit.Message(reason.Usage, "--node-os currently requires a Windows host with Hyper-V")
+		}
+		if err := validateMixedOSFlag(viper.GetStringSlice(nodeOS)); err != nil {
+			exit.Message(reason.Usage, "{{.err}}", out.V{"err": err})
+		}
+		if viper.GetInt(nodes) != 2 {
+			exit.Message(reason.Usage, "The --nodes flag must be set to 2 when using --node-os")
+		}
+		applyMixedOSDefaults(cmd, existing)
+	}
+
 	validateSpecifiedDriver(existing, options)
 	if existing == nil {
 		// driver-selection warnings are only meaningful for fresh clusters;
@@ -1976,6 +1989,70 @@ func validateDockerStorageDriver(drvName string) {
 	}
 	out.WarningT("{{.Driver}} is currently using the {{.StorageDriver}} storage driver, setting preload=false", out.V{"StorageDriver": si.StorageDriver, "Driver": drvName})
 	viper.Set(preload, false)
+}
+
+// validateMixedOSFlag validates the supplied --node-os values for a mixed-OS
+// cluster. Only a single linux control-plane node plus a single windows
+// worker node is currently supported, so exactly two values must be given
+// and they must be "linux" then "windows" (case- and whitespace-insensitive).
+func validateMixedOSFlag(osValues []string) error {
+	if len(osValues) != 2 {
+		return errors.New("invalid --node-os value: must specify exactly 2 comma-separated OS values, e.g. linux,windows")
+	}
+
+	first := strings.ToLower(strings.TrimSpace(osValues[0]))
+	second := strings.ToLower(strings.TrimSpace(osValues[1]))
+
+	if first != "linux" || second != "windows" {
+		return errors.New("invalid --node-os value: must be linux,windows")
+	}
+
+	return nil
+}
+
+// applyMixedOSDefaults fills in the driver/cni/container-runtime a mixed-OS
+// cluster requires, but only for a brand-new profile: converting an existing
+// profile to mixed-OS isn't supported yet (its persisted runtime/CNI could
+// silently drift from what --node-os requires, since updateExistingConfigFromFlags
+// only touches fields for flags the user actually passed), so require a fresh
+// profile instead.
+func applyMixedOSDefaults(cmd *cobra.Command, existing *config.ClusterConfig) {
+	if existing != nil {
+		exit.Message(reason.Usage, "--node-os cannot be used with an existing profile; delete it first with 'minikube delete -p {{.profile}}' or start a new profile with --profile", out.V{"profile": ClusterFlagValue()})
+	}
+
+	required := []struct {
+		flagName, want, label string
+	}{
+		{"driver", driver.HyperV, "driver"},
+		{cniFlag, "flannel", "CNI"},
+		{containerRuntime, constants.Containerd, "container runtime"},
+	}
+
+	for _, r := range required {
+		changed := cmd.Flags().Changed(r.flagName)
+		got := viper.GetString(r.flagName)
+		if err := checkMixedOSFlagConflict(changed, got, r.want, r.flagName, r.label); err != nil {
+			exit.Message(reason.Usage, "{{.err}}", out.V{"err": err})
+		}
+		if !changed {
+			viper.Set(r.flagName, r.want)
+			out.Infof("--node-os: automatically selecting {{.want}} as the {{.label}}", out.V{"want": r.want, "label": r.label})
+		}
+	}
+}
+
+// checkMixedOSFlagConflict reports a usage error if the user explicitly passed
+// flagName with a value other than want. want is only ever applied as a
+// default (by the caller) when the flag was not explicitly changed - an
+// explicit, conflicting value must be rejected rather than silently
+// overridden, since viper.Set() takes precedence over an explicit flag and
+// would otherwise discard the user's choice without telling them.
+func checkMixedOSFlagConflict(changed bool, got, want, flagName, label string) error {
+	if changed && got != want {
+		return fmt.Errorf("--node-os requires the %s %s, but --%s=%s was specified", want, label, flagName, got)
+	}
+	return nil
 }
 
 // validateSubnet checks that the subnet provided has a private IP

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -149,6 +149,7 @@ const (
 	staticIP                = "static-ip"
 	gpus                    = "gpus"
 	autoPauseInterval       = "auto-pause-interval"
+	nodeOS                  = "node-os"
 	preloadSrc              = "preload-source"
 	rosetta                 = "rosetta"
 	vmnetOffloading         = "vmnet-offloading"
@@ -219,6 +220,14 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(staticIP, "", "Set a static IP for the minikube cluster, the IP must be: private, IPv4, and the last octet must be between 2 and 254, for example 192.168.200.200 (Docker and Podman drivers only)")
 	startCmd.Flags().StringP(gpus, "g", "", "Allow pods to use your GPUs. Options include: [all,nvidia,amd] (Docker driver with Docker container-runtime only)")
 	startCmd.Flags().Duration(autoPauseInterval, time.Minute*1, "Duration of inactivity before the minikube VM is paused (default 1m0s)")
+	startCmd.Flags().StringSlice(nodeOS, nil, "Experimental: the OS to use for each node in a mixed-OS cluster, e.g. linux,windows. Requires --nodes=2 and a Windows host with Hyper-V. Currently only a single linux control-plane node plus a single windows worker node is supported.")
+	// --node-os is scaffolding: it validates and forces driver/cni/runtime, but nothing
+	// yet routes the Windows worker through a Windows-specific node-creation path, so a
+	// mixed-OS cluster requested today still comes up as two Linux nodes. Keep it hidden
+	// until the follow-up PR wires up node topology.
+	if err := startCmd.Flags().MarkHidden(nodeOS); err != nil {
+		klog.Warningf("Failed to hide node-os flag: %v\n", err)
+	}
 	startCmd.Flags().String(preloadSrc, "auto", "Which source to download the preload from (valid options: gcs, github, auto). Defaults to auto (try github first, then gcs as failover).")
 }
 
@@ -757,6 +766,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 		MultiNodeRequested: viper.GetInt(nodes) > 1 || viper.GetBool(ha),
 		GPUs:               viper.GetString(gpus),
 		AutoPauseInterval:  viper.GetDuration(autoPauseInterval),
+		NodeOS:             viper.GetStringSlice(nodeOS),
 		Rosetta:            getRosetta(drvName),
 		VmnetOffloading:    getVmnetOffloading(drvName),
 		DNSServers:         getDNSServers(cmd, drvName),
@@ -991,6 +1001,7 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 	updateStringFromFlag(cmd, &cc.SocketVMnetClientPath, socketVMnetClientPath)
 	updateStringFromFlag(cmd, &cc.SocketVMnetPath, socketVMnetPath)
 	updateDurationFromFlag(cmd, &cc.AutoPauseInterval, autoPauseInterval)
+	updateStringSliceFromFlag(cmd, &cc.NodeOS, nodeOS)
 	updateBoolFromFlag(cmd, &cc.Rosetta, rosetta)
 	updateBoolFromFlag(cmd, &cc.VmnetOffloading, vmnetOffloading)
 

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -471,6 +471,109 @@ func TestValidateRuntime(t *testing.T) {
 	}
 }
 
+func TestValidateMixedOSFlag(t *testing.T) {
+	var tests = []struct {
+		description string
+		osValues    []string
+		errorMsg    string
+	}{
+		{
+			description: "valid",
+			osValues:    []string{"linux", "windows"},
+			errorMsg:    "",
+		},
+		{
+			description: "valid with whitespace",
+			osValues:    []string{" linux", "windows "},
+			errorMsg:    "",
+		},
+		{
+			description: "valid with mixed case",
+			osValues:    []string{"Linux", "WINDOWS"},
+			errorMsg:    "",
+		},
+		{
+			description: "wrong order",
+			osValues:    []string{"windows", "linux"},
+			errorMsg:    "invalid --node-os value: must be linux,windows",
+		},
+		{
+			description: "only one value",
+			osValues:    []string{"linux"},
+			errorMsg:    "invalid --node-os value: must specify exactly 2 comma-separated OS values, e.g. linux,windows",
+		},
+		{
+			description: "three values",
+			osValues:    []string{"linux", "windows", "mac"},
+			errorMsg:    "invalid --node-os value: must specify exactly 2 comma-separated OS values, e.g. linux,windows",
+		},
+		{
+			description: "no values",
+			osValues:    nil,
+			errorMsg:    "invalid --node-os value: must specify exactly 2 comma-separated OS values, e.g. linux,windows",
+		},
+		{
+			description: "old bracket syntax is rejected - StringSlice splits '[linux,windows]' on the comma, leaving stray brackets",
+			osValues:    []string{"[linux", "windows]"},
+			errorMsg:    "invalid --node-os value: must be linux,windows",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got := validateMixedOSFlag(test.osValues)
+			gotError := ""
+			if got != nil {
+				gotError = got.Error()
+			}
+			if gotError != test.errorMsg {
+				t.Errorf("validateMixedOSFlag(osValues=%v): got %v, expected %v", test.osValues, gotError, test.errorMsg)
+			}
+		})
+	}
+}
+
+func TestCheckMixedOSFlagConflict(t *testing.T) {
+	var tests = []struct {
+		description string
+		changed     bool
+		got         string
+		errorMsg    string
+	}{
+		{
+			description: "flag not passed, no conflict",
+			changed:     false,
+			got:         "docker",
+			errorMsg:    "",
+		},
+		{
+			description: "flag explicitly matches the required value",
+			changed:     true,
+			got:         "hyperv",
+			errorMsg:    "",
+		},
+		{
+			description: "flag explicitly conflicts with the required value",
+			changed:     true,
+			got:         "docker",
+			errorMsg:    "--node-os requires the hyperv driver, but --driver=docker was specified",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got := checkMixedOSFlagConflict(test.changed, test.got, "hyperv", "driver", "driver")
+			gotError := ""
+			if got != nil {
+				gotError = got.Error()
+			}
+			if gotError != test.errorMsg {
+				t.Errorf("checkMixedOSFlagConflict(changed=%v, got=%v): got %v, expected %v", test.changed, test.got, gotError, test.errorMsg)
+			}
+		})
+	}
+}
+
 func TestIsTwoDigitSemver(t *testing.T) {
 	var tcs = []struct {
 		desc     string

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -110,6 +110,7 @@ type ClusterConfig struct {
 	SSHAgentPID             int
 	GPUs                    string
 	AutoPauseInterval       time.Duration // Specifies interval of time to wait before checking if cluster should be paused
+	NodeOS                  []string      // Parsed --node-os flag values, e.g. ["linux", "windows"]. Set when a mixed-OS cluster was requested.
 	Rosetta                 bool          // Only used by vfkit driver
 	VmnetOffloading         bool          // Only used by krunkit driver
 	DNSServers              []netip.Addr  // Static DNS servers for the VM (VM drivers only)

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -175,6 +175,19 @@ const (
 
 	// Mirror CN
 	AliyunMirror = "registry.cn-hangzhou.aliyuncs.com/google_containers"
+
+	// DefaultWindowsNodeVersion is the default Windows Server version used for
+	// the Windows worker node in a mixed-OS cluster (--node-os). Windows
+	// Server 2025 is the only version supported for this feature's first
+	// experimental release.
+	DefaultWindowsNodeVersion = "2025"
+
+	// DefaultWindowsVhdURL is the VHD download URL for Windows Server 2025.
+	// The VHD itself is built by kubernetes-sigs/minikube-os#2
+	// (https://github.com/kubernetes-sigs/minikube-os/pull/2) and published to
+	// an Azure blob storage account owned by Microsoft. This is the URL
+	// currently used for the experimental release of this feature.
+	DefaultWindowsVhdURL = "https://minikubevhdimagebuider.blob.core.windows.net/versions/hybrid-minikube-windows-server.vhdx"
 )
 
 var (


### PR DESCRIPTION
Introduce an experimental `--node-os` flag that requests a mixed-OS cluster (currently a single Linux control-plane node plus a single Windows worker, e.g. `"[linux,windows]"`). Once the full feature lands, a mixed-OS cluster will be started like this:

```
minikube.exe start --kubernetes-version=v1.34.0 -n 2 --node-os='[linux,windows]'
```

This PR is the first step toward that: it adds the flag and its supporting validation/defaults, without yet wiring up the Windows-specific node creation the command above depends on.

The flag:

- validates the value format and requires `--nodes=2`
- auto-selects and enforces the _hyperv_ driver, flannel _CNI_, and _containerd_ runtime, rejecting conflicting explicit flags
- is rejected outright against an existing profile, since converting one isn't supported and its persisted runtime/CNI could otherwise drift from what --node-os requires
- is persisted on _ClusterConfig_ as _NodeOS_

The flag is marked _hidden_ because it is only scaffolding: nothing yet routes the Windows worker through a Windows-specific node-creation path, so a mixed-OS cluster requested today still comes up as two Linux nodes. It will be unhidden once the follow-up PR wires up node topology.

Also add `DefaultWindowsNodeVersion` (2025) and `DefaultWindowsVhdURL` constants for the upcoming Windows node work. The VHD is built by kubernetes-sigs/minikube-os#2 and published to an Azure blob storage account owned by Microsoft.

The full mixed-OS (Linux + Windows) node support in this PR is functionally complete and has been validated end-to-end, in this PR #22503,  both nodes reach Ready in testing. Given the size of the diff, we're breaking the work into a series of smaller, independently reviewable PRs rather than asking for review of this one in full. 