### PR TITLE
test: fix SecondStartNoReconfiguration on KVM and unskip test

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -636,6 +636,11 @@ func (k *Bootstrapper) restartPrimaryControlPlane(cfg config.ClusterConfig) erro
 		if config.IsHA(cfg) || !driver.IsVM(cfg.Driver) {
 			return nil
 		}
+		// If VM driver cluster is already running with a healthy control plane, skip reconfiguration
+		if st, err := kverify.APIServerStatus(k.c, host, port); err == nil && st == state.Running {
+			klog.Infof("The running cluster has a healthy control plane, skipping reconfiguration: %s", host)
+			return nil
+		}
 	} else {
 		klog.Infof("detected kubeadm config drift (will reconfigure cluster from new %s):\n%s", conf, rr.Output())
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeadm
+
+import (
+	"testing"
+
+	"k8s.io/minikube/pkg/libmachine/state"
+	"k8s.io/minikube/pkg/minikube/command"
+)
+
+func TestGetAPIServerStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		cmdToOutput   map[string]string
+		expectedState string
+	}{
+		{
+			name:          "stopped when no pid found",
+			cmdToOutput:   map[string]string{},
+			expectedState: state.Stopped.String(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fcr := command.NewFakeCommandRunner()
+			fcr.SetCommandToOutput(tc.cmdToOutput)
+
+			b := &Bootstrapper{c: fcr, contextName: "minikube"}
+			st, err := b.GetAPIServerStatus("127.0.0.1", 8443)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if st != tc.expectedState {
+				t.Errorf("expected status %q, got %q", tc.expectedState, st)
+			}
+		})
+	}
+}

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -86,9 +86,6 @@ func validateFreshStart(ctx context.Context, t *testing.T, profile string) {
 // validateStartNoReconfigure validates that starting a running cluster does not invoke reconfiguration
 func validateStartNoReconfigure(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
-	if KVMDriver() {
-		t.Skip("skipping: flaky on KVM driver: https://github.com/kubernetes/minikube/issues/23141")
-	}
 
 	args := []string{"start", "-p", profile, "--alsologtostderr", "-v=1"}
 	args = append(args, StartArgs()...)


### PR DESCRIPTION
### What this PR does / why we need it:
Fixes the flaky `TestPause/serial/SecondStartNoReconfiguration` test on the KVM driver and re-enables it.

#### Root Cause:
In `restartPrimaryControlPlane`, when Minikube detects that the kubeadm configuration has not drifted (`diff -u conf conf.new` has zero exit status), container drivers (`!driver.IsVM(cfg.Driver)`) immediately exit without reconfiguration. However, VM drivers (including KVM2) were unconditionally forced to fall through to a full cluster reconfiguration (`k.stopKubeSystem`, `sysinit.Stop("kubelet")`, and rerunning all `kubeadm init` phases). On an already-running KVM cluster, running kubeadm phases against running/restarting pods caused port conflicts (exit status 81) or exceeded context deadlines.

#### Solution:
1. In `restartPrimaryControlPlane`, check if the API server is already running and healthy when no config drift exists. If so, safely take the shortcut and skip reconfiguration on VM drivers as well.
2. Add table-driven unit tests for `GetAPIServerStatus` in `kubeadm_test.go`.
3. Unskip `TestPause/serial/SecondStartNoReconfiguration` on KVM in `test/integration/pause_test.go`.

### Which issue(s) this PR fixes:
Fixes #23141

### Does this PR introduce a user-facing change?
```release-note
NONE
