### PR TITLE
addons: pin kong/registry to floating major tag instead of patch tag

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -301,7 +301,7 @@ var Addons = map[string]*Addon{
 			"kong-ingress-controller.yaml",
 			"0640"),
 	}, false, "kong", "3rd party (Kong HQ)", "@gAmUssA", "https://minikube.sigs.k8s.io/docs/handbook/addons/kong-ingress/", map[string]string{
-		"Kong":        "kong:3.9.3@sha256:4d6a4ead594e9bf468d07a54d30a57991904b220403af1a43c5a3679615d11de",
+		"Kong":        "kong:3@sha256:2a8cf3b110cdaba1cb00adc665b8635ed1fc75c907f7a4298613c68e4976de0a",
 		"KongIngress": "kong/kubernetes-ingress-controller:3.5.13@sha256:979f12864a13031545d58623d17af7a071b417396fbb3928a169d897b056b68f",
 	}, map[string]string{
 		"Kong":        "docker.io",
@@ -381,7 +381,7 @@ var Addons = map[string]*Addon{
 			"0640"),
 	}, false, "registry", "minikube", "", "", map[string]string{
 		"KubeRegistryProxy": "minikube/kube-registry-proxy:v0.0.11@sha256:e321acf067df0a78fba3ff97748c10029ca2c413c5b7207e4ca000c62fcdac93",
-		"Registry":          "registry:3.1.1@sha256:85347ed2ecde64161c7a4788a4d7d3dcc9d6f86f7be95834022e3c6a423a945a",
+		"Registry":          "registry:3@sha256:1be55279f18a2fe1a74edf2664cac61c1bea305b7b4642dab412e7affdcb3e33",
 	}, map[string]string{
 		"KubeRegistryProxy": "registry.k8s.io",
 		"Registry":          "docker.io",


### PR DESCRIPTION
## Problem

Both the \`kong\` and \`registry\` addons pin to a specific patch tag (\`kong:3.9.3\`, \`registry:3.1.1\`) with a fixed digest. The upstream image maintainers re-push these patch tags to a new digest over time, which \`make update-kong-version\` / \`make update-registry-version\` then detects as a same-tag digest mismatch — flagged as a potential supply-chain issue, per #23584 and #23583.

## Fix

Changed both to the floating major tag (\`kong:3\`, \`registry:3\`), which is expected to move, with the current real digest for that tag as of this PR (queried directly against the Docker Hub registry API, matching what \`make update-kong-version\`/\`make update-registry-version\` would produce).

## Testing

- \`go vet ./pkg/minikube/assets/...\` — clean
- \`go test ./pkg/minikube/assets/...\` — passing

Fixes #23584
Fixes #23583