### PR TITLE
test: add failing ImageTagPartial test for partial names

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -418,6 +418,48 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 		}
 	})
 
+	// docs: Make sure image tagging works with partial names without requiring docker daemon (#23668)
+	t.Run("ImageTagPartial", func(t *testing.T) {
+		// Uses only `minikube image` commands (pull/save/load from tar) so it
+		// can run on all platforms without depending on non-free programs.
+		// See https://github.com/kubernetes/minikube/issues/23668
+		// Currently fails on containerd runtime since `ctr images tag`
+		// does not resolve partial names.
+		baseImage := "docker.io/library/busybox:latest"
+		tmpDir := t.TempDir()
+		tarPath := filepath.Join(tmpDir, "busybox-partial.tar")
+
+		// Pull without docker daemon, then round-trip via tar to prove tar-load path.
+		if rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "image", "pull", baseImage, "--alsologtostderr")); err != nil {
+			t.Fatalf("failed to pull image %s: %v\n%s", baseImage, err, rr.Output())
+		}
+		t.Cleanup(func() { silentRemoveImage(ctx, t, profile, baseImage) })
+		saveImageToTarfile(ctx, t, profile, baseImage, tarPath)
+		removeImage(ctx, t, profile, baseImage)
+		loadImageFromTarfile(ctx, t, profile, tarPath)
+		checkImageExists(ctx, t, profile, baseImage)
+
+		tests := []struct {
+			name   string
+			source string
+			target string
+		}{
+			// no namespace: busybox:latest should resolve to library/busybox:latest
+			{"NoNamespace", "busybox:latest", fmt.Sprintf("docker.io/library/busybox:test-nonamespace-%s", profile)},
+			// no registry: library/busybox:latest should resolve to docker.io/library/busybox:latest
+			{"NoRegistry", "library/busybox:latest", fmt.Sprintf("docker.io/library/busybox:test-noregistry-%s", profile)},
+			// no tag: docker.io/library/busybox should default to :latest
+			{"NoTag", "docker.io/library/busybox", fmt.Sprintf("docker.io/library/busybox:test-notag-%s", profile)},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Cleanup(func() { silentRemoveImage(ctx, t, profile, tc.target) })
+				tagImage(ctx, t, profile, tc.source, tc.target)
+				checkImageExists(ctx, t, profile, tc.target)
+			})
+		}
+	})
+
 	// docs: Make sure a new updated tag works by `minikube image load --daemon`
 	t.Run("ImageTagAndLoadDaemon", func(t *testing.T) {
 		tagAndLoadImage(ctx, t, profile, taggedImage)
@@ -538,6 +580,14 @@ func loadImageFromTarfile(ctx context.Context, t *testing.T, profile, tarPath st
 	cmd := exec.CommandContext(ctx, Target(), "-p", profile, "image", "load", tarPath, "--alsologtostderr")
 	if rr, err := Run(t, cmd); err != nil {
 		t.Fatalf("failed to load image from %s: %v\n%s", tarPath, err, rr.Output())
+	}
+}
+
+func tagImage(ctx context.Context, t *testing.T, profile, source, target string) {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, Target(), "-p", profile, "image", "tag", source, target, "--alsologtostderr")
+	if rr, err := Run(t, cmd); err != nil {
+		t.Fatalf("failed to tag image %s as %s: %v\n%s", source, target, err, rr.Output())
 	}
 }
 


### PR DESCRIPTION
Short image names do not resolve on containerd, so `minikube image tag busybox:latest ...` fails while docker passes. I added an `ImageTagPartial` case in `validateImageCommands` that pulls busybox, saves and reloads it from a tar, then tags the three partial forms from the issue. It doesn't use the docker daemon so it can run on all platforms. Checked it with `gofmt` and `go vet -tags integration ./test/integration/`, both are clean. It'll stay red on containerd until the nerdctl switch lands, that's expected.

Closes #23668