### PR TITLE
site: Update Hugo from v0.160.1 to v0.165.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ command = "pwd && cd themes/docsy && npm install && git submodule update -f --in
 # node Active LTS
 NODE_VERSION = "24.20.0"
 # https://github.com/gohugoio/hugo/releases
-HUGO_VERSION = "v0.160.1"
+HUGO_VERSION = "v0.165.0"
 
 [context.production.environment]
 HUGO_ENV = "production"

--- a/site/config.toml
+++ b/site/config.toml
@@ -29,6 +29,11 @@ pygmentsStyle = "tango"
  # First one is picked as the Twitter card image if not set on page.
  #images = ["images/project-illustration.png"]
 
+# Hugo >= 0.162.0 blocks text/html content files by default.
+# Our site uses .html content files (landing page, leaderboards), so allow them.
+[security]
+allowContent = ['.*']
+
 [markup]
   [markup.highlight]
     codeFences = true
@@ -66,6 +71,8 @@ id = "G-JPP6RFM2BP"
 [languages.en]
 title = "minikube"
 languageName = "English"
+# Hugo >= 0.158.0 uses 'label' instead of 'languageName'
+label = "English"
 weight = 1
 [languages.en.params]
 description = "minikube is local Kubernetes"


### PR DESCRIPTION
Hugo v0.162.0 introduced a `security.allowContent` policy that blocks `text/html` content files by default. Our site has 138 `.html` content files (landing page, leaderboards), causing any Hugo version bump past v0.162.0 to fail Netlify deploys.

Add `[security] allowContent = ['.*']` to `site/config.toml`. Also add `label` key for Hugo >= 0.158.0 deprecation of `languageName`.

Fixes #23651

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
