### PR TITLE
Use nerdctl for containerd image commands

### DIFF
--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -46,6 +46,8 @@ import (
 
 const (
 	containerdNamespaceRoot = "/run/containerd/runc/k8s.io"
+	// nerdctlNamespace is the containerd namespace minikube manages via nerdctl
+	nerdctlNamespace = "k8s.io"
 	// ContainerdConfFile is the path to the containerd configuration
 	containerdConfigFile               = "/etc/containerd/config.toml"
 	containerdMirrorsRoot              = "/etc/containerd/certs.d"
@@ -262,14 +264,24 @@ func (r *Containerd) Disable() error {
 	return r.Init.ForceStop("containerd")
 }
 
+// nerdctlCmd returns a nerdctl invocation against the k8s.io namespace.
+// nerdctl is the supported production interface to containerd: unlike the
+// ctr/crictl debugging tools it resolves partial image names the same way
+// docker does (see https://github.com/kubernetes/minikube/issues/23670).
+func nerdctlCmd(args ...string) *exec.Cmd {
+	full := append([]string{"nerdctl", "-n", nerdctlNamespace}, args...)
+	return exec.Command("sudo", full...)
+}
+
 // ImageExists checks if image exists based on image name and optionally image sha
 func (r *Containerd) ImageExists(name string, sha string) bool {
 	klog.Infof("Checking existence of image with name %q and sha %q", name, sha)
-	c := exec.Command("sudo", "ctr", "-n=k8s.io", "images", "ls", fmt.Sprintf("name==%s", name))
-	// note: image name and image id's sha can be on different lines in ctr output
-	if rr, err := r.Runner.RunCmd(c); err != nil ||
-		!strings.Contains(rr.Output(), name) ||
-		(sha != "" && !strings.Contains(rr.Output(), sha)) {
+	rr, err := r.Runner.RunCmd(nerdctlCmd("image", "inspect", name))
+	if err != nil {
+		return false
+	}
+	// note: image name and image id's sha can be on different lines in inspect output
+	if sha != "" && !strings.Contains(rr.Output(), sha) {
 		return false
 	}
 	return true
@@ -277,7 +289,43 @@ func (r *Containerd) ImageExists(name string, sha string) bool {
 
 // ListImages lists images managed by this container runtime
 func (r *Containerd) ListImages(ListImagesOptions) ([]ListImage, error) {
-	return listCRIImages(r.Runner)
+	return listNerdctlImages(r.Runner)
+}
+
+// listNerdctlImages lists images using nerdctl
+func listNerdctlImages(cr CommandRunner) ([]ListImage, error) {
+	// Name/Repository/Tag/ID/Digest/Size are long-stable template fields.
+	// Rows are filtered to tagged images only: under k8s.io the same image
+	// is also stored under digest and config-ID names, which show up with
+	// Tag "<none>" and must not pollute the list.
+	c := nerdctlCmd("images", "--no-trunc", "--format", "{{.Name}}\t{{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.Digest}}\t{{.Size}}")
+	rr, err := cr.RunCmd(c)
+	if err != nil {
+		return nil, fmt.Errorf("nerdctl images: %w", err)
+	}
+
+	images := []ListImage{}
+	for line := range strings.Lines(strings.TrimSpace(rr.Output())) {
+		if line == "" {
+			continue
+		}
+		// Name, Repository, Tag, ID and Digest never contain tabs, Size is last
+		parts := strings.SplitN(line, "\t", 6)
+		if len(parts) != 6 {
+			continue
+		}
+		repository, tag, id, digest, size := parts[1], parts[2], parts[3], parts[4], parts[5]
+		if repository == "<none>" || tag == "<none>" {
+			continue
+		}
+		img := ListImage{ID: id, Size: size}
+		img.RepoTags = []string{fmt.Sprintf("%s:%s", repository, tag)}
+		if digest != "" && digest != "<none>" {
+			img.RepoDigests = []string{digest}
+		}
+		images = append(images, img)
+	}
+	return images, nil
 }
 
 // LoadImage loads an image into this runtime
@@ -285,13 +333,13 @@ func (r *Containerd) LoadImage(imagePath string) error {
 	klog.Infof("Loading image: %s", imagePath)
 	// retry up to 3 times handle transient "short read" or "unexpected EOF" errors example #22309
 	return retry.Expo(func() error {
-		c := exec.Command("sudo", "ctr", "-n=k8s.io", "images", "import", imagePath)
+		c := nerdctlCmd("load", "--input", imagePath)
 		if _, err := r.Runner.RunCmd(c); err != nil {
 			// Only retry on transient "short read" or "unexpected EOF" errors
 			if strings.Contains(err.Error(), "short read") || strings.Contains(err.Error(), "unexpected EOF") {
-				return fmt.Errorf("ctr images import: %w", err)
+				return fmt.Errorf("nerdctl load: %w", err)
 			}
-			return backoff.Permanent(fmt.Errorf("ctr images import: %w", err))
+			return backoff.Permanent(fmt.Errorf("nerdctl load: %w", err))
 		}
 		return nil
 	}, 250*time.Millisecond, 2*time.Minute, 3)
@@ -299,30 +347,43 @@ func (r *Containerd) LoadImage(imagePath string) error {
 
 // PullImage pulls an image into this runtime
 func (r *Containerd) PullImage(name string) error {
-	return pullCRIImage(r.Runner, name)
+	klog.Infof("Pulling image: %s", name)
+	c := nerdctlCmd("pull", name)
+	if _, err := r.Runner.RunCmd(c); err != nil {
+		return fmt.Errorf("nerdctl pull: %w", err)
+	}
+	return nil
 }
 
 // SaveImage save an image from this runtime
 func (r *Containerd) SaveImage(name string, destPath string) error {
 	klog.Infof("Saving image %s: %s", name, destPath)
-	c := exec.Command("sudo", "ctr", "-n=k8s.io", "images", "export", destPath, name)
+	c := nerdctlCmd("save", "--output", destPath, name)
 	if _, err := r.Runner.RunCmd(c); err != nil {
-		return fmt.Errorf("ctr images export: %w", err)
+		return fmt.Errorf("nerdctl save: %w", err)
 	}
 	return nil
 }
 
 // RemoveImage removes a image
 func (r *Containerd) RemoveImage(name string) error {
-	return removeCRIImage(r.Runner, name, false)
+	klog.Infof("Removing image: %s", name)
+	// nerdctl removes a single tag, unlike crictl which deletes all images
+	// sharing the same hash, and resolves partial names, so no
+	// docker.io/localhost fallback retry is needed here.
+	c := nerdctlCmd("rmi", name)
+	if _, err := r.Runner.RunCmd(c); err != nil {
+		return fmt.Errorf("nerdctl rmi: %w", err)
+	}
+	return nil
 }
 
 // TagImage tags an image in this runtime
 func (r *Containerd) TagImage(source string, target string) error {
 	klog.Infof("Tagging image %s: %s", source, target)
-	c := exec.Command("sudo", "ctr", "-n=k8s.io", "images", "tag", source, target)
+	c := nerdctlCmd("tag", source, target)
 	if _, err := r.Runner.RunCmd(c); err != nil {
-		return fmt.Errorf("ctr images tag: %w", err)
+		return fmt.Errorf("nerdctl tag: %w", err)
 	}
 	return nil
 }
@@ -433,9 +494,9 @@ func (r *Containerd) BuildImage(src string, file string, tag string, push bool, 
 // PushImage pushes an image
 func (r *Containerd) PushImage(name string) error {
 	klog.Infof("Pushing image %s", name)
-	c := exec.Command("sudo", "ctr", "-n=k8s.io", "images", "push", name)
+	c := nerdctlCmd("push", name)
 	if _, err := r.Runner.RunCmd(c); err != nil {
-		return fmt.Errorf("ctr images push: %w", err)
+		return fmt.Errorf("nerdctl push: %w", err)
 	}
 	return nil
 }

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 	"testing"
 
@@ -97,6 +98,8 @@ func TestImageExists(t *testing.T) {
 		{"docker", "available-image", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", true},
 		{"crio", "missing-image", "0000000000000000000000000000000000000000000000000000000000000000", false},
 		{"crio", "available-image", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", true},
+		{"containerd", "missing-image", "0000000000000000000000000000000000000000000000000000000000000000", false},
+		{"containerd", "available-image", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", true},
 	}
 	for _, tc := range tests {
 		runner := NewFakeRunner(t)
@@ -115,6 +118,65 @@ func TestImageExists(t *testing.T) {
 				t.Errorf("ImageExists(%s) returned diff (-want +got):\n%s", tc.runtime, diff)
 			}
 		})
+	}
+}
+
+// TestContainerdNerdctlImageOps makes sure the containerd runtime manages
+// images with nerdctl instead of the ctr/crictl debugging tools
+// (see https://github.com/kubernetes/minikube/issues/23670).
+func TestContainerdNerdctlImageOps(t *testing.T) {
+	runner := NewFakeRunner(t)
+	r, err := New(Config{Type: "containerd", Runner: runner})
+	if err != nil {
+		t.Fatalf("New(containerd): %v", err)
+	}
+
+	if err := r.PullImage("test-image:1.0"); err != nil {
+		t.Fatalf("PullImage(): %v", err)
+	}
+	if err := r.TagImage("test-image:1.0", "test-image:2.0"); err != nil {
+		t.Fatalf("TagImage(): %v", err)
+	}
+	if !r.ImageExists("test-image:2.0", "") {
+		t.Errorf("ImageExists(test-image:2.0) = false, want true")
+	}
+	list, err := r.ListImages(ListImagesOptions{})
+	if err != nil {
+		t.Fatalf("ListImages(): %v", err)
+	}
+	tags := []string{}
+	for _, img := range list {
+		tags = append(tags, img.RepoTags...)
+	}
+	for _, want := range []string{"test-image:1.0", "test-image:2.0"} {
+		found := false
+		for _, tag := range tags {
+			if tag == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("ListImages() tags %v does not contain %q", tags, want)
+		}
+	}
+	if err := r.RemoveImage("test-image:2.0"); err != nil {
+		t.Fatalf("RemoveImage(): %v", err)
+	}
+	if r.ImageExists("test-image:2.0", "") {
+		t.Errorf("ImageExists(test-image:2.0) = true after RemoveImage, want false")
+	}
+
+	// image ops must go through nerdctl, never ctr or crictl
+	joined := strings.Join(runner.cmds, " ")
+	if !strings.Contains(joined, "nerdctl") {
+		t.Errorf("expected nerdctl invocations, got cmds: %v", runner.cmds)
+	}
+	for _, c := range runner.cmds {
+		if c == "ctr" || c == "crictl" || strings.HasSuffix(c, "/crictl") {
+			t.Errorf("containerd image ops must not invoke %q, got cmds: %v", c, runner.cmds)
+			break
+		}
 	}
 }
 
@@ -247,6 +309,8 @@ func (f *FakeRunner) RunCmd(cmd *exec.Cmd) (*command.RunResult, error) {
 		return buffer(f.podman(args, root))
 	case "crictl", "/usr/bin/crictl":
 		return buffer(f.crictl(args, root))
+	case "nerdctl":
+		return buffer(f.nerdctl(args, root))
 	case "crio":
 		return buffer(f.crio(args, root))
 	case "containerd":
@@ -399,6 +463,81 @@ func (f *FakeRunner) podman(args []string, _ bool) (string, error) {
 			return "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", nil
 		}
 
+	}
+	return "", nil
+}
+
+// nerdctl is a fake implementation of nerdctl
+func (f *FakeRunner) nerdctl(args []string, _ bool) (string, error) {
+	f.t.Logf("nerdctl args: %s", args)
+	// strip global flags before the subcommand
+	rest := []string{}
+	skipNext := false
+	for _, a := range args {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		switch a {
+		case "--kube-hide-dupe":
+			continue
+		case "-n", "--namespace":
+			skipNext = true
+			continue
+		}
+		rest = append(rest, a)
+	}
+	args = rest
+	if len(args) == 0 {
+		return "", nil
+	}
+	switch cmd := args[0]; cmd {
+	case "image":
+		if args[1] == "inspect" {
+			name := args[2]
+			sha, ok := f.images[name]
+			if !ok {
+				return "", &exec.ExitError{Stderr: []byte("Error: No such image: " + name)}
+			}
+			return fmt.Sprintf(`[{"RepoTags":["%s"],"Id":"sha256:%s"}]`, name, sha), nil
+		}
+	case "images":
+		lines := []string{}
+		for name, sha := range f.images {
+			repository, tag := name, "latest"
+			if idx := strings.LastIndex(name, ":"); idx != -1 {
+				repository, tag = name[:idx], name[idx+1:]
+			}
+			lines = append(lines, fmt.Sprintf("%s\t%s\t%s\tsha256:%s\tsha256:%s\t1000", name, repository, tag, sha, sha))
+		}
+		sort.Strings(lines)
+		return strings.Join(lines, "\n"), nil
+	case "tag":
+		source, target := args[1], args[2]
+		sha, ok := f.images[source]
+		if !ok {
+			return "", errors.New("no such image")
+		}
+		f.images[target] = sha
+	case "pull":
+		name := args[len(args)-1]
+		if _, ok := f.images[name]; !ok {
+			f.images[name] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+		}
+	case "push", "save", "load":
+		if cmd == "push" {
+			if _, ok := f.images[args[len(args)-1]]; !ok {
+				return "", errors.New("no such image")
+			}
+		}
+	case "rmi":
+		for _, id := range args[1:] {
+			f.t.Logf("fake nerdctl: Removing id %q", id)
+			if f.images[id] == "" {
+				return "", errors.New("no such image")
+			}
+			delete(f.images, id)
+		}
 	}
 	return "", nil
 }


### PR DESCRIPTION
With containerd as the default runtime, `minikube image tag` with short names fails because `ctr` needs fully qualified names, and `crictl rmi` wipes every tag sharing a hash. I switched all containerd image ops to `nerdctl -n k8s.io`, which resolves names like docker does. nerdctl already ships in kicbase and the ISO, so no image changes were needed. It doesn't touch the shared crictl helpers (docker and crio still use them) or the preload check. Checked with `go test ./pkg/minikube/cruntime/ ./pkg/minikube/machine/`, all pass, plus a new `TestContainerdNerdctlImageOps` locking the switch.

Closes #23670