### PR TITLE
Fix nil pointer dereference in release_sanity_test.go getSHAMap

### DIFF
--- a/deploy/minikube/release_sanity_test.go
+++ b/deploy/minikube/release_sanity_test.go
@@ -90,21 +90,33 @@ func checkReleasesV1(t *testing.T, r notify.Release) {
 
 func getSHAMap(r notify.Release) map[string]map[string]string {
 	c := r.Checksums
+	darwinSHAs := make(map[string]string)
+	linuxSHAs := make(map[string]string)
+	windowsSHAs := make(map[string]string)
+
+	if c.AMD64 != nil {
+		darwinSHAs["amd64"] = c.AMD64.Darwin
+		linuxSHAs["amd64"] = c.AMD64.Linux
+		windowsSHAs["amd64"] = c.AMD64.Windows
+	}
+	if c.ARM != nil {
+		linuxSHAs["arm"] = c.ARM.Linux
+	}
+	if c.ARM64 != nil {
+		darwinSHAs["arm64"] = c.ARM64.Darwin
+		linuxSHAs["arm64"] = c.ARM64.Linux
+	}
+	if c.PPC64LE != nil {
+		linuxSHAs["ppc64le"] = c.PPC64LE.Linux
+	}
+	if c.S390X != nil {
+		linuxSHAs["s390x"] = c.S390X.Linux
+	}
+
 	return map[string]map[string]string{
-		"darwin": {
-			"amd64": c.AMD64.Darwin,
-			"arm64": c.ARM64.Darwin,
-		},
-		"linux": {
-			"amd64":   c.AMD64.Linux,
-			"arm":     c.ARM.Linux,
-			"arm64":   c.ARM64.Linux,
-			"ppc64le": c.PPC64LE.Linux,
-			"s390x":   c.S390X.Linux,
-		},
-		"windows": {
-			"amd64": c.AMD64.Windows,
-		},
+		"darwin":  darwinSHAs,
+		"linux":   linuxSHAs,
+		"windows": windowsSHAs,
 	}
 }
 


### PR DESCRIPTION
**Description:**

Fixes #23622

`getSHAMap()` unconditionally dereferences all architecture pointer fields in the `checksums` struct (e.g., `c.ARM.Linux`). When a release doesn't ship binaries for a particular architecture (like `arm` in v1.39.0), the corresponding field is `nil`, causing a segfault.

Added nil checks before accessing each architecture's checksums so only architectures present in the release JSON are verified.


<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
