### PR TITLE
parallels: Fix wrong format string in Debugf call

### DIFF
--- a/pkg/drivers/parallels/parallels_darwin.go
+++ b/pkg/drivers/parallels/parallels_darwin.go
@@ -422,7 +422,7 @@ func (d *Driver) PreCreateCheck() error {
 		return err
 	}
 
-	log.Debugf("Found Parallels Desktop version: %d, edition: %s", ver, edit)
+	log.Debugf("Found Parallels Desktop version: %s, edition: %s", ver, edit)
 
 	switch edit {
 	case "pro", "business":


### PR DESCRIPTION
**Problem**

`log.Debugf` in `parallels_darwin.go:425` uses `%d` (integer format verb) for the `ver` argument, which is of type `*github.com/hashicorp/go-version.Version`. This is incorrect because `%d` expects an integer.

On some Go versions (e.g. go1.26.0), `go vet` flags this as a build error, causing `make gotest` to fail with:

```
pkg/drivers/parallels/parallels_darwin.go:425:47: log.Debugf format %d has arg ver of wrong type *github.com/hashicorp/go-version.Version
```

**Solution**

Change the format verb from `%d` to `%s`. The `*go-version.Version` type implements the `Stringer` interface (`String()` method), so `%s` is the correct verb to print the version string.


<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
