### PR TITLE
hack/update: update kong image tag to 3

### DIFF
--- a/hack/update/kong_version/kong_version.go
+++ b/hack/update/kong_version/kong_version.go
@@ -22,9 +22,10 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/minikube/hack/update"
-
+	"golang.org/x/mod/semver"
 	"k8s.io/klog/v2"
+
+	"k8s.io/minikube/hack/update"
 )
 
 var schema = map[string]update.Item{
@@ -48,7 +49,7 @@ func main() {
 	if err != nil {
 		klog.Fatalf("Unable to get stable version: %v", err)
 	}
-	version := strings.TrimPrefix(stable.Tag, "v")
+	version := strings.TrimPrefix(semver.Major(stable.Tag), "v")
 	sha, err := update.GetImageSHA(fmt.Sprintf("docker.io/kong:%s", version))
 	if err != nil {
 		klog.Fatalf("failed to get image SHA: %v", err)

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -301,7 +301,7 @@ var Addons = map[string]*Addon{
 			"kong-ingress-controller.yaml",
 			"0640"),
 	}, false, "kong", "3rd party (Kong HQ)", "@gAmUssA", "https://minikube.sigs.k8s.io/docs/handbook/addons/kong-ingress/", map[string]string{
-		"Kong":        "kong:3.9.3@sha256:4d6a4ead594e9bf468d07a54d30a57991904b220403af1a43c5a3679615d11de",
+		"Kong":        "kong:3@sha256:2a8cf3b110cdaba1cb00adc665b8635ed1fc75c907f7a4298613c68e4976de0a",
 		"KongIngress": "kong/kubernetes-ingress-controller:3.5.13@sha256:979f12864a13031545d58623d17af7a071b417396fbb3928a169d897b056b68f",
 	}, map[string]string{
 		"Kong":        "docker.io",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
Updates the Kong addon image tag from patch version (`3.9.3`) to major version (`3`) and updates `kong_version.go` to use `semver.Major(stable.Tag)`.

Moving to major floating tag 3 avoids unexpected digest updates on immutable patch tags and ensures the updater cleanly tracks the latest Kong 3 release digest.

**Which issue(s) this PR fixes:**
Fixes #23584

**Special notes for your reviewer:**
- `kong:3` is expected to move on Docker Hub.
- Pinned to the latest digest for `kong:3`.