### PR TITLE
Fix storage provisioner image platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ AUTOPAUSE_HOOK_TAG ?= v0.0.5
 
 # storage provisioner tag to push changes to
 # NOTE: you will need to bump the PreloadVersion if you change this
-STORAGE_PROVISIONER_TAG ?= v5
+STORAGE_PROVISIONER_TAG ?= v5.0.1
 
 STORAGE_PROVISIONER_MANIFEST ?= $(REGISTRY)/storage-provisioner:$(STORAGE_PROVISIONER_TAG)
 STORAGE_PROVISIONER_IMAGE ?= $(REGISTRY)/storage-provisioner-$(GOARCH):$(STORAGE_PROVISIONER_TAG)
@@ -670,7 +670,7 @@ storage-provisioner-image: storage-provisioner-image-$(GOARCH) ## Build storage-
 	docker tag $(REGISTRY)/storage-provisioner-$(GOARCH):$(STORAGE_PROVISIONER_TAG) $(REGISTRY)/storage-provisioner:$(STORAGE_PROVISIONER_TAG)
 
 storage-provisioner-image-%: out/storage-provisioner-%
-	docker build -t $(REGISTRY)/storage-provisioner-$*:$(STORAGE_PROVISIONER_TAG) -f deploy/storage-provisioner/Dockerfile  --build-arg arch=$* .
+	docker build --platform linux/$* -t $(REGISTRY)/storage-provisioner-$*:$(STORAGE_PROVISIONER_TAG) -f deploy/storage-provisioner/Dockerfile --build-arg arch=$* .
 
 
 .PHONY: docker-multi-arch-build


### PR DESCRIPTION
## What this PR does

Builds each storage provisioner image with an explicit target platform so its
OCI metadata matches the architecture of the embedded binary.

It also changes the storage provisioner tag from `v5` to `v5.0.1`, allowing the
corrected image to be published without replacing the existing `v5` image.

This is the first step of the fix. Updating the preloads to consume the
corrected image will be handled separately.

## Verification

Built the supported images locally and verified that their OCI metadata matches
their compiled binaries:

```text
storage-provisioner-amd64:v5.0.1: linux/amd64
storage-provisioner-arm64:v5.0.1: linux/arm64
```

The binaries were verified as x86-64 and AArch64 executables, respectively. An
AMD64 runtime smoke test also confirmed that the storage provisioner starts
successfully.

Part of #23560