### PR TITLE
hack/release_notes: export GITHUB_TOKEN for changelog.go

### DIFF
--- a/hack/release_notes.sh
+++ b/hack/release_notes.sh
@@ -28,6 +28,11 @@ function cleanup_token() {
 }
 trap cleanup_token EXIT
 
+# changelog.go authenticates via GITHUB_TOKEN. Without it, GitHub's
+# unauthenticated limit (60 req/hr) is usually exceeded while listing PRs.
+export GITHUB_TOKEN
+GITHUB_TOKEN=$(cat "$GH_TOKEN")
+
 if  ! [[ -x "${DIR}/pullsheet" ]]; then
   echo >&2 'Installing pullsheet'
   GOBIN="$DIR" go install github.com/google/pullsheet@latest


### PR DESCRIPTION
The script already fetched a gh token for pullsheet, but changelog.go only authenticates when GITHUB_TOKEN is set. Without it, listing PRs hits GitHub's unauthenticated 60 req/hr limit:

Example error:

```console
$ make release-notes
...
list PRs for commit 571989eb31cea2474cc01775f70014e10c723fab:
GET .../commits/.../pulls: 403 API rate limit of 60 still exceeded
until 2026-08-31 23:58:20 +0300 IDT, not making remote request.
```