### PR TITLE
test: Fix nil pointer dereference in release_sanity_test

### DIFF
--- a/deploy/minikube/release_sanity_test.go
+++ b/deploy/minikube/release_sanity_test.go
@@ -75,6 +75,9 @@ func checkReleasesV1(t *testing.T, r notify.Release) {
 		"windows": r.Checksums.Windows,
 	}
 	for platform, sha := range checksums {
+		if sha == "" {
+			continue
+		}
 		fmt.Printf("Checking SHA for %s.\n", platform)
 		actualSha, err := getSHAFromURL(util.GetBinaryDownloadURL(r.Name, platform, "amd64"))
 		if err != nil {
@@ -90,22 +93,40 @@ func checkReleasesV1(t *testing.T, r notify.Release) {
 
 func getSHAMap(r notify.Release) map[string]map[string]string {
 	c := r.Checksums
-	return map[string]map[string]string{
-		"darwin": {
-			"amd64": c.AMD64.Darwin,
-			"arm64": c.ARM64.Darwin,
-		},
-		"linux": {
-			"amd64":   c.AMD64.Linux,
-			"arm":     c.ARM.Linux,
-			"arm64":   c.ARM64.Linux,
-			"ppc64le": c.PPC64LE.Linux,
-			"s390x":   c.S390X.Linux,
-		},
-		"windows": {
-			"amd64": c.AMD64.Windows,
-		},
+	m := map[string]map[string]string{
+		"darwin":  {},
+		"linux":   {},
+		"windows": {},
 	}
+	if c.AMD64 != nil {
+		if c.AMD64.Darwin != "" {
+			m["darwin"]["amd64"] = c.AMD64.Darwin
+		}
+		if c.AMD64.Linux != "" {
+			m["linux"]["amd64"] = c.AMD64.Linux
+		}
+		if c.AMD64.Windows != "" {
+			m["windows"]["amd64"] = c.AMD64.Windows
+		}
+	}
+	if c.ARM != nil && c.ARM.Linux != "" {
+		m["linux"]["arm"] = c.ARM.Linux
+	}
+	if c.ARM64 != nil {
+		if c.ARM64.Darwin != "" {
+			m["darwin"]["arm64"] = c.ARM64.Darwin
+		}
+		if c.ARM64.Linux != "" {
+			m["linux"]["arm64"] = c.ARM64.Linux
+		}
+	}
+	if c.PPC64LE != nil && c.PPC64LE.Linux != "" {
+		m["linux"]["ppc64le"] = c.PPC64LE.Linux
+	}
+	if c.S390X != nil && c.S390X.Linux != "" {
+		m["linux"]["s390x"] = c.S390X.Linux
+	}
+	return m
 }
 
 func checkReleasesV2(t *testing.T, rs notify.Releases) {


### PR DESCRIPTION
Starting with v1.38.0 (#22585), 32-bit ARM (`linux/arm`) was removed from release builds and omitted from `releases-v2.json`. Consequently, `notify.Release.Checksums.ARM` unmarshals as `nil` for newer releases. This caused `make check-release` (`deploy/minikube/release_sanity_test.go`) to panic with a nil pointer dereference when accessing `c.ARM.Linux` in `getSHAMap()`.

This PR guards against `nil` architecture pointers before accessing their fields, allowing `make check-release` to run without crashing on releases that omit optional architectures.

Fixes #23622