### PR TITLE
parallels: replace deprecated io/ioutil and os.SEEK_SET

### DIFF
--- a/pkg/drivers/parallels/parallels_darwin.go
+++ b/pkg/drivers/parallels/parallels_darwin.go
@@ -41,7 +41,7 @@ package parallels
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -630,7 +630,7 @@ func (d *Driver) getIPfromDHCPLease() (string, error) {
 		return "", fmt.Errorf("Not a valid MAC address: %s. It should be exactly 12 digits.", mac)
 	}
 
-	leases, err := ioutil.ReadFile(DHCPLeaseFile)
+	leases, err := os.ReadFile(DHCPLeaseFile)
 	if err != nil {
 		return "", err
 	}
@@ -743,7 +743,7 @@ func (d *Driver) generateDiskImage(size int) error {
 		return err
 	}
 	defer hds.Close()
-	hds.Seek(0, os.SEEK_SET)
+	hds.Seek(0, io.SeekStart)
 	_, err = hds.Write(tarBuf.Bytes())
 	if err != nil {
 		return err


### PR DESCRIPTION
`pkg/drivers/parallels/parallels_darwin.go` used two long-deprecated stdlib APIs. This replaces both. No behavior change.

- `io/ioutil` (deprecated since Go 1.16): the only use was `ioutil.ReadFile(DHCPLeaseFile)`, now `os.ReadFile`. Same signature and return values, so the import is dropped.
- `os.SEEK_SET` (deprecated since Go 1.7): replaced with `io.SeekStart`. Both constants are `0`, so this is a rename. The freed import slot is reused for `io`, which keeps the stdlib import block alphabetical.

This file is darwin-only, so `go build ./...` on Linux skips it. Verified with a cross-compile instead:

```
GOOS=darwin go build ./pkg/drivers/parallels/...
GOOS=darwin go vet   ./pkg/drivers/parallels/...
GOOS=darwin go build ./pkg/minikube/registry/drvs/parallels/...
gofmt -l     pkg/drivers/parallels/parallels_darwin.go
goimports -l pkg/drivers/parallels/parallels_darwin.go
```

All clean.

`io/ioutil` also remains in seven `pkg/libmachine/**/*_test.go` files that came over with the libmachine import. Happy to clean those up in a follow-up if wanted.
