### PR TITLE
chore: fix ISO build warning and Boskos comment

### DIFF
--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -66,7 +66,7 @@ sudo apt-get -y install build-essential unzip rsync bc python3 p7zip-full cmake
 CMAKE_VERSION=$(cmake --version | head -n1 | awk '{print $3}')
 echo "Start of ISO build: CMake version: $CMAKE_VERSION"
 if dpkg --compare-versions "$CMAKE_VERSION" lt "3.20"; then
-	echo "WARNING: CMake version $CMAKE_VERSION is less than 3.20. this will cause a slower build due to rebuidling cmake ..."
+	echo "WARNING: CMake version $CMAKE_VERSION is less than 3.20. This will cause a slower build due to rebuilding CMake ..."
 fi
 
 # Let's make sure we have the newest ISO reference

--- a/hack/prow/minitest/deployer/boskos_deployer.go
+++ b/hack/prow/minitest/deployer/boskos_deployer.go
@@ -53,7 +53,7 @@ type MiniTestBosKosDeployer struct {
 	sshAddr          string
 
 	boskosClient *client.Client
-	// this channel serves as a signal channel for the hearbeat goroutine
+	// this channel serves as a signal channel for the heartbeat goroutine
 	// so that it can be explicitly closed
 	boskosHeartbeatClose chan struct{}
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->


Corrects two maintenance-facing messages:

- Capitalize and fix the CMake rebuilding warning emitted by `build_iso.sh`.
- Correct “hearbeat” in the Boskos deployer's shutdown-channel comment.

`bash -n hack/jenkins/build_iso.sh` and `git diff --check` both pass.
