### PR TITLE
fix: return error when image tag fails instead of silent success

### DIFF
--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -321,22 +321,10 @@ func (r *Containerd) RemoveImage(name string) error {
 func (r *Containerd) TagImage(source string, target string) error {
 	klog.Infof("Tagging image %s: %s", source, target)
 	c := exec.Command("sudo", "ctr", "-n=k8s.io", "images", "tag", source, target)
-	if _, err := r.Runner.RunCmd(c); err == nil {
-		return nil
-	} else {
-		// ctr requires fully qualified names, unlike docker tag.
-		// Retry with docker.io prefix, mirroring removeCRIImage fallback.
-		// See https://github.com/kubernetes/minikube/issues/23659
-		normSource := AddDockerIO(source)
-		normTarget := AddDockerIO(target)
-		if normSource != source || normTarget != target {
-			c = exec.Command("sudo", "ctr", "-n=k8s.io", "images", "tag", normSource, normTarget)
-			if _, err2 := r.Runner.RunCmd(c); err2 == nil {
-				return nil
-			}
-		}
+	if _, err := r.Runner.RunCmd(c); err != nil {
 		return fmt.Errorf("ctr images tag: %w", err)
 	}
+	return nil
 }
 
 func gitClone(cr CommandRunner, src string) (string, error) {

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -321,10 +321,22 @@ func (r *Containerd) RemoveImage(name string) error {
 func (r *Containerd) TagImage(source string, target string) error {
 	klog.Infof("Tagging image %s: %s", source, target)
 	c := exec.Command("sudo", "ctr", "-n=k8s.io", "images", "tag", source, target)
-	if _, err := r.Runner.RunCmd(c); err != nil {
+	if _, err := r.Runner.RunCmd(c); err == nil {
+		return nil
+	} else {
+		// ctr requires fully qualified names, unlike docker tag.
+		// Retry with docker.io prefix, mirroring removeCRIImage fallback.
+		// See https://github.com/kubernetes/minikube/issues/23659
+		normSource := AddDockerIO(source)
+		normTarget := AddDockerIO(target)
+		if normSource != source || normTarget != target {
+			c = exec.Command("sudo", "ctr", "-n=k8s.io", "images", "tag", normSource, normTarget)
+			if _, err2 := r.Runner.RunCmd(c); err2 == nil {
+				return nil
+			}
+		}
 		return fmt.Errorf("ctr images tag: %w", err)
 	}
-	return nil
 }
 
 func gitClone(cr CommandRunner, src string) (string, error) {

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -885,6 +885,9 @@ func TagImage(profile *config.Profile, source string, target string, options *ru
 
 	klog.Infof("succeeded tagging in: %s", strings.Join(succeeded, " "))
 	klog.Infof("failed tagging in: %s", strings.Join(failed, " "))
+	if len(failed) > 0 {
+		return fmt.Errorf("failed to tag image on %s", strings.Join(failed, ", "))
+	}
 	return nil
 }
 


### PR DESCRIPTION
`minikube image tag local/foo:1 local/foo:2` exited 0 but tagged nothing on containerd. `ctr tag` needs full names while `docker tag` does not, and the error was swallowed. I have added a docker.io retry in Containerd.TagImage and return an error from machine.TagImage so it fails loudly now. Tested with `go test ./pkg/minikube/cruntime/...`, it passes.

Fixes #23659