### PR TITLE
ISO: Replace mkisofs with xorriso in builder Dockerfile

### DIFF
--- a/deploy/iso/minikube-iso/Dockerfile
+++ b/deploy/iso/minikube-iso/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update \
 		cmake \
 		dumb-init \
 		libpcre3-dev \
-		mkisofs \
+		xorriso \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /app


### PR DESCRIPTION
Following #23546 which updated `deploy/iso/minikube-iso/board/minikube/aarch64/post-image.sh` to invoke `xorriso -as mkisofs` directly instead of `mkisofs`, building the ISO inside the builder container (via `make buildroot-image && make minikube-iso-aarch64` as documented in `site/content/en/docs/contrib/building/iso.md`) would fail inside the container with:

```
xorriso: command not found
```

This is because `deploy/iso/minikube-iso/Dockerfile` only installed `mkisofs` (which pulls `genisoimage` on Ubuntu 24.04).

This PR replaces `mkisofs` with `xorriso` in `deploy/iso/minikube-iso/Dockerfile`, aligning the builder image with `site/content/en/docs/contrib/building/iso.md` and ensuring containerized ISO builds have `xorriso` available.

cc @nirs