### PR TITLE
hack/update: ignore GitHub pre-releases for cri-dockerd

### DIFF
--- a/hack/update/cri_dockerd_version/cri_dockerd_version.go
+++ b/hack/update/cri_dockerd_version/cri_dockerd_version.go
@@ -78,13 +78,15 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	stable, _, _, err := update.GHReleases(ctx, "Mirantis", "cri-dockerd")
+	rel, err := update.GHLatestRelease(ctx, "Mirantis", "cri-dockerd")
 	if err != nil {
-		klog.Fatalf("Unable to get stable version: %v", err)
+		klog.Fatalf("Unable to get latest cri-dockerd release: %v", err)
 	}
-
-	version := strings.TrimPrefix(stable.Tag, "v")
-	data := Data{Version: version, FullCommit: stable.Commit}
+	version := strings.TrimPrefix(rel.Tag, "v")
+	data := Data{
+		Version:    version,
+		FullCommit: rel.Commit,
+	}
 
 	if err := update.Apply(schema, data); err != nil {
 		klog.Fatalf("unable to apply update: %v", err)

--- a/hack/update/github.go
+++ b/hack/update/github.go
@@ -101,6 +101,22 @@ func GHReleases(ctx context.Context, owner, repo string) (stable, latest, edge R
 	return stable, latest, edge, nil
 }
 
+// GHLatestRelease returns the latest published GitHub release (not a prerelease
+// or draft) and the commit SHA for its tag.
+func GHLatestRelease(ctx context.Context, owner, repo string) (Release, error) {
+	ghc := GHClient()
+	release, _, err := ghc.Repositories.GetLatestRelease(ctx, owner, repo)
+	if err != nil {
+		return Release{}, err
+	}
+	tag := release.GetTagName()
+	commit, _, err := ghc.Repositories.GetCommit(ctx, owner, repo, tag, nil)
+	if err != nil {
+		return Release{}, fmt.Errorf("unable to resolve commit for %s: %w", tag, err)
+	}
+	return Release{Tag: tag, Commit: commit.GetSHA()}, nil
+}
+
 func StableVersion(ctx context.Context, owner, repo string) (string, error) {
 	stable, _, _, err := GHReleases(ctx, owner, repo)
 	if err != nil || !semver.IsValid(stable.Tag) {


### PR DESCRIPTION
the cri-dockerd updater walks git tags, so GitHub pre-releases like v0.4.6 look "stable" (no -rc suffix) and we try to bump to them.

use the releases API and skip prerelease/draft when picking the version.

Fixes #23581