### PR TITLE
Kicbase: Add Helm 4 to kicbase image

### DIFF
--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -248,6 +248,15 @@ RUN export ARCH=$(dpkg --print-architecture) && \
     sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list && \
     clean-install nvidia-container-toolkit; fi
 
+# install helm
+ARG HELM_VERSION="v4.2.3"
+RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/') && \
+    mkdir /tmp/helm && \
+    curl -fsSL --retry 5 -o /tmp/helm.tgz "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" && \
+    tar --strip-components=1 -xzf /tmp/helm.tgz -C /tmp/helm && \
+    install -D -m 0755 /tmp/helm/helm /usr/bin/helm && \
+    rm -rf /tmp/helm /tmp/helm.tgz
+    
 # install version.json
 ARG VERSION_JSON
 RUN echo "${VERSION_JSON}" > /version.json

--- a/hack/kicbase_version/os-package-list.txt
+++ b/hack/kicbase_version/os-package-list.txt
@@ -16,10 +16,10 @@ ii  ca-certificates                 20250419~deb12u1               all          
 ii  catatonit                       0.1.7-1+b2                     amd64        init process for containers
 ii  conmon                          2.1.6+ds1-1                    amd64        OCI container runtime monitor
 ii  conntrack                       1:1.4.7-1+b2                   amd64        Program to modify the conntrack tables
-ii  containerd.io                   2.3.3-1~debian.12~bookworm     amd64        An open and reliable container runtime
+ii  containerd.io                   2.3.4-2~debian.12~bookworm     amd64        An open and reliable container runtime
 ii  containernetworking-plugins     1.1.1+ds1-3+b5                 amd64        standard networking plugins - binaries
 ii  coreutils                       9.1-1                          amd64        GNU core utilities
-ii  cri-o                           1.35.7-1.1                     amd64        Open Container Initiative-based implementation of Kubernetes Container Runtime Interface
+ii  cri-o                           1.35.8-1.1                     amd64        Open Container Initiative-based implementation of Kubernetes Container Runtime Interface
 ii  crun                            1.8.1-1+deb12u1                amd64        lightweight OCI runtime for running containers
 ii  curl                            7.88.1-10+deb12u15             amd64        command line tool for transferring data with URL syntax
 ii  dash                            0.5.12-2                       amd64        POSIX-compliant shell
@@ -35,9 +35,9 @@ ii  diffutils                       1:3.8-4                        amd64        
 ii  dirmngr                         2.2.40-1.1+deb12u2             amd64        GNU privacy guard - network certificate management service
 ii  dmsetup                         2:1.02.185-2                   amd64        Linux Kernel Device Mapper userspace library
 ii  dnsutils                        1:9.18.49-1~deb12u2            all          Transitional package for bind9-dnsutils
-ii  docker-buildx-plugin            0.36.1-1~debian.12~bookworm    amd64        Docker Buildx plugin extends build capabilities with BuildKit.
-ii  docker-ce                       5:29.7.2-1~debian.12~bookworm  amd64        Docker: the open-source application container engine
-ii  docker-ce-cli                   5:29.7.2-1~debian.12~bookworm  amd64        Docker CLI: the open-source application container engine
+ii  docker-buildx-plugin            0.37.0-1~debian.12~bookworm    amd64        Docker Buildx plugin extends build capabilities with BuildKit.
+ii  docker-ce                       5:29.8.0-1~debian.12~bookworm  amd64        Docker: the open-source application container engine
+ii  docker-ce-cli                   5:29.8.0-1~debian.12~bookworm  amd64        Docker CLI: the open-source application container engine
 ii  dpkg                            1.21.23                        amd64        Debian package management system
 ii  e2fsprogs                       1.47.0-2+b2                    amd64        ext2/ext3/ext4 file system utilities
 ii  ebtables                        2.0.11-5                       amd64        Ethernet bridge frame table administration
@@ -95,7 +95,7 @@ ii  libdevmapper1.02.1:amd64        2:1.02.185-2                   amd64        
 ii  libedit2:amd64                  3.1-20221030-2                 amd64        BSD editline and history libraries
 ii  libelf1:amd64                   0.188-2.1                      amd64        library to read and write ELF files
 ii  libevent-core-2.1-7:amd64       2.1.12-stable-8                amd64        Asynchronous event notification library (core)
-ii  libexpat1:amd64                 2.5.0-1+deb12u2                amd64        XML parsing C library - runtime library
+ii  libexpat1:amd64                 2.5.0-1+deb12u3                amd64        XML parsing C library - runtime library
 ii  libext2fs2:amd64                1.47.0-2+b2                    amd64        ext2/ext3/ext4 file system libraries
 ii  libfdisk1:amd64                 2.38.1-5+deb12u3               amd64        fdisk partitioning library
 ii  libffi8:amd64                   3.4.4-1                        amd64        Foreign Function Interface library runtime
@@ -168,7 +168,7 @@ ii  libsepol2:amd64                 3.4-2.1                        amd64        
 ii  libsmartcols1:amd64             2.38.1-5+deb12u3               amd64        smart column output alignment library
 ii  libsqlite3-0:amd64              3.40.1-2+deb12u2               amd64        SQLite 3 shared library
 ii  libss2:amd64                    1.47.0-2+b2                    amd64        command-line interface parsing library
-ii  libssh2-1:amd64                 1.10.0-3+b1                    amd64        SSH2 client-side library
+ii  libssh2-1:amd64                 1.10.0-3+deb12u1               amd64        SSH2 client-side library
 ii  libssl3:amd64                   3.0.20-1~deb12u2               amd64        Secure Sockets Layer toolkit - shared libraries
 ii  libstdc++6:amd64                12.2.0-14+deb12u1              amd64        GNU Standard C++ Library v3
 ii  libsubid4:amd64                 1:4.13+dfsg1-1+deb12u2         amd64        subordinate id handling library -- shared library

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,14 +24,14 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.51"
+	Version = "v0.0.51-1788719696-23591"
 
 	// SHA of the kic base image
-	baseImageSHA = "4a1c825b61479e6c898851ea66f13c620aaeab6002746e95067fc2c4b38a0b24"
+	baseImageSHA = "01bc448296750a93c677a9c36ca23a79c5cabff89880ea1bba05a64f4a22e12e"
 	// The name of the GCR kicbase repository
-	gcrRepo = "gcr.io/k8s-minikube/kicbase"
+	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository
-	dockerhubRepo = "docker.io/kicbase/stable"
+	dockerhubRepo = "docker.io/kicbase/build"
 )
 
 var (

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -27,7 +27,7 @@ minikube start [flags]
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-pause-interval duration      Duration of inactivity before the minikube VM is paused (default 1m0s) (default 1m0s)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase:v0.0.51@sha256:4a1c825b61479e6c898851ea66f13c620aaeab6002746e95067fc2c4b38a0b24")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.51-1788719696-23591@sha256:01bc448296750a93c677a9c36ca23a79c5cabff89880ea1bba05a64f4a22e12e")
       --binary-mirror string              Location to fetch kubectl, kubelet, & kubeadm binaries from.
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cert-expiration duration          Duration until minikube certificate expiration, defaults to three years (26280h). (default 26280h0m0s)


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
Fixes #23481
Related to #23302 and #23275

**Description:**
This PR installs Helm into the `kicbase` Dockerfile image. Pre-installing Helm ensures consistency with the Minikube ISO and enables Helm-based addons to function properly in air-gapped / guest container environments where outbound internet access is restricted during testing.
