### PR TITLE
test: image tag coverage without docker daemon

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -435,6 +435,45 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 		}
 	})
 
+	// docs: Make sure image tagging works with partial names without requiring docker daemon (https://github.com/kubernetes/minikube/issues/23668)
+	t.Run("ImageTagPartial", func(t *testing.T) {
+		// Uses only `minikube image` commands (pull/save/load from tar) so it
+		// can run on all platforms without depending on non-free programs.
+		// Currently fails on containerd runtime since `ctr images tag`
+		// does not resolve partial names.
+		baseImage := "docker.io/library/busybox:latest"
+		tmpDir := t.TempDir()
+		tarPath := filepath.Join(tmpDir, "busybox-partial.tar")
+
+		// Pull without docker daemon, then round-trip via tar to prove tar-load path.
+		pullImage(ctx, t, profile, baseImage)
+		t.Cleanup(func() { silentRemoveImage(ctx, t, profile, baseImage) })
+		saveImageToTarfile(ctx, t, profile, baseImage, tarPath)
+		removeImage(ctx, t, profile, baseImage)
+		loadImageFromTarfile(ctx, t, profile, tarPath)
+		checkImageExists(ctx, t, profile, baseImage)
+
+		tests := []struct {
+			name   string
+			source string
+			target string
+		}{
+			// no namespace: busybox:latest should resolve to library/busybox:latest
+			{"NoNamespace", "busybox:latest", fmt.Sprintf("docker.io/library/busybox:test-nonamespace-%s", profile)},
+			// no registry: library/busybox:latest should resolve to docker.io/library/busybox:latest
+			{"NoRegistry", "library/busybox:latest", fmt.Sprintf("docker.io/library/busybox:test-noregistry-%s", profile)},
+			// no tag: docker.io/library/busybox should default to :latest
+			{"NoTag", "docker.io/library/busybox", fmt.Sprintf("docker.io/library/busybox:test-notag-%s", profile)},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Cleanup(func() { silentRemoveImage(ctx, t, profile, tc.target) })
+				tagImage(ctx, t, profile, tc.source, tc.target)
+				checkImageExists(ctx, t, profile, tc.target)
+			})
+		}
+	})
+
 	// docs(skip): Make sure a new updated tag works by `minikube image load --daemon`, requires a local docker daemon
 	t.Run("ImageTagAndLoadDaemon", func(t *testing.T) {
 		requireDockerDaemon(t)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -244,7 +244,11 @@ func validateNodeLabels(ctx context.Context, t *testing.T, profile string) {
 }
 
 // tagAndLoadImage is a helper function to pull, tag, load image (decreases cyclomatic complexity for linter).
+// It requires a local docker daemon.
 func tagAndLoadImage(ctx context.Context, t *testing.T, profile, taggedImage string) {
+	t.Helper()
+	requireDockerDaemon(t)
+
 	newPulledImage := fmt.Sprintf("%s:%s", echoServerImage, "latest")
 	rr, err := Run(t, exec.CommandContext(ctx, "docker", "pull", newPulledImage))
 	if err != nil {
@@ -300,14 +304,13 @@ func expectedImageFormat(format string) []string {
 }
 
 // validateImageCommands runs tests on all the `minikube image` commands, ex. `minikube image load`, `minikube image list`, etc.
+// Only the `--daemon` subtests below require a local docker daemon and skip
+// without it; everything else pulls from a remote registry or builds inside
+// minikube so it runs on all platforms (see https://github.com/kubernetes/minikube/issues/23669).
 func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 	// docs(skip): Skips on `none` driver as image loading is not supported
 	if NoneDriver() {
 		t.Skip("image commands are not available on the none driver")
-	}
-	// docs(skip): Skips on GitHub Actions / prow environment and macOS as this test case requires a running docker daemon
-	if VFKitDriver() && runtime.GOOS == "darwin" {
-		t.Skip("skipping on darwin github action runners, as this test requires a running docker daemon")
 	}
 
 	runImageList(ctx, t, profile, "ImageListShort", "short", "%s")
@@ -337,6 +340,7 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 	})
 
 	taggedImage := fmt.Sprintf("%s:%s", echoServerImage, profile)
+	pulledImage := fmt.Sprintf("%s:%s", echoServerImage, "1.0")
 	imageFile := "echo-server-save.tar"
 	var imagePath string
 	defer os.Remove(imageFile)
@@ -348,7 +352,21 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 			t.Fatalf("failed to get absolute path of file %q: %v", imageFile, err)
 		}
 
-		pulledImage := fmt.Sprintf("%s:%s", echoServerImage, "1.0")
+		// Pull from the remote registry without docker daemon so the rest of
+		// the tests run on all platforms.
+		pullImage(ctx, t, profile, pulledImage)
+	})
+
+	// docs: Make sure image tagging works by `minikube image tag`
+	t.Run("ImageTag", func(t *testing.T) {
+		tagImage(ctx, t, profile, pulledImage, taggedImage)
+		checkImageExists(ctx, t, profile, taggedImage)
+	})
+
+	// docs(skip): Make sure image loading from Docker daemon works by `minikube image load --daemon`, requires a local docker daemon
+	t.Run("ImageLoadDaemon", func(t *testing.T) {
+		requireDockerDaemon(t)
+
 		rr, err := Run(t, exec.CommandContext(ctx, "docker", "pull", pulledImage))
 		if err != nil {
 			t.Fatalf("failed to setup test (pull image): %v\n%s", err, rr.Output())
@@ -358,11 +376,8 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 		if err != nil {
 			t.Fatalf("failed to setup test (tag image) : %v\n%s", err, rr.Output())
 		}
-	})
 
-	// docs: Make sure image loading from Docker daemon works by `minikube image load --daemon`
-	t.Run("ImageLoadDaemon", func(t *testing.T) {
-		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "image", "load", "--daemon", taggedImage, "--alsologtostderr"))
+		rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "image", "load", "--daemon", taggedImage, "--alsologtostderr"))
 		if err != nil {
 			t.Fatalf("loading image into minikube from daemon: %v\n%s", err, rr.Output())
 		}
@@ -370,8 +385,10 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 		checkImageExists(ctx, t, profile, taggedImage)
 	})
 
-	// docs: Try to load image already loaded and make sure `minikube image load --daemon` works
+	// docs(skip): Try to load image already loaded and make sure `minikube image load --daemon` works, requires a local docker daemon
 	t.Run("ImageReloadDaemon", func(t *testing.T) {
+		requireDockerDaemon(t)
+
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "image", "load", "--daemon", taggedImage, "--alsologtostderr"))
 		if err != nil {
 			t.Fatalf("loading image into minikube from daemon: %v\n%s", err, rr.Output())
@@ -418,12 +435,13 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 		}
 	})
 
-	// docs: Make sure a new updated tag works by `minikube image load --daemon`
+	// docs(skip): Make sure a new updated tag works by `minikube image load --daemon`, requires a local docker daemon
 	t.Run("ImageTagAndLoadDaemon", func(t *testing.T) {
+		requireDockerDaemon(t)
 		tagAndLoadImage(ctx, t, profile, taggedImage)
 	})
 
-	// docs: Make sure image saving works by `minikube image load --daemon`
+	// docs: Make sure image saving works by `minikube image save`
 	t.Run("ImageSaveToFile", func(t *testing.T) {
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "image", "save", taggedImage, imagePath, "--alsologtostderr"))
 		if err != nil {
@@ -462,8 +480,10 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 		checkImageExists(ctx, t, profile, taggedImage)
 	})
 
-	// docs: Make sure image saving to Docker daemon works by `minikube image load`
+	// docs(skip): Make sure image saving to Docker daemon works by `minikube image save --daemon`, requires a local docker daemon
 	t.Run("ImageSaveDaemon", func(t *testing.T) {
+		requireDockerDaemon(t)
+
 		rr, err := Run(t, exec.CommandContext(ctx, "docker", "rmi", taggedImage))
 		if err != nil {
 			t.Fatalf("failed to remove image from docker: %v\n%s", err, rr.Output())
@@ -538,6 +558,33 @@ func loadImageFromTarfile(ctx context.Context, t *testing.T, profile, tarPath st
 	cmd := exec.CommandContext(ctx, Target(), "-p", profile, "image", "load", tarPath, "--alsologtostderr")
 	if rr, err := Run(t, cmd); err != nil {
 		t.Fatalf("failed to load image from %s: %v\n%s", tarPath, err, rr.Output())
+	}
+}
+
+func pullImage(ctx context.Context, t *testing.T, profile, imageName string) {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, Target(), "-p", profile, "image", "pull", imageName, "--alsologtostderr")
+	if rr, err := Run(t, cmd); err != nil {
+		t.Fatalf("failed to pull image %s: %v\n%s", imageName, err, rr.Output())
+	}
+}
+
+func tagImage(ctx context.Context, t *testing.T, profile, source, target string) {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, Target(), "-p", profile, "image", "tag", source, target, "--alsologtostderr")
+	if rr, err := Run(t, cmd); err != nil {
+		t.Fatalf("failed to tag image %s as %s: %v\n%s", source, target, err, rr.Output())
+	}
+}
+
+// requireDockerDaemon skips the test when the docker CLI is unavailable.
+// Only `minikube image load/save --daemon` need a local docker daemon;
+// everything else must run on all platforms without it
+// (see https://github.com/kubernetes/minikube/issues/23669).
+func requireDockerDaemon(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath(oci.Docker); err != nil {
+		t.Skipf("docker is not installed, skipping daemon test")
 	}
 }
 


### PR DESCRIPTION
Image functional tests needed a docker daemon, so they skipped on some platforms and never covered `image tag` or `image pull`. I switched Setup to `minikube image pull` from the remote registry, added explicit `ImageTag` and `ImageTagPartial` cases (the partial names fail on containerd, that's expected until the nerdctl switch), and gated only the `--daemon` subtests on docker presence. It doesn't use the daemon anywhere else. Checked with `gofmt` and `go vet -tags integration ./test/integration/`, both are clean. This supersedes #23671, which had the partial test alone and would have clashed here.

Closes #23668
Closes #23669