### PR TITLE
addons: avoid false gcp-auth refresh timeout for controller-managed pods

### DIFF
--- a/pkg/addons/addons_gcpauth.go
+++ b/pkg/addons/addons_gcpauth.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"golang.org/x/oauth2/google"
@@ -217,6 +218,8 @@ func refreshExistingPods(cc *config.ClusterConfig) error {
 
 			klog.Infof("refreshing pod %q", p.Name)
 
+			oldUID := p.UID
+
 			// Recreating the pod should pickup the necessary changes
 			err := pods.Delete(context.TODO(), p.Name, metav1.DeleteOptions{})
 			if err != nil {
@@ -228,15 +231,36 @@ func refreshExistingPods(cc *config.ClusterConfig) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 
-			for err == nil {
+			recreatedByController := false
+			for {
 				if ctx.Err() == context.DeadlineExceeded {
 					return fmt.Errorf("pod %q failed to restart", p.Name)
 				}
-				_, err = pods.Get(context.TODO(), p.Name, metav1.GetOptions{})
+
+				pod, getErr := pods.Get(context.TODO(), p.Name, metav1.GetOptions{})
+				if getErr != nil {
+					if apierrors.IsNotFound(getErr) {
+						break
+					}
+					return fmt.Errorf("failed to get pod %q: %v", p.Name, getErr)
+				}
+
+				if pod.UID != oldUID {
+					recreatedByController = true
+					break
+				}
+
 				time.Sleep(time.Second)
 			}
 
+			if recreatedByController {
+				continue
+			}
+
 			if _, err := pods.Create(context.TODO(), &p, metav1.CreateOptions{}); err != nil {
+				if apierrors.IsAlreadyExists(err) {
+					continue
+				}
 				return fmt.Errorf("failed to create pod %q: %v", p.Name, err)
 			}
 		}


### PR DESCRIPTION
This adjusts `gcp-auth --refresh` pod restart detection to use Pod UID, which avoids false failures for controller-managed pods (for example StatefulSets) that quickly recreate the same pod name.

## What changed
- In `pkg/addons/addons_gcpauth.go` (`refreshExistingPods`):
  - record the old pod UID before deletion
  - after delete, poll `Get` by name and treat either condition as successful restart progress:
    - pod is `NotFound` (old object gone), or
    - pod exists but with a different UID (new object already recreated by controller)
  - only call manual `Create` when the pod is actually gone
  - handle `AlreadyExists` defensively on `Create`
  - return non-NotFound `Get` errors instead of treating them as restart success

## Why
Current logic waits up to 15s for `Get(name)` to fail, then recreates the pod manually. For StatefulSet-managed pods, the controller can recreate the same pod name quickly, so `Get(name)` may keep succeeding continuously even though the old instance was replaced. This leads to a timeout and `pod "..." failed to restart` false negative.

This change makes restart detection instance-aware (UID-based), preserving behavior for unmanaged pods while avoiding the false timeout race for managed workloads.
