### PR TITLE
config: accept escaped local ISO file paths

### DIFF
--- a/cmd/minikube/cmd/config/validations.go
+++ b/cmd/minikube/cmd/config/validations.go
@@ -96,8 +96,9 @@ func IsURLExists(_, location string) error {
 		return nil
 	}
 
-	// chop off "file://" from the location, giving us the real system path
-	sysPath := strings.TrimPrefix(location, "file://")
+	// URL.Path is already unescaped, unlike the original URL string. Keep the
+	// host for Windows drive-letter URLs such as file://C:/path.
+	sysPath := parsed.Host + parsed.Path
 	stat, err := os.Stat(sysPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cmd/minikube/cmd/config/validations_test.go
+++ b/cmd/minikube/cmd/config/validations_test.go
@@ -138,6 +138,10 @@ func TestIsURLExists(t *testing.T) {
 		Scheme: "file",
 		Path:   filepath.ToSlash(self),
 	}).String()
+	dir := (&url.URL{
+		Scheme: "file",
+		Path:   filepath.ToSlash(t.TempDir()),
+	}).String()
 
 	tests := []validationTest{
 		{
@@ -148,9 +152,31 @@ func TestIsURLExists(t *testing.T) {
 			value:     u + "/subpath-of-file",
 			shouldErr: true,
 		},
+		{
+			value:     dir,
+			shouldErr: true,
+		},
+		{
+			value:     "file://%",
+			shouldErr: true,
+		},
 	}
 
 	runValidations(t, tests, "url", IsURLExists)
+}
+
+func TestIsURLExistsEscapedPath(t *testing.T) {
+	for _, name := range []string{"iso image.iso", "iso#image.iso", "iso%image.iso"} {
+		path := filepath.Join(t.TempDir(), name)
+		if err := os.WriteFile(path, nil, 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		location := (&url.URL{Scheme: "file", Path: filepath.ToSlash(path)}).String()
+		if err := IsURLExists("url", location); err != nil {
+			t.Errorf("IsURLExists(%q) returned error: %v", location, err)
+		}
+	}
 }
 
 func TestIsValidCPUs(t *testing.T) {


### PR DESCRIPTION
`minikube config set iso-url` rejects an existing local ISO when its file URL contains escaped characters, such as `file:///tmp/my%20images/minikube.iso`. The existence check used the encoded URL string as the filesystem path.

Use the parsed, decoded path while retaining the host component used by existing Windows drive-letter URLs. Add regression cases for spaces, `#`, and `%`, and retain rejection of directories, nonexistent paths, and malformed URLs.

Validation:
- Reproduced the failure with minikube v1.39.0; confirmed a locally built fixed binary accepts and stores each escaped URI.
- New escaped-path test fails with the original implementation and passes with this change.
- `go test ./cmd/minikube/cmd/config -count=1`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/config.test.exe ./cmd/minikube/cmd/config` (cross-compilation only)
- Repository golangci-lint v2.12.2 on `./cmd/minikube/cmd/config`: 0 issues.
