### PR TITLE
kic: do not apply --ports to additional nodes

### DIFF
--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -73,8 +73,11 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 
 	extraArgs := []string{}
 
-	for _, port := range cc.ExposedPorts {
-		extraArgs = append(extraArgs, "-p", port)
+	// --ports is cluster-wide config but can only bind once on the host.
+	if len(cc.Nodes) == 0 || n.Name == cc.Nodes[0].Name {
+		for _, port := range cc.ExposedPorts {
+			extraArgs = append(extraArgs, "-p", port)
+		}
 	}
 
 	return kic.NewDriver(kic.Config{

--- a/pkg/minikube/registry/drvs/docker/docker_test.go
+++ b/pkg/minikube/registry/drvs/docker/docker_test.go
@@ -22,7 +22,9 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+	"k8s.io/minikube/pkg/drivers/kic"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/registry"
 	"k8s.io/minikube/pkg/minikube/run"
@@ -194,4 +196,47 @@ func TestStatus(t *testing.T) {
 			t.Errorf("status(%q) = %+v; expected shouldReturnError = %t", tt.input, state, tt.shouldReturnError)
 		}
 	}
+}
+
+func TestConfigureExposedPortsOnlyOnPrimaryNode(t *testing.T) {
+	primary := config.Node{Name: "m01"}
+	extra := config.Node{Name: "m02"}
+	cc := config.ClusterConfig{
+		Name:         "p",
+		ExposedPorts: []string{"80:80"},
+		Nodes:        []config.Node{primary, extra},
+	}
+
+	got, err := configure(cc, primary)
+	if err != nil {
+		t.Fatalf("configure primary: %v", err)
+	}
+	d, ok := got.(*kic.Driver)
+	if !ok {
+		t.Fatalf("configure primary returned %T", got)
+	}
+	if !containsPair(d.NodeConfig.ExtraArgs, "-p", "80:80") {
+		t.Errorf("primary ExtraArgs = %v, want -p 80:80", d.NodeConfig.ExtraArgs)
+	}
+
+	got, err = configure(cc, extra)
+	if err != nil {
+		t.Fatalf("configure extra: %v", err)
+	}
+	d, ok = got.(*kic.Driver)
+	if !ok {
+		t.Fatalf("configure extra returned %T", got)
+	}
+	if containsPair(d.NodeConfig.ExtraArgs, "-p", "80:80") {
+		t.Errorf("additional node ExtraArgs = %v, did not want -p 80:80", d.NodeConfig.ExtraArgs)
+	}
+}
+
+func containsPair(args []string, flag, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -80,8 +80,11 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 
 	extraArgs := []string{}
 
-	for _, port := range cc.ExposedPorts {
-		extraArgs = append(extraArgs, "-p", port)
+	// --ports is cluster-wide config but can only bind once on the host.
+	if len(cc.Nodes) == 0 || n.Name == cc.Nodes[0].Name {
+		for _, port := range cc.ExposedPorts {
+			extraArgs = append(extraArgs, "-p", port)
+		}
 	}
 
 	return kic.NewDriver(kic.Config{


### PR DESCRIPTION
`minikube start --ports 80:80` stores the mapping on the cluster config, and `node add` reused it for the new container. docker then fails with "port is already allocated".

only publish those host ports on the first node.

Fixes #16766