### PR TITLE
hack/update: track registry addon on the major tag

### DIFF
--- a/hack/update/registry_version/registry_version.go
+++ b/hack/update/registry_version/registry_version.go
@@ -17,7 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"k8s.io/minikube/hack/update"
 
@@ -39,14 +42,14 @@ type Data struct {
 }
 
 func main() {
-	tags, err := update.ImageTagsFromDockerHub("library/registry")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	stable, _, _, err := update.GHReleases(ctx, "distribution", "distribution")
 	if err != nil {
-		klog.Fatal(err)
+		klog.Fatalf("Unable to get stable version: %v", err)
 	}
-	tag, err := latestStableSemverTag(tags)
-	if err != nil {
-		klog.Fatal(err)
-	}
+	tag := strings.TrimPrefix(semver.Major(stable.Tag), "v")
 	sha, err := update.GetImageSHA(fmt.Sprintf("docker.io/registry:%s", tag))
 	if err != nil {
 		klog.Fatalf("failed to get image SHA: %v", err)
@@ -57,14 +60,4 @@ func main() {
 	if err := update.Apply(schema, data); err != nil {
 		klog.Fatalf("unable to apply update: %v", err)
 	}
-}
-
-func latestStableSemverTag(tags []string) (string, error) {
-	for _, tag := range tags {
-		vTag := fmt.Sprintf("v%s", tag)
-		if semver.IsValid(vTag) && semver.Prerelease(vTag) == "" {
-			return tag, nil
-		}
-	}
-	return "", fmt.Errorf("no stable semver tag found")
 }

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -381,7 +381,7 @@ var Addons = map[string]*Addon{
 			"0640"),
 	}, false, "registry", "minikube", "", "", map[string]string{
 		"KubeRegistryProxy": "minikube/kube-registry-proxy:v0.0.11@sha256:e321acf067df0a78fba3ff97748c10029ca2c413c5b7207e4ca000c62fcdac93",
-		"Registry":          "registry:3.1.1@sha256:85347ed2ecde64161c7a4788a4d7d3dcc9d6f86f7be95834022e3c6a423a945a",
+		"Registry":          "registry:3@sha256:1be55279f18a2fe1a74edf2664cac61c1bea305b7b4642dab412e7affdcb3e33",
 	}, map[string]string{
 		"KubeRegistryProxy": "registry.k8s.io",
 		"Registry":          "docker.io",


### PR DESCRIPTION
`make update-registry-version` keeps filing PRs that look like 3.1.1 → 3.1.1 because that patch tag got moved to a new digest.

same idea as the kong addon: pin `registry:3` (the moving major tag) and the current digest.

Fixes #23583