### PR TITLE
Change default container runtime to containerd

### DIFF
--- a/.github/workflows/functional_extra.yml
+++ b/.github/workflows/functional_extra.yml
@@ -120,7 +120,7 @@ jobs:
           \$env:Path += ';C:\Users\minikubeadmin\go\bin';
           \$OutputEncoding = [System.Text.Encoding]::UTF8;
           
-          ./e2e-windows-amd64.exe --minikube-start-args='--driver=hyperv' --binary=./minikube-windows-amd64.exe '-test.run' TestFunctional '-test.v' '-test.timeout=40m' | Tee-Object -FilePath testout.txt
+          ./e2e-windows-amd64.exe --minikube-start-args='--driver=hyperv --container-runtime=docker' --binary=./minikube-windows-amd64.exe '-test.run' TestFunctional '-test.v' '-test.timeout=40m' | Tee-Object -FilePath testout.txt
           \$env:result=\$lastexitcode
           
           Get-Content testout.txt | go tool test2json -t | Out-File -Encoding UTF8 testout.json

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -82,12 +82,14 @@ jobs:
           - name: docker-docker-ubuntu24.04-x86
             driver: docker
             cruntime: docker
+            extra-start-args: --container-runtime=docker
             os: ubuntu-24.04
             arch: amd64
             test-timeout: 18m
           - name: docker-docker-ubuntu24.04-arm
             driver: docker
             cruntime: docker
+            extra-start-args: --container-runtime=docker
             os: ubuntu-24.04-arm
             arch: arm64
             test-timeout: 18m 
@@ -113,21 +115,24 @@ jobs:
             rootless: true
             arch: amd64
             test-timeout: 18m 
-          - name: podman-docker-ubuntu-24.04-x86
+          - name: podman-crio-ubuntu-24.04-x86
             driver: podman
-            cruntime: docker
+            cruntime: crio
+            extra-start-args: --container-runtime=crio
             os: ubuntu-24.04
             arch: amd64
             test-timeout: 22m
           - name: baremetal-docker-ubuntu-24.04-x86
             driver: none
             cruntime: docker
+            extra-start-args: --container-runtime=docker
             os: ubuntu-24.04
             arch: amd64
             test-timeout: 10m
           - name: baremetal-docker-ubuntu-24.04-arm
             driver: none
             cruntime: docker
+            extra-start-args: --container-runtime=docker
             os: ubuntu-24.04-arm
             arch: arm64
             test-timeout: 10m

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -41,25 +41,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: qemu-docker-macos-15-x86
+          - name: qemu-containerd-macos-15-x86
             driver: qemu
             os: macos-15-intel
-            start_flags: --network socket_vmnet --force
+            start_flags: --network socket_vmnet --force --container-runtime=containerd
             sudo: "sudo"
-          - name: vfkit-docker-macos-15-x86
+          - name: vfkit-containerd-macos-15-x86
             driver: vfkit
             os: macos-15-intel
-            start_flags: --network vmnet-shared --force
+            start_flags: --network vmnet-shared --force --container-runtime=containerd
             sudo: "sudo"
-          - name: docker-docker-ubuntu-24.04-x86
+          - name: docker-containerd-ubuntu-24.04-x86
             driver: docker
             os: ubuntu-24.04
-            start_flags: ""
+            start_flags: --container-runtime=containerd
             sudo: ""
-          - name: docker-docker-ubuntu-24.04-arm
+          - name: docker-containerd-ubuntu-24.04-arm
             driver: docker
             os: ubuntu-24.04-arm
-            start_flags: ""
+            start_flags: --container-runtime=containerd
             sudo: ""
     steps:
       - id: info-block

--- a/cmd/minikube/cmd/config/validations_test.go
+++ b/cmd/minikube/cmd/config/validations_test.go
@@ -103,7 +103,8 @@ func TestValidCIDR(t *testing.T) {
 func TestValidRuntime(t *testing.T) {
 	var tests = []validationTest{
 		{
-			value:     "", // default
+			// "" is accepted: cruntime.New maps it to docker for pre-2022 profiles.
+			value:     "",
 			shouldErr: false,
 		},
 		{

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -310,13 +310,13 @@ docker-cli install instructions: https://minikube.sigs.k8s.io/docs/tutorials/doc
 		if len(co.Config.Nodes) > 1 {
 			exit.Message(reason.EnvMultiConflict, `The docker-env command is incompatible with multi-node clusters. Use the 'registry' add-on: https://minikube.sigs.k8s.io/docs/handbook/registry/`)
 		}
-		cr := co.Config.KubernetesConfig.ContainerRuntime
-		if err := dockerEnvSupported(cr, driverName); err != nil {
+		crName := co.Config.KubernetesConfig.ContainerRuntime
+		if err := dockerEnvSupported(crName, driverName); err != nil {
 			exit.Message(reason.Usage, err.Error())
 		}
 
 		// for the sake of docker-env command, start nerdctl and nerdctld
-		if cr == constants.Containerd {
+		if crName == constants.Containerd {
 			out.WarningT("Using the docker-env command with the containerd runtime is a highly experimental feature, please provide feedback or contribute to make it better")
 
 			startNerdctld(options)
@@ -342,7 +342,7 @@ docker-cli install instructions: https://minikube.sigs.k8s.io/docs/tutorials/doc
 
 		r := co.CP.Runner
 
-		if cr == constants.Docker {
+		if crName == constants.Docker {
 			ensureDockerd(cname, r)
 		}
 
@@ -416,7 +416,7 @@ docker-cli install instructions: https://minikube.sigs.k8s.io/docs/tutorials/doc
 			cmd.Stderr = os.Stderr
 
 			// TODO: refactor to work with docker, temp fix to resolve regression
-			if cr == constants.Containerd {
+			if crName == constants.Containerd {
 				cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_AUTH_SOCK=%s", co.Config.SSHAuthSock))
 				cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_AGENT_PID=%d", co.Config.SSHAgentPID))
 			}
@@ -426,7 +426,7 @@ docker-cli install instructions: https://minikube.sigs.k8s.io/docs/tutorials/doc
 			}
 
 			// TODO: refactor to work with docker, temp fix to resolve regression
-			if cr == constants.Containerd {
+			if crName == constants.Containerd {
 				// eventually, run something similar to ssh --append-known
 				appendKnownHelper(nodeName, true)
 			}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -352,10 +352,6 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 	}
 
 	crName := getContainerRuntime(existing)
-	if crName == constants.Docker && (existing == nil || viper.IsSet(containerRuntime)) {
-		// TODO: remove this warning in minikube v1.40
-		out.WarningT(constants.DefaultContainerRuntimeChangeWarning)
-	}
 	cc, n, err := generateClusterConfig(cmd, existing, k8sVersion, crName, driverName, options)
 	if err != nil {
 		return node.Starter{}, fmt.Errorf("Failed to generate cluster config: %w", err)
@@ -1555,7 +1551,7 @@ func getContainerRuntime(old *config.ClusterConfig) string {
 // defaultRuntime returns the default container runtime.
 // Keep in sync with test/integration.ContainerRuntime.
 func defaultRuntime() string {
-	return constants.Docker
+	return constants.Containerd
 }
 
 // if container runtime is not docker, check that cni is not disabled

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1552,9 +1552,9 @@ func getContainerRuntime(old *config.ClusterConfig) string {
 	return userValue
 }
 
-// defaultRuntime returns the default container runtime
+// defaultRuntime returns the default container runtime.
+// Keep in sync with test/integration.ContainerRuntime.
 func defaultRuntime() string {
-	// minikube default
 	return constants.Docker
 }
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -351,12 +351,12 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 		stopk8s = true
 	}
 
-	rtime := getContainerRuntime(existing)
-	if rtime == constants.Docker && (existing == nil || viper.IsSet(containerRuntime)) {
+	crName := getContainerRuntime(existing)
+	if crName == constants.Docker && (existing == nil || viper.IsSet(containerRuntime)) {
 		// TODO: remove this warning in minikube v1.40
 		out.WarningT(constants.DefaultContainerRuntimeChangeWarning)
 	}
-	cc, n, err := generateClusterConfig(cmd, existing, k8sVersion, rtime, driverName, options)
+	cc, n, err := generateClusterConfig(cmd, existing, k8sVersion, crName, driverName, options)
 	if err != nil {
 		return node.Starter{}, fmt.Errorf("Failed to generate cluster config: %w", err)
 	}
@@ -590,14 +590,14 @@ func displayEnviron(env []string) {
 	}
 }
 
-func showKubectlInfo(kcs *kubeconfig.Settings, k8sVersion, rtime, machineName string) error {
+func showKubectlInfo(kcs *kubeconfig.Settings, k8sVersion, crName, machineName string) error {
 	if k8sVersion == constants.NoKubernetesVersion {
 		register.Reg.SetStep(register.Done)
 		out.Step(style.Ready, "Done! minikube is ready without Kubernetes!")
 
 		// Runtime message.
 		boxConfig := box.NewBox().Padding(4, 1).Style(box.Round).Color(box.Green)
-		switch rtime {
+		switch crName {
 		case constants.Docker:
 			out.BoxedWithConfig(boxConfig, style.Tip, "Things to try without Kubernetes ...", `- "minikube ssh" to SSH into minikube's node.
 - "minikube docker-env" to point your docker-cli to the docker inside minikube.
@@ -1470,40 +1470,40 @@ func validateDiskSize(diskSize string) error {
 }
 
 // validateRuntime validates the supplied runtime
-func validateRuntime(rtime string) error {
+func validateRuntime(crName string) error {
 	validOptions := cruntime.ValidRuntimes()
 	// `crio` is accepted as an alternative spelling to `cri-o`
 	validOptions = append(validOptions, constants.CRIO)
 
-	if rtime == constants.DefaultContainerRuntime {
+	if crName == constants.DefaultContainerRuntime {
 		return nil
 	}
 
 	var validRuntime bool
 	for _, option := range validOptions {
-		if rtime == option {
+		if crName == option {
 			validRuntime = true
 		}
 
 		// Convert `cri-o` to `crio` as the K8s config uses the `crio` spelling
-		if rtime == "cri-o" {
+		if crName == "cri-o" {
 			viper.Set(containerRuntime, constants.CRIO)
 		}
 
 	}
 
-	if (rtime == "crio" || rtime == "cri-o") && strings.HasPrefix(runtime.GOARCH, "ppc64") {
-		return fmt.Errorf("The %s runtime is not compatible with the %s architecture. See https://github.com/cri-o/cri-o/issues/2467 for more details", rtime, runtime.GOARCH)
+	if (crName == "crio" || crName == "cri-o") && strings.HasPrefix(runtime.GOARCH, "ppc64") {
+		return fmt.Errorf("The %s runtime is not compatible with the %s architecture. See https://github.com/cri-o/cri-o/issues/2467 for more details", crName, runtime.GOARCH)
 	}
 
 	if !validRuntime {
-		return fmt.Errorf("Invalid Container Runtime: %s. Valid runtimes are: %s", rtime, cruntime.ValidRuntimes())
+		return fmt.Errorf("Invalid Container Runtime: %s. Valid runtimes are: %s", crName, cruntime.ValidRuntimes())
 	}
 	return nil
 }
 
 // validateGPUs validates that a valid option was given, and if so, can it be used with the given configuration
-func validateGPUs(value, drvName, rtime string) error {
+func validateGPUs(value, drvName, crName string) error {
 	if value == "" {
 		return nil
 	}
@@ -1513,7 +1513,7 @@ func validateGPUs(value, drvName, rtime string) error {
 	if value != "nvidia" && value != "all" && value != "amd" && value != "nvidia.com" {
 		return errors.New(`The gpus flag must be passed a value of "nvidia", "nvidia.com", "amd" or "all"`)
 	}
-	if drvName == constants.Docker && (rtime == constants.Docker || rtime == constants.DefaultContainerRuntime) {
+	if drvName == constants.Docker && (crName == constants.Docker || crName == constants.DefaultContainerRuntime) {
 		return nil
 	}
 	return errors.New("The gpus flag can only be used with the docker driver and docker container-runtime")
@@ -1556,15 +1556,15 @@ func defaultRuntime() string {
 }
 
 // if container runtime is not docker, check that cni is not disabled
-func validateCNI(cmd *cobra.Command, runtimeName string) {
-	if runtimeName == constants.Docker {
+func validateCNI(cmd *cobra.Command, crName string) {
+	if crName == constants.Docker {
 		return
 	}
 	if cmd.Flags().Changed(cniFlag) && strings.ToLower(viper.GetString(cniFlag)) == "false" {
 		if viper.GetBool(force) {
-			out.WarnReason(reason.Usage, "You have chosen to disable the CNI but the \"{{.name}}\" container runtime requires CNI", out.V{"name": runtimeName})
+			out.WarnReason(reason.Usage, "You have chosen to disable the CNI but the \"{{.name}}\" container runtime requires CNI", out.V{"name": crName})
 		} else {
-			exit.Message(reason.Usage, "The \"{{.name}}\" container runtime requires CNI", out.V{"name": runtimeName})
+			exit.Message(reason.Usage, "The \"{{.name}}\" container runtime requires CNI", out.V{"name": crName})
 		}
 	}
 }
@@ -1731,14 +1731,14 @@ func configureNodes(cc config.ClusterConfig, existing *config.ClusterConfig) (co
 	if err != nil {
 		return cc, config.Node{}, fmt.Errorf("failed getting kubernetes version: %w", err)
 	}
-	cr := getContainerRuntime(&cc)
+	crName := getContainerRuntime(&cc)
 
 	// create the initial node, which will necessarily be primary control-plane node
 	if existing == nil {
 		pcp := config.Node{
 			Port:              cc.APIServerPort,
 			KubernetesVersion: kv,
-			ContainerRuntime:  cr,
+			ContainerRuntime:  crName,
 			ControlPlane:      true,
 			Worker:            true,
 		}
@@ -1751,7 +1751,7 @@ func configureNodes(cc config.ClusterConfig, existing *config.ClusterConfig) (co
 	nodes := []config.Node{}
 	for _, n := range existing.Nodes {
 		n.KubernetesVersion = kv
-		n.ContainerRuntime = cr
+		n.ContainerRuntime = crName
 		nodes = append(nodes, n)
 	}
 	cc.Nodes = nodes
@@ -1761,7 +1761,7 @@ func configureNodes(cc config.ClusterConfig, existing *config.ClusterConfig) (co
 		return cc, config.Node{}, fmt.Errorf("failed getting control-plane node: %w", err)
 	}
 	pcp.KubernetesVersion = kv
-	pcp.ContainerRuntime = cr
+	pcp.ContainerRuntime = crName
 
 	return cc, pcp, nil
 }
@@ -2036,9 +2036,9 @@ func validateBareMetal(drvName string) {
 	}
 
 	// default container runtime varies, starting with Kubernetes 1.24 - assume that only the default container runtime has been tested
-	rtime := viper.GetString(containerRuntime)
-	if rtime != constants.DefaultContainerRuntime && rtime != defaultRuntime() {
-		out.WarningT("Using the '{{.runtime}}' runtime with the 'none' driver is an untested configuration!", out.V{"runtime": rtime})
+	crName := viper.GetString(containerRuntime)
+	if crName != constants.DefaultContainerRuntime && crName != defaultRuntime() {
+		out.WarningT("Using the '{{.runtime}}' runtime with the 'none' driver is an untested configuration!", out.V{"runtime": crName})
 	}
 
 	// conntrack is required starting with Kubernetes 1.18, include the release candidates for completion

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -321,7 +321,7 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 
 	virtualBoxMacOS13PlusWarning(driverName)
 	hyperkitDeprecationWarning(driverName)
-	validateFlags(cmd, driverName)
+	validateFlags(cmd, driverName, existing)
 	validateUser(driverName)
 	if driverName == oci.Docker {
 		validateDockerStorageDriver(driverName)
@@ -1296,7 +1296,7 @@ func validateCPUCount(drvName string) {
 }
 
 // validateFlags validates the supplied flags against known bad combinations
-func validateFlags(cmd *cobra.Command, drvName string) { //nolint:gocyclo
+func validateFlags(cmd *cobra.Command, drvName string, existing *config.ClusterConfig) { //nolint:gocyclo
 	if cmd.Flags().Changed(humanReadableDiskSize) {
 		err := validateDiskSize(viper.GetString(humanReadableDiskSize))
 		if err != nil {
@@ -1358,7 +1358,7 @@ func validateFlags(cmd *cobra.Command, drvName string) { //nolint:gocyclo
 	}
 
 	if cmd.Flags().Changed(gpus) {
-		if err := validateGPUs(viper.GetString(gpus), drvName, viper.GetString(containerRuntime)); err != nil {
+		if err := validateGPUs(viper.GetString(gpus), drvName, getContainerRuntime(existing)); err != nil {
 			exit.Message(reason.Usage, "{{.err}}", out.V{"err": err})
 		}
 	}
@@ -1513,7 +1513,7 @@ func validateGPUs(value, drvName, crName string) error {
 	if value != "nvidia" && value != "all" && value != "amd" && value != "nvidia.com" {
 		return errors.New(`The gpus flag must be passed a value of "nvidia", "nvidia.com", "amd" or "all"`)
 	}
-	if drvName == constants.Docker && (crName == constants.Docker || crName == constants.DefaultContainerRuntime) {
+	if drvName == constants.Docker && crName == constants.Docker {
 		return nil
 	}
 	return errors.New("The gpus flag can only be used with the docker driver and docker container-runtime")

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1343,11 +1343,10 @@ func validateFlags(cmd *cobra.Command, drvName string, existing *config.ClusterC
 		}
 	}
 
-	if cmd.Flags().Changed(containerRuntime) {
-		err := validateRuntime(viper.GetString(containerRuntime))
-		if err != nil {
-			exit.Message(reason.Usage, "{{.err}}", out.V{"err": err})
-		}
+	// Always validate: viper includes config and MINIKUBE_CONTAINER_RUNTIME,
+	// not only --container-runtime. Empty is the auto sentinel and is valid.
+	if err := validateRuntime(viper.GetString(containerRuntime)); err != nil {
+		exit.Message(reason.Usage, "{{.err}}", out.V{"err": err})
 	}
 
 	validateCNI(cmd, getContainerRuntime(existing))

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1348,8 +1348,9 @@ func validateFlags(cmd *cobra.Command, drvName string, existing *config.ClusterC
 		if err != nil {
 			exit.Message(reason.Usage, "{{.err}}", out.V{"err": err})
 		}
-		validateCNI(cmd, viper.GetString(containerRuntime))
 	}
+
+	validateCNI(cmd, getContainerRuntime(existing))
 
 	if cmd.Flags().Changed(staticIP) {
 		if err := validateStaticIP(viper.GetString(staticIP), drvName, viper.GetString(subnet)); err != nil {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1535,18 +1535,21 @@ func validateAutoPauseInterval(interval time.Duration) error {
 }
 
 func getContainerRuntime(old *config.ClusterConfig) string {
-	paramRuntime := viper.GetString(containerRuntime)
-
-	// try to load the old version first if the user didn't specify anything
-	if paramRuntime == constants.DefaultContainerRuntime && old != nil {
-		paramRuntime = old.KubernetesConfig.ContainerRuntime
+	userValue := viper.GetString(containerRuntime)
+	if userValue == constants.DefaultContainerRuntime {
+		// Use value from old cluster config.
+		if old != nil {
+			if old.KubernetesConfig.ContainerRuntime == "" {
+				// Pre-2022 profiles stored "" to mean docker (the then-default).
+				// Do not map that to defaultRuntime() or those clusters would
+				// switch to containerd.
+				return constants.Docker
+			}
+			return old.KubernetesConfig.ContainerRuntime
+		}
+		return defaultRuntime()
 	}
-
-	if paramRuntime == constants.DefaultContainerRuntime {
-		paramRuntime = defaultRuntime()
-	}
-
-	return paramRuntime
+	return userValue
 }
 
 // defaultRuntime returns the default container runtime

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1408,7 +1408,7 @@ func validateFlags(cmd *cobra.Command, drvName string, existing *config.ClusterC
 		exit.Message(reason.Usage, "Sorry, please set the --output flag to one of the following valid options: [text,json]")
 	}
 
-	validateBareMetal(drvName)
+	validateBareMetal(drvName, getContainerRuntime(existing))
 	validateRegistryMirror()
 	validateInsecureRegistry()
 }
@@ -2022,7 +2022,7 @@ func validateStaticIP(staticIP, drvName, subnet string) error {
 	return nil
 }
 
-func validateBareMetal(drvName string) {
+func validateBareMetal(drvName, crName string) {
 	if !driver.BareMetal(drvName) {
 		return
 	}
@@ -2035,9 +2035,7 @@ func validateBareMetal(drvName string) {
 		exit.Message(reason.DrvUnsupportedProfile, "The '{{.name}} driver does not support multiple profiles: https://minikube.sigs.k8s.io/docs/reference/drivers/none/", out.V{"name": drvName})
 	}
 
-	// default container runtime varies, starting with Kubernetes 1.24 - assume that only the default container runtime has been tested
-	crName := viper.GetString(containerRuntime)
-	if crName != constants.DefaultContainerRuntime && crName != defaultRuntime() {
+	if crName != constants.Docker {
 		out.WarningT("Using the '{{.runtime}}' runtime with the 'none' driver is an untested configuration!", out.V{"runtime": crName})
 	}
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -970,7 +970,6 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 	updateStringSliceFromFlag(cmd, &cc.KubernetesConfig.APIServerNames, "apiserver-names")
 	updateStringFromFlag(cmd, &cc.KubernetesConfig.DNSDomain, dnsDomain)
 	updateStringFromFlag(cmd, &cc.KubernetesConfig.FeatureGates, featureGates)
-	updateStringFromFlag(cmd, &cc.KubernetesConfig.ContainerRuntime, containerRuntime)
 	updateStringFromFlag(cmd, &cc.KubernetesConfig.CRISocket, criSocket)
 	updateStringFromFlag(cmd, &cc.KubernetesConfig.NetworkPlugin, networkPlugin)
 	updateStringFromFlag(cmd, &cc.KubernetesConfig.ServiceCIDR, serviceCIDR)

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -333,7 +333,7 @@ func ClusterFlagValue() string {
 }
 
 // generateClusterConfig generate a config.ClusterConfig based on flags or existing cluster config
-func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k8sVersion string, rtime string, drvName string, options *run.CommandOptions) (config.ClusterConfig, config.Node, error) {
+func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k8sVersion string, crName string, drvName string, options *run.CommandOptions) (config.ClusterConfig, config.Node, error) {
 	var cc config.ClusterConfig
 	if existing != nil {
 		cc = updateExistingConfigFromFlags(cmd, existing)
@@ -344,7 +344,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 		}
 	} else {
 		klog.Info("no existing cluster config was found, will generate one from the flags ")
-		cc = generateNewConfigFromFlags(cmd, k8sVersion, rtime, drvName, options)
+		cc = generateNewConfigFromFlags(cmd, k8sVersion, crName, drvName, options)
 
 		cnm, err := cni.New(&cc)
 		if err != nil {
@@ -654,7 +654,7 @@ func getMDNS(cmd *cobra.Command, driverName string) bool {
 }
 
 // generateNewConfigFromFlags generate a config.ClusterConfig based on flags
-func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime string, drvName string, options *run.CommandOptions) config.ClusterConfig {
+func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, crName string, drvName string, options *run.CommandOptions) config.ClusterConfig {
 	var cc config.ClusterConfig
 
 	// networkPlugin cni deprecation warning
@@ -745,7 +745,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 			APIServerIPs:           apiServerIPs,
 			DNSDomain:              viper.GetString(dnsDomain),
 			FeatureGates:           viper.GetString(featureGates),
-			ContainerRuntime:       rtime,
+			ContainerRuntime:       crName,
 			CRISocket:              viper.GetString(criSocket),
 			NetworkPlugin:          chosenNetworkPlugin,
 			ServiceCIDR:            viper.GetString(serviceCIDR),

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -893,7 +893,7 @@ func upgradeExistingConfig(cmd *cobra.Command, cc *config.ClusterConfig) {
 // updateExistingConfigFromFlags will update the existing config from the flags - used on a second start
 // skipping updating existing docker env, docker opt, InsecureRegistry, registryMirror, extra-config, apiserver-ips
 func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterConfig) config.ClusterConfig { //nolint to suppress cyclomatic complexity 45 of func `updateExistingConfigFromFlags` is high (> 30)
-	validateFlags(cmd, existing.Driver)
+	validateFlags(cmd, existing.Driver, existing)
 
 	cc := *existing
 

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -440,35 +440,34 @@ func TestValidateDiskSize(t *testing.T) {
 }
 
 func TestValidateRuntime(t *testing.T) {
-	var tests = []struct {
-		runtime  string
-		errorMsg string
+	valid := []struct {
+		name  string
+		value string
 	}{
-		{
-			runtime:  "cri-o",
-			errorMsg: "",
-		},
-		{
-			runtime:  "docker",
-			errorMsg: "",
-		},
-		{
-			runtime:  "test",
-			errorMsg: fmt.Sprintf("Invalid Container Runtime: test. Valid runtimes are: %v", cruntime.ValidRuntimes()),
-		},
+		{"default", constants.DefaultContainerRuntime},
+		{"docker", constants.Docker},
+		{"containerd", constants.Containerd},
+		{"crio", constants.CRIO},
+		{"cri-o", "cri-o"},
 	}
-	for _, test := range tests {
-		t.Run(test.runtime, func(t *testing.T) {
-			got := validateRuntime(test.runtime)
-			gotError := ""
-			if got != nil {
-				gotError = got.Error()
-			}
-			if gotError != test.errorMsg {
-				t.Errorf("ValidateRuntime(runtime=%v): got %v, expected %v", test.runtime, got, test.errorMsg)
+	for _, tc := range valid {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateRuntime(tc.value); err != nil {
+				t.Errorf("validateRuntime(%q) = %v, want nil", tc.value, err)
 			}
 		})
 	}
+
+	t.Run("invalid", func(t *testing.T) {
+		err := validateRuntime("invalid")
+		if err == nil {
+			t.Fatal("validateRuntime(\"invalid\") = nil, want error")
+		}
+		want := fmt.Sprintf("Invalid Container Runtime: invalid. Valid runtimes are: %v", cruntime.ValidRuntimes())
+		if err.Error() != want {
+			t.Errorf("validateRuntime(\"invalid\") = %q, want %q", err, want)
+		}
+	})
 }
 
 func TestIsTwoDigitSemver(t *testing.T) {

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -807,13 +807,13 @@ func TestValidateGPUs(t *testing.T) {
 		{"", "kvm", "containerd", ""},
 		{"all", "docker", "docker", ""},
 		{"nvidia", "docker", "docker", ""},
-		{"all", "docker", "", ""},
-		{"nvidia", "docker", "", ""},
+		{"all", "docker", "", "The gpus flag can only be used with the docker driver and docker container-runtime"},
+		{"nvidia", "docker", "", "The gpus flag can only be used with the docker driver and docker container-runtime"},
+		{"amd", "docker", "", "The gpus flag can only be used with the docker driver and docker container-runtime"},
 		{"all", "kvm", "docker", "The gpus flag can only be used with the docker driver and docker container-runtime"},
 		{"nvidia", "docker", "containerd", "The gpus flag can only be used with the docker driver and docker container-runtime"},
 		{"cat", "docker", "docker", `The gpus flag must be passed a value of "nvidia", "nvidia.com", "amd" or "all"`},
 		{"amd", "docker", "docker", ""},
-		{"amd", "docker", "", ""},
 		{"amd", "docker", "containerd", "The gpus flag can only be used with the docker driver and docker container-runtime"},
 	}
 

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -125,7 +125,7 @@ func TestMirrorCountry(t *testing.T) {
 	viper.SetDefault(humanReadableDiskSize, defaultDiskSize)
 	checkRepository = checkRepoMock
 	k8sVersion := constants.DefaultKubernetesVersion
-	crName := constants.DefaultContainerRuntime
+	crName := defaultRuntime()
 	var tests = []struct {
 		description     string
 		k8sVersion      string
@@ -186,7 +186,7 @@ func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
 	viper.SetDefault(humanReadableDiskSize, defaultDiskSize)
 
 	k8sVersion := constants.NewestKubernetesVersion
-	crName := constants.DefaultContainerRuntime
+	crName := defaultRuntime()
 	var tests = []struct {
 		description  string
 		proxy        string

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -853,3 +853,61 @@ func TestValidateAutoPause(t *testing.T) {
 		}
 	}
 }
+
+func TestGetContainerRuntime(t *testing.T) {
+	orig := viper.GetString(containerRuntime)
+	t.Cleanup(func() { viper.Set(containerRuntime, orig) })
+
+	tests := []struct {
+		description string
+		flag        string
+		old         *cfg.ClusterConfig
+		want        string
+	}{
+		{
+			description: "new cluster uses product default",
+			want:        defaultRuntime(),
+		},
+		{
+			description: "flag docker",
+			flag:        constants.Docker,
+			want:        constants.Docker,
+		},
+		{
+			description: "flag containerd",
+			flag:        constants.Containerd,
+			want:        constants.Containerd,
+		},
+		{
+			description: "existing docker profile",
+			old:         &cfg.ClusterConfig{KubernetesConfig: cfg.KubernetesConfig{ContainerRuntime: constants.Docker}},
+			want:        constants.Docker,
+		},
+		{
+			description: "existing containerd profile",
+			old:         &cfg.ClusterConfig{KubernetesConfig: cfg.KubernetesConfig{ContainerRuntime: constants.Containerd}},
+			want:        constants.Containerd,
+		},
+		{
+			description: "legacy empty profile is docker",
+			old:         &cfg.ClusterConfig{KubernetesConfig: cfg.KubernetesConfig{ContainerRuntime: ""}},
+			want:        constants.Docker,
+		},
+		{
+			description: "flag overrides existing profile",
+			flag:        constants.CRIO,
+			old:         &cfg.ClusterConfig{KubernetesConfig: cfg.KubernetesConfig{ContainerRuntime: constants.Docker}},
+			want:        constants.CRIO,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			viper.Set(containerRuntime, test.flag)
+			got := getContainerRuntime(test.old)
+			if got != test.want {
+				t.Errorf("getContainerRuntime() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -125,7 +125,7 @@ func TestMirrorCountry(t *testing.T) {
 	viper.SetDefault(humanReadableDiskSize, defaultDiskSize)
 	checkRepository = checkRepoMock
 	k8sVersion := constants.DefaultKubernetesVersion
-	rtime := constants.DefaultContainerRuntime
+	crName := constants.DefaultContainerRuntime
 	var tests = []struct {
 		description     string
 		k8sVersion      string
@@ -171,7 +171,7 @@ func TestMirrorCountry(t *testing.T) {
 			viper.SetDefault(imageRepository, test.imageRepository)
 			viper.SetDefault(imageMirrorCountry, test.mirrorCountry)
 			viper.SetDefault(kvmNUMACount, 1)
-			config, _, err := generateClusterConfig(cmd, nil, k8sVersion, rtime, driver.Mock, &run.CommandOptions{})
+			config, _, err := generateClusterConfig(cmd, nil, k8sVersion, crName, driver.Mock, &run.CommandOptions{})
 			if err != nil {
 				t.Fatalf("Got unexpected error %v during config generation", err)
 			}
@@ -186,7 +186,7 @@ func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
 	viper.SetDefault(humanReadableDiskSize, defaultDiskSize)
 
 	k8sVersion := constants.NewestKubernetesVersion
-	rtime := constants.DefaultContainerRuntime
+	crName := constants.DefaultContainerRuntime
 	var tests = []struct {
 		description  string
 		proxy        string
@@ -232,7 +232,7 @@ func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
 
 			cfg.DockerEnv = []string{} // clear docker env to avoid pollution
 			proxy.SetDockerEnv()
-			config, _, err := generateClusterConfig(cmd, nil, k8sVersion, rtime, "none", &run.CommandOptions{})
+			config, _, err := generateClusterConfig(cmd, nil, k8sVersion, crName, "none", &run.CommandOptions{})
 			if err != nil {
 				t.Fatalf("Got unexpected error %v during config generation", err)
 			}

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -67,8 +67,6 @@ const (
 	Docker = "docker"
 	// DefaultContainerRuntime is our default container runtime
 	DefaultContainerRuntime = ""
-	// DefaultContainerRuntimeChangeWarning is shown when the default runtime will change.
-	DefaultContainerRuntimeChangeWarning = `Starting v1.39.0, minikube will default to "containerd" container runtime. See #21973 for more info.`
 
 	// cgroup drivers
 	DefaultCgroupDriver  = "systemd"

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -213,6 +213,10 @@ func New(c Config) (Manager, error) {
 	sm := sysinit.New(c.Runner)
 
 	switch c.Type {
+	// "" is docker: until c4800a611 (2022, "Make the default container runtime
+	// dynamic") start persisted the raw --container-runtime flag, whose default
+	// is "". Those profiles are docker. Later starts store a real name, so ""
+	// is not the current product default and must not become containerd.
 	case "", "docker":
 		sp := c.Socket
 		cs := ""

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -38,7 +38,7 @@ func TestName(t *testing.T) {
 		runtime string
 		want    string
 	}{
-		{"", "Docker"},
+		{"", "Docker"}, // pre-2022 stored empty; not the product default
 		{"docker", "Docker"},
 		{"crio", "CRI-O"},
 		{"cri-o", "CRI-O"},

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -237,6 +237,8 @@ func setContainerRuntimeOptions(name string, p miniProvisioner) error {
 	case "containerd":
 		return nil
 	default:
+		// docker, including "" (pre-2022 stored empty flag, same as
+		// cruntime.New). Unknown names also get docker options.
 		_, err := p.GenerateDockerOptions(engine.DefaultPort)
 		return err
 	}

--- a/site/content/en/docs/handbook/config.md
+++ b/site/content/en/docs/handbook/config.md
@@ -89,11 +89,11 @@ minikube start --extra-config=kubeadm.ignore-preflight-errors=SystemVerification
 
 ## Runtime configuration
 
-The default container runtime in minikube is [Docker]({{<ref "/docs/runtimes/docker">}}).
+The default container runtime in minikube is [containerd]({{<ref "/docs/runtimes/containerd">}}).
 
 Depending on specific factors like the driver you choose, there may be recommendations of a preferred container runtime, see [drivers page]({{<ref "/docs/drivers">}}) for details.
 
-You can select container runtime explicitly by using:
+You can select a container runtime explicitly, for example Docker:
 
 ```shell
 minikube start --container-runtime=docker

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -26,12 +26,12 @@ Glossary:
 
 ## Comparison table for different methods
 
-The best method to push your image to minikube depends on the container-runtime you built your cluster with (the default is docker).
+The best method to push your image to minikube depends on the container-runtime you built your cluster with (the default is containerd).
 Here is a comparison table to help you choose:
 
 | Method | Supported Runtimes | Performance | Load | Build |
 |--- |--- |--- |--- |--- |--- |--- |
-|  [docker-env command](/docs/handbook/pushing/#1-pushing-directly-to-the-in-cluster-docker-daemon-docker-env) |   docker & containerd |  good  | yes | yes |
+|  [docker-env command](/docs/handbook/pushing/#1-pushing-directly-to-the-in-cluster-docker-daemon-docker-env) |   docker; containerd (experimental) |  good  | yes | yes |
 |  [cache command](/docs/handbook/pushing/#2-push-images-using-cache-command) |  all  |  ok  | yes | no |
 |  [podman-env command](/docs/handbook/pushing/#3-pushing-directly-to-in-cluster-cri-o-podman-env) |   only cri-o |  good  | yes | yes |
 |  [registry addon](/docs/handbook/pushing/#4-pushing-to-an-in-cluster-using-registry-addon)   |   all |  ok  | yes | no |
@@ -40,7 +40,7 @@ Here is a comparison table to help you choose:
 |  [image load command](/docs/handbook/pushing/#7-loading-directly-to-in-cluster-container-runtime)  |  all  |  ok  | yes | no |
 |  [image build command](/docs/handbook/pushing/#8-building-images-to-in-cluster-container-runtime)  |  all  |  ok  | no | yes |
 
-* Note 1: The default container-runtime on minikube is `docker`.
+* Note 1: The default container-runtime on minikube is `containerd`. Method 1 (docker-env) against the in-cluster Docker daemon requires `--container-runtime=docker`.
 * Note 2: The `none` driver (bare metal) does not need pushing image to the cluster, as any image on your system is already available to the Kubernetes cluster.
 * Note 3: When using ssh to run the commands, the files to load or build must already be available on the node (not only on the client host).
 
@@ -49,6 +49,7 @@ Here is a comparison table to help you choose:
 ## 1. Pushing directly to the in-cluster Docker daemon (docker-env)
 
 This is similar to podman-env but only for Docker runtime.
+Start the cluster with `--container-runtime=docker`; the default runtime is containerd.
 When using a container or VM driver (all drivers except none), you can reuse the Docker daemon inside minikube cluster.
 This means you don't have to build on your host machine and push the image into a docker registry. You can just build inside the same docker daemon as minikube which speeds up local experiments.
 

--- a/test/integration/error_spam_test.go
+++ b/test/integration/error_spam_test.go
@@ -27,8 +27,6 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-
-	"k8s.io/minikube/pkg/minikube/constants"
 )
 
 // stderrAllow are regular expressions acceptable to find in normal stderr
@@ -54,8 +52,6 @@ var stderrAllow = []string{
 	// Warning of issues with specific Kubernetes versions
 	`Kubernetes .* has a known `,
 	`For more information, see`,
-	// warning about upcoming default container runtime change
-	regexp.QuoteMeta(constants.DefaultContainerRuntimeChangeWarning),
 	// registry connectivity warning from inside the container
 	`Failing to connect to https://registry.k8s.io/`,
 	`you may need to configure a proxy`,

--- a/test/integration/kic_custom_network_test.go
+++ b/test/integration/kic_custom_network_test.go
@@ -53,6 +53,7 @@ func TestKicCustomNetwork(t *testing.T) {
 			defer Cleanup(t, profile, cancel)
 
 			startArgs := []string{"start", "-p", profile, fmt.Sprintf("--network=%s", test.networkName)}
+			startArgs = append(startArgs, StartArgs()...)
 			c := exec.CommandContext(ctx, Target(), startArgs...)
 			rr, err := Run(t, c)
 			if err != nil {
@@ -89,6 +90,7 @@ func TestKicExistingNetwork(t *testing.T) {
 	verifyNetworkExists(ctx, t, networkName)
 
 	startArgs := []string{"start", "-p", profile, fmt.Sprintf("--network=%s", networkName)}
+	startArgs = append(startArgs, StartArgs()...)
 	c := exec.CommandContext(ctx, Target(), startArgs...)
 	rr, err := Run(t, c)
 	if err != nil {
@@ -108,6 +110,7 @@ func TestKicCustomSubnet(t *testing.T) {
 
 	subnet := "192.168.60.0/24"
 	startArgs := []string{"start", "-p", profile, fmt.Sprintf("--subnet=%s", subnet)}
+	startArgs = append(startArgs, StartArgs()...)
 	c := exec.CommandContext(ctx, Target(), startArgs...)
 	rr, err := Run(t, c)
 	if err != nil {
@@ -128,6 +131,7 @@ func TestKicStaticIP(t *testing.T) {
 
 	staticIP := "192.168.200.200"
 	startArgs := []string{"start", "-p", profile, fmt.Sprintf("--static-ip=%s", staticIP)}
+	startArgs = append(startArgs, StartArgs()...)
 	c := exec.CommandContext(ctx, Target(), startArgs...)
 	rr, err := Run(t, c)
 	if err != nil {

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -198,7 +198,7 @@ func ContainerRuntime() string {
 			return strings.TrimPrefix(s, flag)
 		}
 	}
-	return constants.Docker
+	return constants.Containerd
 }
 
 // arm64Platform returns true if running on arm64/* platform

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -189,7 +189,8 @@ func VFKitDriver() bool {
 	return matchDriverFlag("vfkit")
 }
 
-// ContainerRuntime returns the name of a specific container runtime if it was specified
+// ContainerRuntime returns the name of a specific container runtime if it was specified.
+// When the flag is omitted, this copies cmd.defaultRuntime; keep them in sync.
 func ContainerRuntime() string {
 	flag := "--container-runtime="
 	for _, s := range StartArgs() {


### PR DESCRIPTION
This prepares start and related code so the default container runtime
can change without treating an unset flag as docker, then switches the
default to containerd.

- Rename the runtime string to `crName` so every place that chooses or
  checks the runtime is easy to find, and so future work does not mix
  that string up with a `cruntime.Manager` or a command runner.
- Pass the resolved runtime from `getContainerRuntime` into flag
  checks (`--gpus`, none-driver warning, CNI) instead of the raw viper
  value. Empty from `viper.Get` is the auto sentinel (`""`), not docker.
- Always run `validateCNI`, not only when `--container-runtime` is on
  the command line, so runtime from config or `MINIKUBE_CONTAINER_RUNTIME`
  is checked too.
- Always run `validateRuntime` for the same sources. An invalid name
  from config or env is rejected, and `cri-o` is normalized to `crio`.
  Empty is the auto sentinel and is valid.
- Document that a stored `""` in `cruntime.New` and provision options is
  docker: that is the pre-2022 profile format, not the current product
  default. Do not map it to containerd.
- Treat a stored empty `ContainerRuntime` in `getContainerRuntime` as
  docker (pre-2022 profiles), not as unset. Unset from the user still
  means the product default. Rewrite the function around those three
  sources so a later default change cannot migrate those clusters.
- On restart, stop copying raw `viper.GetString(containerRuntime)` into
  the cluster config. `updateExistingConfigFromFlags` already overwrote
  that field with `getContainerRuntime`; the first write was wrong.
- Point `defaultRuntime` and the integration `ContainerRuntime` helper
  at each other, and have generateClusterConfig tests pass
  `defaultRuntime()` instead of `""`.
- Default new clusters to containerd. Remove the v1.39 change warning
  and the error-spam allowlist entry for it.
- Update the handbook so the documented default is containerd, and
  `--container-runtime=docker` is the opt-in. Method 1 (`docker-env`)
  against the in-cluster Docker daemon requires that flag. Keep
  `--container-runtime=containerd` on the rootless docker example.
- Pass `--container-runtime` on every GitHub functional job (docker
  jobs were named `*-docker-*` but used the product default). Run the
  podman job as `podman-crio-*` with `--container-runtime=crio`. Keep
  the Hyper-V extra job on docker. Smoke has one start per
  driver/platform, so those jobs now pass
  `--container-runtime=containerd` and are renamed `*-containerd-*`.
  The flag stays explicit so the job name and start args stay in sync.
- Append `StartArgs()` in the kic custom-network tests so CI's
  `--container-runtime` reaches `minikube start`.

Existing profiles keep the runtime stored in the cluster config.

**Docker is unchanged as a runtime.** Users who want docker can still
use it; they must pass `--container-runtime=docker` (or set it in
config/env). Only the implicit default for new clusters changes.

Prow already passed `--driver` and `--container-runtime` on every
integration job.


## Example run - default runtime (containerd)

```console
% minikube start -d vfkit
😄  minikube v1.38.1 on Darwin 26.6.2 (arm64)
✨  Using the vfkit driver based on user configuration
🌐  Automatically selected the vmnet-shared network
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🔥  Creating vfkit VM (CPUs=2, Memory=6144MB, Disk=20000MB) ...
📦  Preparing Kubernetes v1.37.0 on containerd 2.3.4 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```

## Example run - docker runtime

```console
% minikube start -d vfkit --container-runtime docker
😄  minikube v1.38.1 on Darwin 26.6.2 (arm64)
✨  Using the vfkit driver based on user configuration
🌐  Automatically selected the vmnet-shared network
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🔥  Creating vfkit VM (CPUs=2, Memory=6144MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.37.0 on Docker 28.5.2 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```

---
Fixes #22601