### PR TITLE
Overhaul `release_sanity_test.go` to be fast, correct, and usable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -645,7 +645,7 @@ out/minikube-installer.exe: out/minikube-windows-amd64.exe
 
 .PHONY: check-release
 check-release: ## Verify release checksums for $(VERSION) in releases JSON
-	go test -v ./deploy/minikube/release_sanity_test.go -run '/$(subst .,\.,$(VERSION))$$'
+	go test -v ./deploy/minikube/release_sanity_test.go -run '//$(subst .,\.,$(VERSION))$$'
 
 buildroot-image: $(ISO_BUILD_IMAGE) # convenient alias to build the docker container
 $(ISO_BUILD_IMAGE): deploy/iso/minikube-iso/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -644,8 +644,8 @@ out/minikube-installer.exe: out/minikube-windows-amd64.exe
 	rm -rf out/windows_tmp
 
 .PHONY: check-release
-check-release: ## Execute go test
-	go test -timeout 42m -v ./deploy/minikube/release_sanity_test.go
+check-release: ## Verify release checksums for $(VERSION) in releases JSON
+	go test -v ./deploy/minikube/release_sanity_test.go -run '/$(subst .,\.,$(VERSION))$$'
 
 buildroot-image: $(ISO_BUILD_IMAGE) # convenient alias to build the docker container
 $(ISO_BUILD_IMAGE): deploy/iso/minikube-iso/Dockerfile

--- a/deploy/minikube/release_sanity_test.go
+++ b/deploy/minikube/release_sanity_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"net/http"
 	"testing"
 
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
@@ -35,6 +36,9 @@ func getSHAFromURL(url string) (string, error) {
 		return "", fmt.Errorf("GET %s: %w", url, err)
 	}
 	defer r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GET %s: %s", url, r.Status)
+	}
 	h := sha256.New()
 	if _, err := io.Copy(h, r.Body); err != nil {
 		return "", fmt.Errorf("GET %s: failed to copy body: %w", url, err)

--- a/deploy/minikube/release_sanity_test.go
+++ b/deploy/minikube/release_sanity_test.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"slices"
+	"sync/atomic"
 	"testing"
 
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
@@ -31,28 +32,30 @@ import (
 	"k8s.io/minikube/pkg/util"
 )
 
-// TestReleasesJSON checks if all *GA* releases
-//
-//	enlisted in https://storage.googleapis.com/minikube/releases-v2.json
-//	are available to download and have correct hashsum
-func TestReleasesJSON(t *testing.T) {
-	releases, err := notify.AllVersionsFromURL(notify.GithubMinikubeReleasesURL)
-	if err != nil {
-		t.Fatalf("Error getting releases.json: %v", err)
-	}
-	checkReleases(t, releases)
-}
+// TestReleases checks if all releases enlisted in the releases JSON files
+// are available to download and have correct checksums.
+func TestReleases(t *testing.T) {
+	var checked atomic.Int32
 
-// TestBetaReleasesJSON checks if all *BETA* releases
-//
-//	enlisted in https://storage.googleapis.com/minikube/releases-beta-v2.json
-//	are available to download and have correct hashsum
-func TestBetaReleasesJSON(t *testing.T) {
-	releases, err := notify.AllVersionsFromURL(notify.GithubMinikubeBetaReleasesURL)
-	if err != nil {
-		t.Fatalf("Error getting releases-bets.json: %v", err)
+	t.Run("stable", func(t *testing.T) {
+		releases, err := notify.AllVersionsFromURL(notify.GithubMinikubeReleasesURL)
+		if err != nil {
+			t.Fatalf("Error getting releases.json: %v", err)
+		}
+		checkReleases(t, &checked, releases)
+	})
+
+	t.Run("beta", func(t *testing.T) {
+		releases, err := notify.AllVersionsFromURL(notify.GithubMinikubeBetaReleasesURL)
+		if err != nil {
+			t.Fatalf("Error getting releases-beta.json: %v", err)
+		}
+		checkReleases(t, &checked, releases)
+	})
+
+	if checked.Load() == 0 {
+		t.Fatal("no binaries were checked")
 	}
-	checkReleases(t, releases)
 }
 
 type binary struct {
@@ -141,7 +144,7 @@ func releaseBinaries(r notify.Release) []binary {
 	return bins
 }
 
-func checkReleases(t *testing.T, rs notify.Releases) {
+func checkReleases(t *testing.T, checked *atomic.Int32, rs notify.Releases) {
 	client := retryablehttp.NewClient()
 	client.Logger = nil
 	for _, r := range rs.Releases {
@@ -152,6 +155,7 @@ func checkReleases(t *testing.T, rs notify.Releases) {
 			for _, bin := range releaseBinaries(r) {
 				t.Run(bin.OS+"-"+bin.Arch, func(t *testing.T) {
 					t.Parallel()
+					checked.Add(1)
 					url := util.GetBinaryDownloadURL(r.Name, bin.OS, bin.Arch)
 					actualSha, err := getSHAFromURL(client, url)
 					if err != nil {

--- a/deploy/minikube/release_sanity_test.go
+++ b/deploy/minikube/release_sanity_test.go
@@ -29,24 +29,6 @@ import (
 	"k8s.io/minikube/pkg/util"
 )
 
-func getSHAFromURL(url string) (string, error) {
-	fmt.Println("Downloading: ", url)
-	r, err := retryablehttp.Get(url)
-	if err != nil {
-		return "", fmt.Errorf("GET %s: %w", url, err)
-	}
-	defer r.Body.Close()
-	if r.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("GET %s: %s", url, r.Status)
-	}
-	h := sha256.New()
-	if _, err := io.Copy(h, r.Body); err != nil {
-		return "", fmt.Errorf("GET %s: failed to copy body: %w", url, err)
-	}
-
-	return hex.EncodeToString(h.Sum(nil)), nil
-}
-
 // TestReleasesJSON checks if all *GA* releases
 //
 //	enlisted in https://storage.googleapis.com/minikube/releases-v2.json
@@ -152,4 +134,22 @@ func checkReleasesV2(t *testing.T, rs notify.Releases) {
 			}
 		}
 	}
+}
+
+func getSHAFromURL(url string) (string, error) {
+	fmt.Println("Downloading: ", url)
+	r, err := retryablehttp.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GET %s: %s", url, r.Status)
+	}
+	h := sha256.New()
+	if _, err := io.Copy(h, r.Body); err != nil {
+		return "", fmt.Errorf("GET %s: failed to copy body: %w", url, err)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/deploy/minikube/release_sanity_test.go
+++ b/deploy/minikube/release_sanity_test.go
@@ -142,30 +142,32 @@ func releaseBinaries(r notify.Release) []binary {
 }
 
 func checkReleases(t *testing.T, rs notify.Releases) {
+	client := retryablehttp.NewClient()
+	client.Logger = nil
 	for _, r := range rs.Releases {
-		fmt.Printf("Checking release: %s\n", r.Name)
-		if err := validateChecksums(r); err != nil {
-			t.Errorf("release %s: %v", r.Name, err)
-			continue
-		}
-		for _, bin := range releaseBinaries(r) {
-			fmt.Printf("Checking SHA for %s-%s.\n", bin.OS, bin.Arch)
-			actualSha, err := getSHAFromURL(util.GetBinaryDownloadURL(r.Name, bin.OS, bin.Arch))
-			if err != nil {
-				t.Errorf("Error calculating SHA for %s-%s-%s. Error: %v", r.Name, bin.OS, bin.Arch, err)
-				continue
+		t.Run(r.Name, func(t *testing.T) {
+			if err := validateChecksums(r); err != nil {
+				t.Fatalf("%v", err)
 			}
-			if actualSha != bin.SHA {
-				t.Errorf("ERROR: SHA does not match for version %s, os %s, arch %s. Expected %s, got %s.", r.Name, bin.OS, bin.Arch, bin.SHA, actualSha)
-				continue
+			for _, bin := range releaseBinaries(r) {
+				t.Run(bin.OS+"-"+bin.Arch, func(t *testing.T) {
+					t.Parallel()
+					url := util.GetBinaryDownloadURL(r.Name, bin.OS, bin.Arch)
+					actualSha, err := getSHAFromURL(client, url)
+					if err != nil {
+						t.Fatalf("Error calculating SHA: %v", err)
+					}
+					if actualSha != bin.SHA {
+						t.Fatalf("SHA mismatch: expected %s, got %s", bin.SHA, actualSha)
+					}
+				})
 			}
-		}
+		})
 	}
 }
 
-func getSHAFromURL(url string) (string, error) {
-	fmt.Println("Downloading: ", url)
-	r, err := retryablehttp.Get(url)
+func getSHAFromURL(client *retryablehttp.Client, url string) (string, error) {
+	r, err := client.Get(url)
 	if err != nil {
 		return "", fmt.Errorf("GET %s: %w", url, err)
 	}

--- a/deploy/minikube/release_sanity_test.go
+++ b/deploy/minikube/release_sanity_test.go
@@ -32,7 +32,7 @@ func getSHAFromURL(url string) (string, error) {
 	fmt.Println("Downloading: ", url)
 	r, err := retryablehttp.Get(url)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("GET %s: %w", url, err)
 	}
 	defer r.Body.Close()
 	h := sha256.New()

--- a/deploy/minikube/release_sanity_test.go
+++ b/deploy/minikube/release_sanity_test.go
@@ -35,13 +35,12 @@ func getSHAFromURL(url string) (string, error) {
 		return "", err
 	}
 	defer r.Body.Close()
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return "", err
+	h := sha256.New()
+	if _, err := io.Copy(h, r.Body); err != nil {
+		return "", fmt.Errorf("GET %s: failed to copy body: %w", url, err)
 	}
 
-	b := sha256.Sum256(body)
-	return hex.EncodeToString(b[:]), nil
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // TestReleasesJSON checks if all *GA* releases

--- a/deploy/minikube/release_sanity_test.go
+++ b/deploy/minikube/release_sanity_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"cmp"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"testing"
 
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
@@ -38,7 +40,7 @@ func TestReleasesJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error getting releases.json: %v", err)
 	}
-	checkReleasesV2(t, releases)
+	checkReleases(t, releases)
 }
 
 // TestBetaReleasesJSON checks if all *BETA* releases
@@ -50,87 +52,112 @@ func TestBetaReleasesJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error getting releases-bets.json: %v", err)
 	}
-	checkReleasesV2(t, releases)
+	checkReleases(t, releases)
 }
 
-func checkReleasesV1(t *testing.T, r notify.Release) {
-	checksums := map[string]string{
-		"darwin":  r.Checksums.Darwin,
-		"linux":   r.Checksums.Linux,
-		"windows": r.Checksums.Windows,
-	}
-	for platform, sha := range checksums {
-		if sha == "" {
-			continue
-		}
-		fmt.Printf("Checking SHA for %s.\n", platform)
-		actualSha, err := getSHAFromURL(util.GetBinaryDownloadURL(r.Name, platform, "amd64"))
-		if err != nil {
-			t.Errorf("Error calculating SHA for %s-%s. Error: %v", r.Name, platform, err)
-			continue
-		}
-		if actualSha != sha {
-			t.Errorf("ERROR: SHA does not match for version %s, platform %s. Expected %s, got %s.", r.Name, platform, sha, actualSha)
-			continue
-		}
-	}
+type binary struct {
+	OS   string
+	Arch string
+	SHA  string
 }
 
-func getSHAMap(r notify.Release) map[string]map[string]string {
+// validateChecksums verifies that the v1 flat fields and v2 nested amd64
+// fields are identical.
+func validateChecksums(r notify.Release) error {
 	c := r.Checksums
-	m := map[string]map[string]string{
-		"darwin":  {},
-		"linux":   {},
-		"windows": {},
+	if c.AMD64 == nil {
+		return nil
 	}
+	if c.Darwin != c.AMD64.Darwin {
+		return fmt.Errorf("darwin amd64 checksum mismatch: v1=%s v2=%s", c.Darwin, c.AMD64.Darwin)
+	}
+	if c.Linux != c.AMD64.Linux {
+		return fmt.Errorf("linux amd64 checksum mismatch: v1=%s v2=%s", c.Linux, c.AMD64.Linux)
+	}
+	if c.Windows != c.AMD64.Windows {
+		return fmt.Errorf("windows amd64 checksum mismatch: v1=%s v2=%s", c.Windows, c.AMD64.Windows)
+	}
+	return nil
+}
+
+// releaseBinaries returns a deduplicated list of binaries with expected
+// checksums for a release. The releases JSON contains entries in two formats:
+//   - v1 (older releases): flat "darwin"/"linux"/"windows" fields, always amd64.
+//   - v2 (newer releases): nested arch objects ("amd64", "arm64", …) plus the
+//     same flat fields duplicated for backward compatibility.
+//
+// Both are normalized into a single list so each binary is checked exactly once.
+func releaseBinaries(r notify.Release) []binary {
+	c := r.Checksums
+	var bins []binary
+
 	if c.AMD64 != nil {
+		// v2: nested arch objects.
 		if c.AMD64.Darwin != "" {
-			m["darwin"]["amd64"] = c.AMD64.Darwin
+			bins = append(bins, binary{"darwin", "amd64", c.AMD64.Darwin})
 		}
 		if c.AMD64.Linux != "" {
-			m["linux"]["amd64"] = c.AMD64.Linux
+			bins = append(bins, binary{"linux", "amd64", c.AMD64.Linux})
 		}
 		if c.AMD64.Windows != "" {
-			m["windows"]["amd64"] = c.AMD64.Windows
+			bins = append(bins, binary{"windows", "amd64", c.AMD64.Windows})
+		}
+	} else {
+		// v1: flat fields, always amd64.
+		if c.Darwin != "" {
+			bins = append(bins, binary{"darwin", "amd64", c.Darwin})
+		}
+		if c.Linux != "" {
+			bins = append(bins, binary{"linux", "amd64", c.Linux})
+		}
+		if c.Windows != "" {
+			bins = append(bins, binary{"windows", "amd64", c.Windows})
 		}
 	}
 	if c.ARM != nil && c.ARM.Linux != "" {
-		m["linux"]["arm"] = c.ARM.Linux
+		bins = append(bins, binary{"linux", "arm", c.ARM.Linux})
 	}
 	if c.ARM64 != nil {
 		if c.ARM64.Darwin != "" {
-			m["darwin"]["arm64"] = c.ARM64.Darwin
+			bins = append(bins, binary{"darwin", "arm64", c.ARM64.Darwin})
 		}
 		if c.ARM64.Linux != "" {
-			m["linux"]["arm64"] = c.ARM64.Linux
+			bins = append(bins, binary{"linux", "arm64", c.ARM64.Linux})
 		}
 	}
 	if c.PPC64LE != nil && c.PPC64LE.Linux != "" {
-		m["linux"]["ppc64le"] = c.PPC64LE.Linux
+		bins = append(bins, binary{"linux", "ppc64le", c.PPC64LE.Linux})
 	}
 	if c.S390X != nil && c.S390X.Linux != "" {
-		m["linux"]["s390x"] = c.S390X.Linux
+		bins = append(bins, binary{"linux", "s390x", c.S390X.Linux})
 	}
-	return m
+
+	slices.SortFunc(bins, func(a, b binary) int {
+		if c := cmp.Compare(a.OS, b.OS); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Arch, b.Arch)
+	})
+	return bins
 }
 
-func checkReleasesV2(t *testing.T, rs notify.Releases) {
+func checkReleases(t *testing.T, rs notify.Releases) {
 	for _, r := range rs.Releases {
 		fmt.Printf("Checking release: %s\n", r.Name)
-		checkReleasesV1(t, r)
-		release := getSHAMap(r)
-		for os, archs := range release {
-			for arch, sha := range archs {
-				fmt.Printf("Checking SHA for %s-%s.\n", os, arch)
-				actualSha, err := getSHAFromURL(util.GetBinaryDownloadURL(r.Name, os, arch))
-				if err != nil {
-					t.Errorf("Error calculating SHA for %s-%s-%s. Error: %v", r.Name, os, arch, err)
-					continue
-				}
-				if actualSha != sha {
-					t.Errorf("ERROR: SHA does not match for version %s, os %s, arch %s. Expected %s, got %s.", r.Name, os, arch, sha, actualSha)
-					continue
-				}
+		if err := validateChecksums(r); err != nil {
+			t.Errorf("release %s: %v", r.Name, err)
+			continue
+		}
+		for _, bin := range releaseBinaries(r) {
+			fmt.Printf("Checking SHA for %s-%s.\n", bin.OS, bin.Arch)
+			actualSha, err := getSHAFromURL(util.GetBinaryDownloadURL(r.Name, bin.OS, bin.Arch))
+			if err != nil {
+				t.Errorf("Error calculating SHA for %s-%s-%s. Error: %v", r.Name, bin.OS, bin.Arch, err)
+				continue
+			}
+			if actualSha != bin.SHA {
+				t.Errorf("ERROR: SHA does not match for version %s, os %s, arch %s. Expected %s, got %s.", r.Name, bin.OS, bin.Arch, bin.SHA, actualSha)
+				continue
 			}
 		}
 	}


### PR DESCRIPTION
The release sanity test downloaded and hashed every binary for every release ever published — 524 downloads, sequentially, taking ~33 minutes. After publishing v1.39.0, you'd wait half an hour just to learn it was fine.

For newer releases (v1.26.0+) the amd64 binaries were downloaded and hashed twice — once from the v1 flat checksum fields and again from the v2 nested arch fields, which contain the same values.

HTTP errors were silently hashed as HTML error pages, producing confusing "SHA does not match" instead of "download failed".

Changes:

- Stream hash with `io.Copy` into `sha256.New()` instead of `io.ReadAll` + `sha256.Sum256`, reducing memory from ~300 MB to ~17M.
- Non-200 HTTP responses fail immediately instead of hashing error pages.
- Each binary is checked exactly once (524 → 458 downloads).
- Validate inconsistencies between the v1 flat list and v2 nested before any downloads.
- Normalize and deduplicate v1 and v2 format to flat list of binaries to check.
- Merge `TestReleasesJSON` and `TestBetaReleasesJSON` into a single `TestReleases` with `stable`/`beta` subtests for consistent naming and clearer output.
- Binaries within each release run with `t.Parallel()`, overlapping the network-bound downloads (~8 concurrent).
- `make check-release` now checks only the current VERSION instead of all 123 releases (160x faster)
- Fail when no binaries were checked (e.g. wrong `-run` filter, missing release in JSON).

| | Before | After |
|---|---|---|
| All releases | ~33 min | ~8.7 min |
| Single release (`make check-release`) | ~33 min | ~13 sec |
| Downloads releases | 524 | 458 |
| Downloads beta releases | 56 | 44 |