### PR TITLE
Kicbase: Switch debian base to Trixie (13)

### DIFF
--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -17,9 +17,9 @@
 # For systemd + docker configuration used below, see the following references:
 # https://systemd.io/CONTAINER_INTERFACE/
 
-# this ARG needs to be global to use it in `FROM` & is updated for new versions of debian:bookworm-slim-*
-ARG KICBASE_IMAGE="debian:bookworm-20260713-slim"
-# start from debin 12, this image is reasonably small as a starting point
+# this ARG needs to be global to use it in `FROM` & is updated for new versions of debian:trixie-slim-*
+ARG KICBASE_IMAGE="debian:trixie-20260824-slim"
+# start from debian 13, this image is reasonably small as a starting point
 # for a kubernetes node image, it doesn't contain much we don't need.
 FROM ${KICBASE_IMAGE} AS kicbase
 
@@ -87,7 +87,7 @@ RUN echo "Ensuring scripts are executable ..." \
     && rm -f /lib/systemd/system/sockets.target.wants/*initctl* \
     && rm -f /lib/systemd/system/basic.target.wants/* \
     && echo "ReadKMsg=no" >> /etc/systemd/journald.conf \
-    && ln -s "$(which systemd)" /sbin/init \
+    && ln -sf /usr/lib/systemd/systemd /sbin/init \
  && echo "Ensuring /etc/kubernetes/manifests" \
     && mkdir -p /etc/kubernetes/manifests \
  && echo "Adjusting systemd-tmpfiles timer" \

--- a/hack/kicbase_version/os-package-list.txt
+++ b/hack/kicbase_version/os-package-list.txt
@@ -1,239 +1,231 @@
 Desired=Unknown/Install/Remove/Purge/Hold
 | Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
 |/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
-||/ Name                            Version                        Architecture Description
-+++-===============================-==============================-============-========================================================================================
-ii  adduser                         3.134                          all          add and remove users and groups
-ii  apt                             2.6.1                          amd64        commandline package manager
-ii  base-files                      12.4+deb12u15                  amd64        Debian base system miscellaneous files
-ii  base-passwd                     3.6.1                          amd64        Debian base system master password and group files
-ii  bash                            5.2.15-2+b13                   amd64        GNU Bourne Again SHell
-ii  bind9-dnsutils                  1:9.18.49-1~deb12u2            amd64        Clients provided with BIND 9
-ii  bind9-host                      1:9.18.49-1~deb12u2            amd64        DNS Lookup Utility
-ii  bind9-libs:amd64                1:9.18.49-1~deb12u2            amd64        Shared Libraries used by BIND 9
-ii  bsdutils                        1:2.38.1-5+deb12u3             amd64        basic utilities from 4.4BSD-Lite
-ii  ca-certificates                 20250419~deb12u1               all          Common CA certificates
-ii  catatonit                       0.1.7-1+b2                     amd64        init process for containers
-ii  conmon                          2.1.6+ds1-1                    amd64        OCI container runtime monitor
-ii  conntrack                       1:1.4.7-1+b2                   amd64        Program to modify the conntrack tables
-ii  containerd.io                   2.3.4-2~debian.12~bookworm     amd64        An open and reliable container runtime
-ii  containernetworking-plugins     1.1.1+ds1-3+b5                 amd64        standard networking plugins - binaries
-ii  coreutils                       9.1-1                          amd64        GNU core utilities
-ii  cri-o                           1.35.8-1.1                     amd64        Open Container Initiative-based implementation of Kubernetes Container Runtime Interface
-ii  crun                            1.8.1-1+deb12u1                amd64        lightweight OCI runtime for running containers
-ii  curl                            7.88.1-10+deb12u15             amd64        command line tool for transferring data with URL syntax
-ii  dash                            0.5.12-2                       amd64        POSIX-compliant shell
-ii  dbus                            1.14.10-1~deb12u1              amd64        simple interprocess messaging system (system message bus)
-ii  dbus-bin                        1.14.10-1~deb12u1              amd64        simple interprocess messaging system (command line utilities)
-ii  dbus-daemon                     1.14.10-1~deb12u1              amd64        simple interprocess messaging system (reference message bus)
-ii  dbus-session-bus-common         1.14.10-1~deb12u1              all          simple interprocess messaging system (session bus configuration)
-ii  dbus-system-bus-common          1.14.10-1~deb12u1              all          simple interprocess messaging system (system bus configuration)
-ii  debconf                         1.5.82                         all          Debian configuration management system
-ii  debian-archive-keyring          2023.3+deb12u2                 all          GnuPG archive keys of the Debian archive
-ii  debianutils                     5.7-0.5~deb12u1                amd64        Miscellaneous utilities specific to Debian
-ii  diffutils                       1:3.8-4                        amd64        File comparison utilities
-ii  dirmngr                         2.2.40-1.1+deb12u2             amd64        GNU privacy guard - network certificate management service
-ii  dmsetup                         2:1.02.185-2                   amd64        Linux Kernel Device Mapper userspace library
-ii  dnsutils                        1:9.18.49-1~deb12u2            all          Transitional package for bind9-dnsutils
-ii  docker-buildx-plugin            0.37.0-1~debian.12~bookworm    amd64        Docker Buildx plugin extends build capabilities with BuildKit.
-ii  docker-ce                       5:29.8.0-1~debian.12~bookworm  amd64        Docker: the open-source application container engine
-ii  docker-ce-cli                   5:29.8.0-1~debian.12~bookworm  amd64        Docker CLI: the open-source application container engine
-ii  dpkg                            1.21.23                        amd64        Debian package management system
-ii  e2fsprogs                       1.47.0-2+b2                    amd64        ext2/ext3/ext4 file system utilities
-ii  ebtables                        2.0.11-5                       amd64        Ethernet bridge frame table administration
-ii  ethtool                         1:6.1-1                        amd64        display or change Ethernet device settings
-ii  findutils                       4.9.0-4                        amd64        utilities for finding files--find, xargs
-ii  gcc-12-base:amd64               12.2.0-14+deb12u1              amd64        GCC, the GNU Compiler Collection (base package)
-ii  gnupg                           2.2.40-1.1+deb12u2             all          GNU privacy guard - a free PGP replacement
-ii  gnupg-l10n                      2.2.40-1.1+deb12u2             all          GNU privacy guard - localization files
-ii  gnupg-utils                     2.2.40-1.1+deb12u2             amd64        GNU privacy guard - utility programs
-ii  golang-github-containers-common 0.50.1+ds1-4                   all          Common files for github.com/containers repositories
-ii  golang-github-containers-image  5.23.1-4                       all          Configuration files and manpages for github.com/containers repositories
-ii  gpg                             2.2.40-1.1+deb12u2             amd64        GNU Privacy Guard -- minimalist public key operations
-ii  gpg-agent                       2.2.40-1.1+deb12u2             amd64        GNU privacy guard - cryptographic agent
-ii  gpg-wks-client                  2.2.40-1.1+deb12u2             amd64        GNU privacy guard - Web Key Service client
-ii  gpg-wks-server                  2.2.40-1.1+deb12u2             amd64        GNU privacy guard - Web Key Service server
-ii  gpgconf                         2.2.40-1.1+deb12u2             amd64        GNU privacy guard - core configuration utilities
-ii  gpgsm                           2.2.40-1.1+deb12u2             amd64        GNU privacy guard - S/MIME version
-ii  gpgv                            2.2.40-1.1+deb12u2             amd64        GNU privacy guard - signature verification tool
-ii  grep                            3.8-5                          amd64        GNU grep, egrep and fgrep
-ii  gzip                            1.12-1                         amd64        GNU compression utilities
-ii  hostname                        3.23+nmu1                      amd64        utility to set/show the host name or domain name
-ii  init-system-helpers             1.65.2+deb12u1                 all          helper tools for all init systems
-ii  iproute2                        6.1.0-3                        amd64        networking and traffic control tools
-ii  iptables                        1.8.9-2                        amd64        administration tools for packet filtering and NAT
-ii  iputils-ping                    3:20221126-1+deb12u1           amd64        Tools to test the reachability of network hosts
-ii  keyutils                        1.6.3-2                        amd64        Linux Key Management Utilities
-ii  kmod                            30+20221128-1                  amd64        tools for managing Linux kernel modules
-ii  libacl1:amd64                   2.3.1-3                        amd64        access control list - shared library
-ii  libapparmor1:amd64              3.0.8-3                        amd64        changehat AppArmor library
-ii  libapt-pkg6.0:amd64             2.6.1                          amd64        package management runtime library
-ii  libargon2-1:amd64               0~20171227-0.3+deb12u1         amd64        memory-hard hashing function - runtime library
-ii  libassuan0:amd64                2.5.5-5                        amd64        IPC library for the GnuPG components
-ii  libattr1:amd64                  1:2.5.1-4                      amd64        extended attribute handling - shared library
-ii  libaudit-common                 1:3.0.9-1                      all          Dynamic library for security auditing - common files
-ii  libaudit1:amd64                 1:3.0.9-1                      amd64        Dynamic library for security auditing
-ii  libblkid1:amd64                 2.38.1-5+deb12u3               amd64        block device ID library
-ii  libbpf1:amd64                   1:1.1.2-0+deb12u1              amd64        eBPF helper library (shared library)
-ii  libbrotli1:amd64                1.0.9-2+b6                     amd64        library implementing brotli encoder and decoder (shared libraries)
-ii  libbsd0:amd64                   0.11.7-2                       amd64        utility functions from BSD systems - shared library
-ii  libbz2-1.0:amd64                1.0.8-5+b1                     amd64        high-quality block-sorting file compressor library - runtime
-ii  libc-bin                        2.36-9+deb12u14                amd64        GNU C Library: Binaries
-ii  libc6:amd64                     2.36-9+deb12u14                amd64        GNU C Library: Shared libraries
-ii  libcap-ng0:amd64                0.8.3-1+b3                     amd64        alternate POSIX capabilities library
-ii  libcap2:amd64                   1:2.66-4+deb12u3+b1            amd64        POSIX 1003.1e capabilities (library)
-ii  libcap2-bin                     1:2.66-4+deb12u3+b1            amd64        POSIX 1003.1e capabilities (utilities)
-ii  libcbor0.8:amd64                0.8.0-2+b1                     amd64        library for parsing and generating CBOR (RFC 7049)
-ii  libcom-err2:amd64               1.47.0-2+b2                    amd64        common error description library
-ii  libcrypt1:amd64                 1:4.4.33-2                     amd64        libcrypt shared library
-ii  libcryptsetup12:amd64           2:2.6.1-4~deb12u2              amd64        disk encryption support - shared library
-ii  libcurl4:amd64                  7.88.1-10+deb12u15             amd64        easy-to-use client-side URL transfer library (OpenSSL flavour)
-ii  libdb5.3:amd64                  5.3.28+dfsg2-1                 amd64        Berkeley v5.3 Database Libraries [runtime]
-ii  libdbus-1-3:amd64               1.14.10-1~deb12u1              amd64        simple interprocess messaging system (library)
-ii  libdebconfclient0:amd64         0.270                          amd64        Debian Configuration Management System (C-implementation library)
-ii  libdevmapper1.02.1:amd64        2:1.02.185-2                   amd64        Linux Kernel Device Mapper userspace library
-ii  libedit2:amd64                  3.1-20221030-2                 amd64        BSD editline and history libraries
-ii  libelf1:amd64                   0.188-2.1                      amd64        library to read and write ELF files
-ii  libevent-core-2.1-7:amd64       2.1.12-stable-8                amd64        Asynchronous event notification library (core)
-ii  libexpat1:amd64                 2.5.0-1+deb12u3                amd64        XML parsing C library - runtime library
-ii  libext2fs2:amd64                1.47.0-2+b2                    amd64        ext2/ext3/ext4 file system libraries
-ii  libfdisk1:amd64                 2.38.1-5+deb12u3               amd64        fdisk partitioning library
-ii  libffi8:amd64                   3.4.4-1                        amd64        Foreign Function Interface library runtime
-ii  libfido2-1:amd64                1.12.0-2+b1                    amd64        library for generating and verifying FIDO 2.0 objects
-ii  libfstrm0:amd64                 0.6.1-1                        amd64        Frame Streams (fstrm) library
-ii  libgcc-s1:amd64                 12.2.0-14+deb12u1              amd64        GCC support library
-ii  libgcrypt20:amd64               1.10.1-3+deb12u1               amd64        LGPL Crypto library - runtime library
-ii  libglib2.0-0:amd64              2.74.6-2+deb12u9               amd64        GLib library of C routines
-ii  libgmp10:amd64                  2:6.2.1+dfsg1-1.1              amd64        Multiprecision arithmetic library
-ii  libgnutls30:amd64               3.7.9-2+deb12u7                amd64        GNU TLS library - main runtime library
-ii  libgpg-error0:amd64             1.46-1                         amd64        GnuPG development runtime library
-ii  libgpgme11:amd64                1.18.0-3+b1                    amd64        GPGME - GnuPG Made Easy (library)
-ii  libgssapi-krb5-2:amd64          1.20.1-2+deb12u5               amd64        MIT Kerberos runtime libraries - krb5 GSS-API Mechanism
-ii  libhogweed6:amd64               3.8.1-2                        amd64        low level cryptographic library (public-key cryptos)
-ii  libicu72:amd64                  72.1-3+deb12u1                 amd64        International Components for Unicode
-ii  libidn2-0:amd64                 2.3.3-1+b1                     amd64        Internationalized domain names (IDNA2008/TR46) library
-ii  libip4tc2:amd64                 1.8.9-2                        amd64        netfilter libip4tc library
-ii  libip6tc2:amd64                 1.8.9-2                        amd64        netfilter libip6tc library
-ii  libjansson4:amd64               2.14-2                         amd64        C library for encoding, decoding and manipulating JSON data
-ii  libjemalloc2:amd64              5.3.0-1                        amd64        general-purpose scalable concurrent malloc(3) implementation
-ii  libjson-c5:amd64                0.16-2                         amd64        JSON manipulation library - shared library
-ii  libk5crypto3:amd64              1.20.1-2+deb12u5               amd64        MIT Kerberos runtime libraries - Crypto Library
-ii  libkeyutils1:amd64              1.6.3-2                        amd64        Linux Key Management Utilities (library)
-ii  libkmod2:amd64                  30+20221128-1                  amd64        libkmod shared library
-ii  libkrb5-3:amd64                 1.20.1-2+deb12u5               amd64        MIT Kerberos runtime libraries
-ii  libkrb5support0:amd64           1.20.1-2+deb12u5               amd64        MIT Kerberos runtime libraries - Support library
-ii  libksba8:amd64                  1.6.3-2                        amd64        X.509 and CMS support library
-ii  libldap-2.5-0:amd64             2.5.13+dfsg-5                  amd64        OpenLDAP libraries
-ii  liblmdb0:amd64                  0.9.24-1                       amd64        Lightning Memory-Mapped Database shared library
-ii  liblz4-1:amd64                  1.9.4-1                        amd64        Fast LZ compression algorithm library - runtime
-ii  liblzma5:amd64                  5.4.1-1+deb12u1                amd64        XZ-format compression library
-ii  libmaxminddb0:amd64             1.7.1-1                        amd64        IP geolocation database library
-ii  libmd0:amd64                    1.0.4-2                        amd64        message digest functions from BSD systems - shared library
-ii  libmnl0:amd64                   1.0.4-3                        amd64        minimalistic Netlink communication library
-ii  libmount1:amd64                 2.38.1-5+deb12u3               amd64        device mounting library
-ii  libncursesw6:amd64              6.4-4                          amd64        shared libraries for terminal handling (wide character support)
-ii  libnetfilter-conntrack3:amd64   1.0.9-3                        amd64        Netfilter netlink-conntrack library
-ii  libnettle8:amd64                3.8.1-2                        amd64        low level cryptographic library (symmetric and one-way cryptos)
-ii  libnfnetlink0:amd64             1.0.2-2                        amd64        Netfilter netlink library
-ii  libnfsidmap1:amd64              1:2.6.2-4+deb12u1              amd64        NFS idmapping library
-ii  libnftables1:amd64              1.0.6-2+deb12u2                amd64        Netfilter nftables high level userspace API library
-ii  libnftnl11:amd64                1.2.4-2                        amd64        Netfilter nftables userspace API library
-ii  libnghttp2-14:amd64             1.52.0-1+deb12u3               amd64        library implementing HTTP/2 protocol (shared library)
-ii  libnpth0:amd64                  1.6-3                          amd64        replacement for GNU Pth using system threads
-ii  libnsl2:amd64                   1.3.0-2                        amd64        Public client interface for NIS(YP) and NIS+
-ii  libnvidia-container-tools       1.20.0-1                       amd64        NVIDIA container runtime library (command-line tools)
-ii  libnvidia-container1:amd64      1.20.0-1                       amd64        NVIDIA container runtime library
-ii  libp11-kit0:amd64               0.24.1-2                       amd64        library for loading and coordinating access to PKCS#11 modules - runtime
-ii  libpam-modules:amd64            1.5.2-6+deb12u2                amd64        Pluggable Authentication Modules for PAM
-ii  libpam-modules-bin              1.5.2-6+deb12u2                amd64        Pluggable Authentication Modules for PAM - helper binaries
-ii  libpam-runtime                  1.5.2-6+deb12u2                all          Runtime support for the PAM library
-ii  libpam0g:amd64                  1.5.2-6+deb12u2                amd64        Pluggable Authentication Modules library
-ii  libpcre2-8-0:amd64              10.42-1                        amd64        New Perl Compatible Regular Expression Library- 8 bit runtime files
-ii  libpopt0:amd64                  1.19+dfsg-1                    amd64        lib for parsing cmdline parameters
-ii  libproc2-0:amd64                2:4.0.2-3                      amd64        library for accessing process information from /proc
-ii  libprotobuf-c1:amd64            1.4.1-1+b1                     amd64        Protocol Buffers C shared library (protobuf-c)
-ii  libpsl5:amd64                   0.21.2-1                       amd64        Library for Public Suffix List (shared libraries)
-ii  libpython3-stdlib:amd64         3.11.2-1+b1                    amd64        interactive high-level object-oriented language (default python3 version)
-ii  libpython3.11-minimal:amd64     3.11.2-6+deb12u8               amd64        Minimal subset of the Python language (version 3.11)
-ii  libpython3.11-stdlib:amd64      3.11.2-6+deb12u8               amd64        Interactive high-level object-oriented language (standard library, version 3.11)
-ii  libreadline8:amd64              8.2-1.3                        amd64        GNU readline and history libraries, run-time libraries
-ii  librtmp1:amd64                  2.4+20151223.gitfa8646d.1-2+b2 amd64        toolkit for RTMP streams (shared library)
-ii  libsasl2-2:amd64                2.1.28+dfsg-10                 amd64        Cyrus SASL - authentication abstraction library
-ii  libsasl2-modules-db:amd64       2.1.28+dfsg-10                 amd64        Cyrus SASL - pluggable authentication modules (DB)
-ii  libseccomp2:amd64               2.5.4-1+deb12u1                amd64        high level interface to Linux seccomp filter
-ii  libselinux1:amd64               3.4-1+b6                       amd64        SELinux runtime shared libraries
-ii  libsemanage-common              3.4-1                          all          Common files for SELinux policy management libraries
-ii  libsemanage2:amd64              3.4-1+b5                       amd64        SELinux policy management library
-ii  libsepol2:amd64                 3.4-2.1                        amd64        SELinux library for manipulating binary security policies
-ii  libsmartcols1:amd64             2.38.1-5+deb12u3               amd64        smart column output alignment library
-ii  libsqlite3-0:amd64              3.40.1-2+deb12u2               amd64        SQLite 3 shared library
-ii  libss2:amd64                    1.47.0-2+b2                    amd64        command-line interface parsing library
-ii  libssh2-1:amd64                 1.10.0-3+deb12u1               amd64        SSH2 client-side library
-ii  libssl3:amd64                   3.0.20-1~deb12u2               amd64        Secure Sockets Layer toolkit - shared libraries
-ii  libstdc++6:amd64                12.2.0-14+deb12u1              amd64        GNU Standard C++ Library v3
-ii  libsubid4:amd64                 1:4.13+dfsg1-1+deb12u2         amd64        subordinate id handling library -- shared library
-ii  libsystemd-shared:amd64         252.39-1~deb12u2               amd64        systemd shared private library
-ii  libsystemd0:amd64               252.39-1~deb12u2               amd64        systemd utility library
-ii  libtasn1-6:amd64                4.19.0-2+deb12u1               amd64        Manage ASN.1 structures (runtime)
-ii  libtinfo6:amd64                 6.4-4                          amd64        shared low-level terminfo library for terminal handling
-ii  libtirpc-common                 1.3.3+ds-1                     all          transport-independent RPC library - common files
-ii  libtirpc3:amd64                 1.3.3+ds-1                     amd64        transport-independent RPC library
-ii  libudev1:amd64                  252.39-1~deb12u2               amd64        libudev shared library
-ii  libunistring2:amd64             1.0-2                          amd64        Unicode string library for C
-ii  libuuid1:amd64                  2.38.1-5+deb12u3               amd64        Universally Unique ID library
-ii  libuv1:amd64                    1.44.2-1+deb12u1               amd64        asynchronous event notification library - runtime library
-ii  libwrap0:amd64                  7.6.q-32                       amd64        Wietse Venema's TCP wrappers library
-ii  libxml2:amd64                   2.9.14+dfsg-1.3~deb12u6        amd64        GNOME XML library
-ii  libxtables12:amd64              1.8.9-2                        amd64        netfilter xtables library
-ii  libxxhash0:amd64                0.8.1-1                        amd64        shared library for xxhash
-ii  libyajl2:amd64                  2.1.0-3+deb12u2                amd64        Yet Another JSON Library
-ii  libzstd1:amd64                  1.5.4+dfsg2-5                  amd64        fast lossless compression algorithm
-ii  login                           1:4.13+dfsg1-1+deb12u2         amd64        system login tools
-ii  logsave                         1.47.0-2+b2                    amd64        save the output of a command in a log file
-ii  lz4                             1.9.4-1                        amd64        Fast LZ compression algorithm library - tool
-ii  mawk                            1.3.4.20200120-3.1             amd64        Pattern scanning and text processing language
-ii  media-types                     10.0.0                         all          List of standard media types and their usual file extension
-ii  mount                           2.38.1-5+deb12u3               amd64        tools for mounting and manipulating filesystems
-ii  ncurses-base                    6.4-4                          all          basic terminal type definitions
-ii  ncurses-bin                     6.4-4                          amd64        terminal-related programs and man pages
-ii  netbase                         6.4                            all          Basic TCP/IP networking system
-ii  netcat-openbsd                  1.219-1                        amd64        TCP/IP swiss army knife
-ii  nfs-common                      1:2.6.2-4+deb12u1              amd64        NFS support files common to client and server
-ii  nftables                        1.0.6-2+deb12u2                amd64        Program to control packet filtering rules by Netfilter project
-ii  nvidia-container-toolkit        1.20.0-1                       amd64        NVIDIA Container toolkit
-ii  nvidia-container-toolkit-base   1.20.0-1                       amd64        NVIDIA Container Toolkit Base
-ii  openssh-client                  1:9.2p1-2+deb12u10             amd64        secure shell (SSH) client, for secure access to remote machines
-ii  openssh-server                  1:9.2p1-2+deb12u10             amd64        secure shell (SSH) server, for secure access from remote machines
-ii  openssh-sftp-server             1:9.2p1-2+deb12u10             amd64        secure shell (SSH) sftp server module, for SFTP access from remote machines
-ii  openssl                         3.0.20-1~deb12u2               amd64        Secure Sockets Layer toolkit - cryptographic utility
-ii  passwd                          1:4.13+dfsg1-1+deb12u2         amd64        change and administer password and group data
-ii  perl-base                       5.36.0-7+deb12u3               amd64        minimal Perl system
-ii  pigz                            2.6-1                          amd64        Parallel Implementation of GZip
-ii  pinentry-curses                 1.2.1-1                        amd64        curses-based PIN or pass-phrase entry dialog for GnuPG
-ii  podman                          4.3.1+ds1-8+deb12u1+b3         amd64        engine to run OCI-based containers in Pods
-ii  procps                          2:4.0.2-3                      amd64        /proc file system utilities
-ii  python3                         3.11.2-1+b1                    amd64        interactive high-level object-oriented language (default python3 version)
-ii  python3-minimal                 3.11.2-1+b1                    amd64        minimal subset of the Python language (default python3 version)
-ii  python3.11                      3.11.2-6+deb12u8               amd64        Interactive high-level object-oriented language (version 3.11)
-ii  python3.11-minimal              3.11.2-6+deb12u8               amd64        Minimal subset of the Python language (version 3.11)
-ii  readline-common                 8.2-1.3                        all          GNU readline and history libraries, common files
-ii  rpcbind                         1.2.6-6+b1                     amd64        converts RPC program numbers into universal addresses
-ii  rsync                           3.2.7-1+deb12u6                amd64        fast, versatile, remote (and local) file-copying tool
-ii  runit-helper                    2.15.2                         all          dh-runit implementation detail
-ii  sed                             4.9-1+deb12u1                  amd64        GNU stream editor for filtering/transforming text
-ii  sensible-utils                  0.0.17+nmu1                    all          Utilities for sensible alternative selection
-ii  socat                           1.7.4.4-2                      amd64        multipurpose relay for bidirectional data transfer
-ii  sudo                            1.9.13p3-1+deb12u4             amd64        Provide limited super user privileges to specific users
-ii  systemd                         252.39-1~deb12u2               amd64        system and service manager
-ii  systemd-sysv                    252.39-1~deb12u2               amd64        system and service manager - SysV compatibility symlinks
-ii  sysvinit-utils                  3.06-4                         amd64        System-V-like utilities
-ii  tar                             1.34+dfsg-1.2+deb12u1          amd64        GNU version of the tar archiving utility
-ii  tzdata                          2026b-0+deb12u1                all          time zone and daylight-saving time data
-ii  ucf                             3.0043+nmu1+deb12u1            all          Update Configuration File(s): preserve user changes to config files
-ii  udev                            252.39-1~deb12u2               amd64        /dev/ and hotplug management daemon
-ii  usr-is-merged                   37~deb12u1                     all          Transitional package to assert a merged-/usr system
-ii  util-linux                      2.38.1-5+deb12u3               amd64        miscellaneous system utilities
-ii  util-linux-extra                2.38.1-5+deb12u3               amd64        interactive login tools
-ii  vim-common                      2:9.0.1378-2+deb12u2           all          Vi IMproved - Common files
-ii  vim-tiny                        2:9.0.1378-2+deb12u2           amd64        Vi IMproved - enhanced vi editor - compact version
-ii  zlib1g:amd64                    1:1.2.13.dfsg-1                amd64        compression library - runtime
+||/ Name                            Version                              Architecture Description
++++-===============================-====================================-============-========================================================================================
+ii  adduser                         3.152                                all          add and remove users and groups
+ii  apt                             3.0.3                                amd64        commandline package manager
+ii  base-files                      13.8+deb13u6                         amd64        Debian base system miscellaneous files
+ii  base-passwd                     3.6.7                                amd64        Debian base system master password and group files
+ii  bash                            5.2.37-2+b9                          amd64        GNU Bourne Again SHell
+ii  bind9-dnsutils                  1:9.20.26-1~deb13u1                  amd64        Clients provided with BIND 9
+ii  bind9-host                      1:9.20.26-1~deb13u1                  amd64        DNS Lookup Utility
+ii  bind9-libs:amd64                1:9.20.26-1~deb13u1                  amd64        Shared Libraries used by BIND 9
+ii  bsdutils                        1:2.41.5-0+deb13u1                   amd64        basic utilities from 4.4BSD-Lite
+ii  ca-certificates                 20250419                             all          Common CA certificates
+ii  catatonit                       0.2.1-2+b13                          amd64        init process for containers
+ii  conmon                          2.1.12-4                             amd64        OCI container runtime monitor
+ii  conntrack                       1:1.4.8-2                            amd64        Program to modify the conntrack tables
+ii  containerd.io                   2.3.4-2~debian.13~trixie             amd64        An open and reliable container runtime
+ii  containernetworking-plugins     1.1.1+ds1-3+b17                      amd64        standard networking plugins - binaries
+ii  coreutils                       9.7-3                                amd64        GNU core utilities
+ii  cri-o                           1.35.8-1.1                           amd64        Open Container Initiative-based implementation of Kubernetes Container Runtime Interface
+ii  crun                            1.21-1                               amd64        lightweight OCI runtime for running containers
+ii  curl                            8.14.1-2+deb13u4                     amd64        command line tool for transferring data with URL syntax
+ii  dash                            0.5.12-12                            amd64        POSIX-compliant shell
+ii  dbus                            1.16.2-2                             amd64        simple interprocess messaging system (system message bus)
+ii  dbus-bin                        1.16.2-2                             amd64        simple interprocess messaging system (command line utilities)
+ii  dbus-daemon                     1.16.2-2                             amd64        simple interprocess messaging system (reference message bus)
+ii  dbus-session-bus-common         1.16.2-2                             all          simple interprocess messaging system (session bus configuration)
+ii  dbus-system-bus-common          1.16.2-2                             all          simple interprocess messaging system (system bus configuration)
+ii  debconf                         1.5.91                               all          Debian configuration management system
+ii  debian-archive-keyring          2025.1                               all          OpenPGP archive certificates of the Debian archive
+ii  debianutils                     5.23.2                               amd64        Miscellaneous utilities specific to Debian
+ii  diffutils                       1:3.10-4                             amd64        File comparison utilities
+ii  dirmngr                         2.4.7-21+deb13u1+b4                  amd64        GNU privacy guard - network certificate management service
+ii  dmsetup                         2:1.02.205-2                         amd64        Linux Kernel Device Mapper userspace library
+ii  docker-buildx-plugin            0.37.0-1~debian.13~trixie            amd64        Docker Buildx plugin extends build capabilities with BuildKit.
+ii  docker-ce                       5:29.8.0-1~debian.13~trixie          amd64        Docker: the open-source application container engine
+ii  docker-ce-cli                   5:29.8.0-1~debian.13~trixie          amd64        Docker CLI: the open-source application container engine
+ii  dpkg                            1.22.22                              amd64        Debian package management system
+ii  ebtables                        2.0.11-6                             amd64        Ethernet bridge frame table administration
+ii  ethtool                         1:6.14.2-1                           amd64        display or change Ethernet device settings
+ii  findutils                       4.10.0-3                             amd64        utilities for finding files--find, xargs
+ii  gcc-14-base:amd64               14.2.0-19                            amd64        GCC, the GNU Compiler Collection (base package)
+ii  gnupg                           2.4.7-21+deb13u1                     all          GNU privacy guard - a free PGP replacement
+ii  gnupg-l10n                      2.4.7-21+deb13u1                     all          GNU privacy guard - localization files
+ii  golang-github-containers-common 0.62.2+ds1-2                         all          Common files for github.com/containers repositories
+ii  golang-github-containers-image  5.34.2-1                             all          Configuration files and manpages for github.com/containers repositories
+ii  gpg                             2.4.7-21+deb13u1+b4                  amd64        GNU Privacy Guard -- minimalist public key operations
+ii  gpg-agent                       2.4.7-21+deb13u1+b4                  amd64        GNU privacy guard - cryptographic agent
+ii  gpgconf                         2.4.7-21+deb13u1+b4                  amd64        GNU privacy guard - core configuration utilities
+ii  gpgsm                           2.4.7-21+deb13u1+b4                  amd64        GNU privacy guard - S/MIME version
+ii  grep                            3.11-4                               amd64        GNU grep, egrep and fgrep
+ii  gzip                            1.13-1                               amd64        GNU compression utilities
+ii  hostname                        3.25                                 amd64        utility to set/show the host name or domain name
+ii  init-system-helpers             1.69~deb13u1                         all          helper tools for all init systems
+ii  iproute2                        6.15.0-1                             amd64        networking and traffic control tools
+ii  iptables                        1.8.11-2                             amd64        administration tools for packet filtering and NAT
+ii  iputils-ping                    3:20240905-3                         amd64        Tools to test the reachability of network hosts
+ii  keyutils                        1.6.3-6                              amd64        Linux Key Management Utilities
+ii  kmod                            34.2-2                               amd64        tools for managing Linux kernel modules
+ii  libacl1:amd64                   2.3.2-2+b1                           amd64        access control list - shared library
+ii  libapparmor1:amd64              4.1.0-1                              amd64        changehat AppArmor library
+ii  libapt-pkg7.0:amd64             3.0.3                                amd64        package management runtime library
+ii  libassuan9:amd64                3.0.2-2                              amd64        IPC library for the GnuPG components
+ii  libatomic1:amd64                14.2.0-19                            amd64        support library providing __atomic built-in functions
+ii  libattr1:amd64                  1:2.5.2-3                            amd64        extended attribute handling - shared library
+ii  libaudit-common                 1:4.0.2-2                            all          Dynamic library for security auditing - common files
+ii  libaudit1:amd64                 1:4.0.2-2+b2                         amd64        Dynamic library for security auditing
+ii  libblkid1:amd64                 2.41.5-0+deb13u1                     amd64        block device ID library
+ii  libbpf1:amd64                   1:1.5.0-3                            amd64        eBPF helper library (shared library)
+ii  libbrotli1:amd64                1.1.0-2+b7                           amd64        library implementing brotli encoder and decoder (shared libraries)
+ii  libbsd0:amd64                   0.12.2-2                             amd64        utility functions from BSD systems - shared library
+ii  libbz2-1.0:amd64                1.0.8-6                              amd64        high-quality block-sorting file compressor library - runtime
+ii  libc-bin                        2.41-12+deb13u3                      amd64        GNU C Library: Binaries
+ii  libc6:amd64                     2.41-12+deb13u3                      amd64        GNU C Library: Shared libraries
+ii  libcap-ng0:amd64                0.8.5-4+b1                           amd64        alternate POSIX capabilities library
+ii  libcap2:amd64                   1:2.75-10+deb13u1+b1                 amd64        POSIX 1003.1e capabilities (library)
+ii  libcap2-bin                     1:2.75-10+deb13u1+b1                 amd64        POSIX 1003.1e capabilities (utilities)
+ii  libcbor0.10:amd64               0.10.2-2                             amd64        library for parsing and generating CBOR (RFC 7049)
+ii  libcom-err2:amd64               1.47.2-3+b11                         amd64        common error description library
+ii  libcrypt1:amd64                 1:4.4.38-1                           amd64        libcrypt shared library
+ii  libcurl4t64:amd64               8.14.1-2+deb13u4                     amd64        easy-to-use client-side URL transfer library (OpenSSL flavour)
+ii  libdb5.3t64:amd64               5.3.28+dfsg2-9                       amd64        Berkeley v5.3 Database Libraries [runtime]
+ii  libdbus-1-3:amd64               1.16.2-2                             amd64        simple interprocess messaging system (library)
+ii  libdebconfclient0:amd64         0.280                                amd64        Debian Configuration Management System (C-implementation library)
+ii  libdevmapper1.02.1:amd64        2:1.02.205-2                         amd64        Linux Kernel Device Mapper userspace library
+ii  libedit2:amd64                  3.1-20250104-1                       amd64        BSD editline and history libraries
+ii  libelf1t64:amd64                0.192-4                              amd64        library to read and write ELF files
+ii  libevent-core-2.1-7t64:amd64    2.1.12-stable-10+b1                  amd64        Asynchronous event notification library (core)
+ii  libexpat1:amd64                 2.8.3-1~deb13u1                      amd64        XML parsing C library - runtime library
+ii  libffi8:amd64                   3.4.8-2                              amd64        Foreign Function Interface library runtime
+ii  libfido2-1:amd64                1.15.0-1+b1                          amd64        library for generating and verifying FIDO 2.0 objects
+ii  libfstrm0:amd64                 0.6.1-1+b3                           amd64        Frame Streams (fstrm) library
+ii  libgcc-s1:amd64                 14.2.0-19                            amd64        GCC support library
+ii  libgcrypt20:amd64               1.11.0-7+deb13u1                     amd64        LGPL Crypto library - runtime library
+ii  libgdbm-compat4t64:amd64        1.24-2                               amd64        GNU dbm database routines (legacy support runtime version) 
+ii  libgdbm6t64:amd64               1.24-2                               amd64        GNU dbm database routines (runtime version) 
+ii  libglib2.0-0t64:amd64           2.84.4-3~deb13u3                     amd64        GLib library of C routines
+ii  libgmp10:amd64                  2:6.3.0+dfsg-3                       amd64        Multiprecision arithmetic library
+ii  libgnutls30t64:amd64            3.8.9-3+deb13u4                      amd64        GNU TLS library - main runtime library
+ii  libgpg-error0:amd64             1.51-4                               amd64        GnuPG development runtime library
+ii  libgpgme11t64:amd64             1.24.2-3                             amd64        GPGME - GnuPG Made Easy (library)
+ii  libgssapi-krb5-2:amd64          1.21.3-5+deb13u1                     amd64        MIT Kerberos runtime libraries - krb5 GSS-API Mechanism
+ii  libhogweed6t64:amd64            3.10.1-1                             amd64        low level cryptographic library (public-key cryptos)
+ii  libidn2-0:amd64                 2.3.8-2                              amd64        Internationalized domain names (IDNA2008/TR46) library
+ii  libip4tc2:amd64                 1.8.11-2                             amd64        netfilter libip4tc library
+ii  libip6tc2:amd64                 1.8.11-2                             amd64        netfilter libip6tc library
+ii  libjansson4:amd64               2.14-2+b3                            amd64        C library for encoding, decoding and manipulating JSON data
+ii  libjemalloc2:amd64              5.3.0-3                              amd64        general-purpose scalable concurrent malloc(3) implementation
+ii  libjson-c5:amd64                0.18+ds-1                            amd64        JSON manipulation library - shared library
+ii  libk5crypto3:amd64              1.21.3-5+deb13u1                     amd64        MIT Kerberos runtime libraries - Crypto Library
+ii  libkeyutils1:amd64              1.6.3-6                              amd64        Linux Key Management Utilities (library)
+ii  libkmod2:amd64                  34.2-2                               amd64        libkmod shared library
+ii  libkrb5-3:amd64                 1.21.3-5+deb13u1                     amd64        MIT Kerberos runtime libraries
+ii  libkrb5support0:amd64           1.21.3-5+deb13u1                     amd64        MIT Kerberos runtime libraries - Support library
+ii  libksba8:amd64                  1.6.7-2+b1                           amd64        X.509 and CMS support library
+ii  liblastlog2-2:amd64             2.41.5-0+deb13u1                     amd64        lastlog2 database shared library
+ii  libldap2:amd64                  2.6.10+dfsg-1                        amd64        OpenLDAP libraries
+ii  liblmdb0:amd64                  0.9.31-1+b2                          amd64        Lightning Memory-Mapped Database shared library
+ii  liblz4-1:amd64                  1.10.0-4                             amd64        Fast LZ compression algorithm library - runtime
+ii  liblzma5:amd64                  5.8.1-1+deb13u1                      amd64        XZ-format compression library
+ii  libmaxminddb0:amd64             1.12.2-1                             amd64        IP geolocation database library
+ii  libmd0:amd64                    1.1.0-2+b1                           amd64        message digest functions from BSD systems - shared library
+ii  libmnl0:amd64                   1.0.5-3                              amd64        minimalistic Netlink communication library
+ii  libmount1:amd64                 2.41.5-0+deb13u1                     amd64        device mounting library
+ii  libncursesw6:amd64              6.5+20250216-2                       amd64        shared libraries for terminal handling (wide character support)
+ii  libnetfilter-conntrack3:amd64   1.1.0-1                              amd64        Netfilter netlink-conntrack library
+ii  libnettle8t64:amd64             3.10.1-1                             amd64        low level cryptographic library (symmetric and one-way cryptos)
+ii  libnfnetlink0:amd64             1.0.2-3                              amd64        Netfilter netlink library
+ii  libnfsidmap1:amd64              1:2.8.3-1                            amd64        NFS idmapping library
+ii  libnftables1:amd64              1.1.3-1                              amd64        Netfilter nftables high level userspace API library
+ii  libnftnl11:amd64                1.2.9-1                              amd64        Netfilter nftables userspace API library
+ii  libnghttp2-14:amd64             1.64.0-1.1+deb13u1                   amd64        library implementing HTTP/2 protocol (shared library)
+ii  libnghttp3-9:amd64              1.8.0-1                              amd64        HTTP/3 library with QUIC and QPACK (library)
+ii  libnpth0t64:amd64               1.8-3                                amd64        replacement for GNU Pth using system threads
+ii  libnvidia-container-tools       1.20.0-1                             amd64        NVIDIA container runtime library (command-line tools)
+ii  libnvidia-container1:amd64      1.20.0-1                             amd64        NVIDIA container runtime library
+ii  libp11-kit0:amd64               0.25.5-3                             amd64        library for loading and coordinating access to PKCS#11 modules - runtime
+ii  libpam-modules:amd64            1.7.0-5                              amd64        Pluggable Authentication Modules for PAM
+ii  libpam-modules-bin              1.7.0-5                              amd64        Pluggable Authentication Modules for PAM - helper binaries
+ii  libpam-runtime                  1.7.0-5                              all          Runtime support for the PAM library
+ii  libpam0g:amd64                  1.7.0-5                              amd64        Pluggable Authentication Modules library
+ii  libpcre2-8-0:amd64              10.46-1~deb13u1                      amd64        New Perl Compatible Regular Expression Library- 8 bit runtime files
+ii  libperl5.40:amd64               5.40.1-6                             amd64        shared Perl library
+ii  libpopt0:amd64                  1.19+dfsg-2                          amd64        lib for parsing cmdline parameters
+ii  libproc2-0:amd64                2:4.0.4-9                            amd64        library for accessing process information from /proc
+ii  libprotobuf-c1:amd64            1.5.1-1                              amd64        Protocol Buffers C shared library (protobuf-c)
+ii  libpsl5t64:amd64                0.21.2-1.1+b1                        amd64        Library for Public Suffix List (shared libraries)
+ii  libreadline8t64:amd64           8.2-6                                amd64        GNU readline and history libraries, run-time libraries
+ii  librtmp1:amd64                  2.4+20151223.gitfa8646d.1-2+b5       amd64        toolkit for RTMP streams (shared library)
+ii  libsasl2-2:amd64                2.1.28+dfsg1-9                       amd64        Cyrus SASL - authentication abstraction library
+ii  libsasl2-modules-db:amd64       2.1.28+dfsg1-9                       amd64        Cyrus SASL - pluggable authentication modules (DB)
+ii  libseccomp2:amd64               2.6.0-2                              amd64        high level interface to Linux seccomp filter
+ii  libselinux1:amd64               3.8.1-1                              amd64        SELinux runtime shared libraries
+ii  libsemanage-common              3.8.1-1                              all          Common files for SELinux policy management libraries
+ii  libsemanage2:amd64              3.8.1-1                              amd64        SELinux policy management library
+ii  libsepol2:amd64                 3.8.1-1                              amd64        SELinux library for manipulating binary security policies
+ii  libsmartcols1:amd64             2.41.5-0+deb13u1                     amd64        smart column output alignment library
+ii  libsqlite3-0:amd64              3.46.1-7+deb13u1                     amd64        SQLite 3 shared library
+ii  libssh2-1t64:amd64              1.11.1-1+deb13u1                     amd64        SSH2 client-side library
+ii  libssl3t64:amd64                3.5.7-1~deb13u2                      amd64        Secure Sockets Layer toolkit - shared libraries
+ii  libstdc++6:amd64                14.2.0-19                            amd64        GNU Standard C++ Library v3
+ii  libsubid5:amd64                 1:4.17.4-2                           amd64        subordinate id handling library -- shared library
+ii  libsystemd-shared:amd64         257.13-1~deb13u1                     amd64        systemd shared private library
+ii  libsystemd0:amd64               257.13-1~deb13u1                     amd64        systemd utility library
+ii  libtasn1-6:amd64                4.20.0-2+deb13u1                     amd64        Manage ASN.1 structures (runtime)
+ii  libtext-charwidth-perl:amd64    0.04-11+b4                           amd64        get display widths of characters on the terminal
+ii  libtext-wrapi18n-perl           0.06-10                              all          internationalized substitute of Text::Wrap
+ii  libtinfo6:amd64                 6.5+20250216-2                       amd64        shared low-level terminfo library for terminal handling
+ii  libtirpc-common                 1.3.6+ds-1                           all          transport-independent RPC library - common files
+ii  libtirpc3t64:amd64              1.3.6+ds-1                           amd64        transport-independent RPC library
+ii  libudev1:amd64                  257.13-1~deb13u1                     amd64        libudev shared library
+ii  libunistring5:amd64             1.3-2                                amd64        Unicode string library for C
+ii  liburcu8t64:amd64               0.15.2-2                             amd64        userspace RCU (read-copy-update) library
+ii  libuuid1:amd64                  2.41.5-0+deb13u1                     amd64        Universally Unique ID library
+ii  libuv1t64:amd64                 1.50.0-2                             amd64        asynchronous event notification library - runtime library
+ii  libwrap0:amd64                  7.6.q-36                             amd64        Wietse Venema's TCP wrappers library
+ii  libwtmpdb0:amd64                0.73.0-3+deb13u1                     amd64        wtmp database shared library
+ii  libxml2:amd64                   2.12.7+dfsg+really2.9.14-2.1+deb13u3 amd64        GNOME XML library
+ii  libxtables12:amd64              1.8.11-2                             amd64        netfilter xtables library
+ii  libxxhash0:amd64                0.8.3-2                              amd64        shared library for xxhash
+ii  libyajl2:amd64                  2.1.0-5+b2                           amd64        Yet Another JSON Library
+ii  libzstd1:amd64                  1.5.7+dfsg-1                         amd64        fast lossless compression algorithm
+ii  login                           1:4.16.0-2+really2.41.5-0+deb13u1    amd64        system login tools
+ii  login.defs                      1:4.17.4-2                           all          system user management configuration
+ii  lz4                             1.10.0-4                             amd64        Fast LZ compression algorithm library - tool
+ii  mawk                            1.3.4.20250131-1                     amd64        Pattern scanning and text processing language
+ii  mount                           2.41.5-0+deb13u1                     amd64        tools for mounting and manipulating filesystems
+ii  ncurses-base                    6.5+20250216-2                       all          basic terminal type definitions
+ii  ncurses-bin                     6.5+20250216-2                       amd64        terminal-related programs and man pages
+ii  netavark                        1.14.0-2                             amd64        Rust based network stack for containers
+ii  netbase                         6.5                                  all          Basic TCP/IP networking system
+ii  netcat-openbsd                  1.229-1                              amd64        TCP/IP swiss army knife
+ii  nfs-common                      1:2.8.3-1                            amd64        NFS support files common to client and server
+ii  nftables                        1.1.3-1                              amd64        Program to control packet filtering rules by Netfilter project
+ii  nvidia-container-toolkit        1.20.0-1                             amd64        NVIDIA Container toolkit
+ii  nvidia-container-toolkit-base   1.20.0-1                             amd64        NVIDIA Container Toolkit Base
+ii  openssh-client                  1:10.0p1-7+deb13u4                   amd64        secure shell (SSH) client, for secure access to remote machines
+ii  openssh-server                  1:10.0p1-7+deb13u4                   amd64        secure shell (SSH) server, for secure access from remote machines
+ii  openssh-sftp-server             1:10.0p1-7+deb13u4                   amd64        secure shell (SSH) sftp server module, for SFTP access from remote machines
+ii  openssl                         3.5.7-1~deb13u2                      amd64        Secure Sockets Layer toolkit - cryptographic utility
+ii  openssl-provider-legacy         3.5.7-1~deb13u2                      amd64        Secure Sockets Layer toolkit - cryptographic utility
+ii  passwd                          1:4.17.4-2                           amd64        change and administer password and group data
+ii  perl                            5.40.1-6                             amd64        Larry Wall's Practical Extraction and Report Language
+ii  perl-base                       5.40.1-6                             amd64        minimal Perl system
+ii  perl-modules-5.40               5.40.1-6                             all          Core Perl modules
+ii  pigz                            2.8-1                                amd64        Parallel Implementation of GZip
+ii  pinentry-curses                 1.3.1-2                              amd64        curses-based PIN or pass-phrase entry dialog for GnuPG
+ii  podman                          5.4.2+ds1-2+b2                       amd64        tool to manage containers and pods
+ii  procps                          2:4.0.4-9                            amd64        /proc file system utilities
+ii  readline-common                 8.2-6                                all          GNU readline and history libraries, common files
+ii  rpcbind                         1.2.7-1                              amd64        converts RPC program numbers into universal addresses
+ii  rsync                           3.4.1+ds1-5+deb13u4                  amd64        fast, versatile, remote (and local) file-copying tool
+ii  runit-helper                    2.16.4                               all          dh-runit implementation detail
+ii  sed                             4.9-2+deb13u1                        amd64        GNU stream editor for filtering/transforming text
+ii  sensible-utils                  0.0.25                               all          Utilities for sensible alternative selection
+ii  socat                           1.8.0.3-1                            amd64        multipurpose relay for bidirectional data transfer
+ii  sqv                             1.3.0-3+b2                           amd64        OpenPGP signature verification program from Sequoia
+ii  sudo                            1.9.16p2-3+deb13u2                   amd64        Provide limited super user privileges to specific users
+ii  systemd                         257.13-1~deb13u1                     amd64        system and service manager
+ii  systemd-sysv                    257.13-1~deb13u1                     amd64        system and service manager - SysV compatibility symlinks
+ii  sysvinit-utils                  3.14-4                               amd64        System-V-like utilities
+ii  tar                             1.35+dfsg-3.1                        amd64        GNU version of the tar archiving utility
+ii  tzdata                          2026b-0+deb13u1                      all          time zone and daylight-saving time data
+ii  ucf                             3.0052                               all          Update Configuration File(s): preserve user changes to config files
+ii  udev                            257.13-1~deb13u1                     amd64        /dev/ and hotplug management daemon
+ii  util-linux                      2.41.5-0+deb13u1                     amd64        miscellaneous system utilities
+ii  vim-common                      2:9.1.1230-2                         all          Vi IMproved - Common files
+ii  vim-tiny                        2:9.1.1230-2                         amd64        Vi IMproved - enhanced vi editor - compact version
+ii  zlib1g:amd64                    1:1.3.dfsg+really1.3.1-1+b1          amd64        compression library - runtime

--- a/hack/update/debian_version/debian_version.go
+++ b/hack/update/debian_version/debian_version.go
@@ -36,30 +36,29 @@ var (
 	}
 )
 
-// Data holds latest Ubuntu jammy version in semver format.
+// Data holds the latest dated Debian slim tag.
 type Data struct {
 	LatestVersion string
 }
 
-// bookwormDateTag matches Debian bookworm slim tags that include an 8-digit
-// date stamp (for example, bookworm-20250929-slim).
-var bookwormDateTag = regexp.MustCompile(`^bookworm-\d{8}-slim$`)
+// dateTag matches the current Debian slim date-stamped tags
+// (for example, trixie-20260824-slim).
+var dateTag = regexp.MustCompile(`^trixie-\d{8}-slim$`)
 
-// latestBookwormSlimTag returns the newest bookworm slim tag that includes a
-// date suffix. The updater now requires a dated tag to be present so that the
-// resulting image digest remains stable and predictable between runs.
-func latestBookwormSlimTag(tags []string) (string, error) {
+// latestSlimTag returns the newest dated slim tag so the resulting
+// image digest stays stable between updater runs.
+func latestSlimTag(tags []string) (string, error) {
 	var newestDateTag string
 	for _, tag := range tags {
-		// Skip anything that isn't a bookworm slim tag to avoid matching other
+		// Skip anything that isn't a trixie slim tag to avoid matching other
 		// Debian variants.
-		if !strings.HasPrefix(tag, "bookworm-") || !strings.HasSuffix(tag, "-slim") {
+		if !strings.HasPrefix(tag, "trixie-") || !strings.HasSuffix(tag, "-slim") {
 			continue
 		}
 
 		// Track the lexicographically greatest dated tag, which corresponds to
 		// the most recent date stamp provided by Debian.
-		if bookwormDateTag.MatchString(tag) {
+		if dateTag.MatchString(tag) {
 			if newestDateTag == "" || tag > newestDateTag {
 				newestDateTag = tag
 			}
@@ -69,7 +68,7 @@ func latestBookwormSlimTag(tags []string) (string, error) {
 	if newestDateTag != "" {
 		return newestDateTag, nil
 	}
-	return "", fmt.Errorf("no dated tag found that matches: %s", bookwormDateTag.String())
+	return "", fmt.Errorf("no dated tag found that matches: %s", dateTag.String())
 }
 
 func main() {
@@ -77,7 +76,7 @@ func main() {
 	if err != nil {
 		klog.Fatal(err)
 	}
-	tag, err := latestBookwormSlimTag(tags)
+	tag, err := latestSlimTag(tags)
 	if err != nil {
 		klog.Fatal(err)
 	}

--- a/hack/update/get_version/get_version.go
+++ b/hack/update/get_version/get_version.go
@@ -77,7 +77,7 @@ var dependencies = map[string]dependency{
 	"portainer":               {addonsFile, `portainer/portainer-ce:(.*)@`},
 	"registry":                {addonsFile, `registry:(.*)@`},
 	"runc":                    {"deploy/iso/minikube-iso/package/runc-master/runc-master.mk", `RUNC_MASTER_VERSION = (.*)`},
-	"debian":                  {dockerfile, `debian:bookworm-(.*)-slim`},
+	"debian":                  {dockerfile, `debian:trixie-(.*)-slim`},
 	"volcano":                 {addonsFile, `volcanosh/vc-webhook-manager:(.*)@`},
 	"yakd":                    {addonsFile, `manusa/yakd:(.*)@`},
 }

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,10 +24,10 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.51-1788719696-23591"
+	Version = "v0.0.51-1788852891-23655"
 
 	// SHA of the kic base image
-	baseImageSHA = "01bc448296750a93c677a9c36ca23a79c5cabff89880ea1bba05a64f4a22e12e"
+	baseImageSHA = "726c61737b2e237b8ddb37b95ed70b947f091236efa21c4ef8258e34c4d3b054"
 	// The name of the GCR kicbase repository
 	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -27,7 +27,7 @@ minikube start [flags]
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-pause-interval duration      Duration of inactivity before the minikube VM is paused (default 1m0s) (default 1m0s)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.51-1788719696-23591@sha256:01bc448296750a93c677a9c36ca23a79c5cabff89880ea1bba05a64f4a22e12e")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.51-1788852891-23655@sha256:726c61737b2e237b8ddb37b95ed70b947f091236efa21c4ef8258e34c4d3b054")
       --binary-mirror string              Location to fetch kubectl, kubelet, & kubeadm binaries from.
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cert-expiration duration          Duration until minikube certificate expiration, defaults to three years (26280h). (default 26280h0m0s)


### PR DESCRIPTION
bookworm-*-slim dropped s390x, so the debian updater was proposing tags kicbase cannot build. staying on the old bookworm image also means missing security fixes.

switched the base to `debian:trixie-20260824-slim` (has amd64/arm64/s390x/ppc64le) and pointed the updater at dated `trixie-YYYYMMDD-slim` tags.

Fixes #23649