### PR TITLE
config: reject invalid view templates with empty configuration

### DIFF
--- a/cmd/minikube/cmd/config/view.go
+++ b/cmd/minikube/cmd/config/view.go
@@ -64,11 +64,11 @@ func View() error {
 	if err != nil {
 		return err
 	}
+	tmpl, err := template.New("view").Parse(viewFormat)
+	if err != nil {
+		exit.Error(reason.InternalViewTmpl, "Error creating view template", err)
+	}
 	for k, v := range cfg {
-		tmpl, err := template.New("view").Parse(viewFormat)
-		if err != nil {
-			exit.Error(reason.InternalViewTmpl, "Error creating view template", err)
-		}
 		viewTmplt := ViewTemplate{k, v}
 		err = tmpl.Execute(os.Stdout, viewTmplt)
 		if err != nil {

--- a/cmd/minikube/cmd/config/view_test.go
+++ b/cmd/minikube/cmd/config/view_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"k8s.io/minikube/pkg/minikube/localpath"
+	"k8s.io/minikube/pkg/minikube/reason"
+)
+
+func TestViewCommand(t *testing.T) {
+	if os.Getenv("MINIKUBE_VIEW_TEST_CHILD") == "1" {
+		viewFormat = os.Getenv("MINIKUBE_VIEW_TEST_FORMAT")
+		if err := View(); err != nil {
+			t.Fatal(err)
+		}
+		os.Exit(0)
+	}
+
+	tests := []struct {
+		name       string
+		format     string
+		config     map[string]interface{}
+		wantOutput string
+		wantExit   bool
+	}{
+		{name: "invalid format and empty config", format: "{{", wantExit: true},
+		{name: "valid format and empty config", format: "{{.ConfigKey}}", wantOutput: ""},
+		{name: "valid format and populated config", format: "- {{.ConfigKey}}: {{.ConfigValue}}\n", config: map[string]interface{}{"driver": "docker"}, wantOutput: "- driver: docker\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			if len(tt.config) != 0 {
+				configDir := filepath.Join(home, ".minikube", "config")
+				if err := os.MkdirAll(configDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				data, err := json.Marshal(tt.config)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(configDir, "config.json"), data, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			cmd := exec.Command(os.Args[0], "-test.run=^TestViewCommand$")
+			cmd.Env = append(os.Environ(),
+				"MINIKUBE_VIEW_TEST_CHILD=1",
+				"MINIKUBE_VIEW_TEST_FORMAT="+tt.format,
+				localpath.MinikubeHome+"="+home)
+			output, err := cmd.CombinedOutput()
+			if tt.wantExit {
+				exitErr, ok := err.(*exec.ExitError)
+				if !ok || exitErr.ExitCode() != reason.InternalViewTmpl.ExitCode || !strings.Contains(string(output), reason.InternalViewTmpl.ID) {
+					t.Fatalf("View error = %v, output = %q; want exit %d containing %s", err, output, reason.InternalViewTmpl.ExitCode, reason.InternalViewTmpl.ID)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("View failed: %v; output: %s", err, output)
+			}
+			if string(output) != tt.wantOutput {
+				t.Fatalf("View output = %q, want %q", output, tt.wantOutput)
+			}
+		})
+	}
+}


### PR DESCRIPTION
With an empty configuration, `minikube config view --format '{{'` exits successfully because the template is only parsed while iterating over configuration entries. The same input fails when the configuration contains an entry.

Parse the template once before iteration so invalid syntax consistently exits with `MK_VIEW_TMPL`. Preserve the existing error category and normal rendering behavior. A subprocess regression test exercises invalid and valid formats with empty configuration and rendering with a populated configuration.

Validation:
- Reproduced exit 0 on v1.39.0; a locally built fixed binary exits 10 with `MK_VIEW_TMPL` for the invalid template and preserves valid output.
- New regression test fails with the original implementation and passes with this change.
- `go test ./cmd/minikube/cmd/config -count=1`
- `go test -covermode=count -coverprofile=/tmp/config-view.cover ./cmd/minikube/cmd/config -count=1`
- Windows amd64 test binary cross-compilation passes (not executed on Windows).
- Repository golangci-lint v2.12.2 on `./cmd/minikube/cmd/config`: 0 issues.
