### PR TITLE
exit: fill in the template variables used by error advice

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -521,7 +521,11 @@ func validateQemuNetwork(n string) string {
 			exit.Message(reason.Usage, "The socket_vmnet network is only supported on macOS")
 		}
 		if !detect.SocketVMNetInstalled() {
-			exit.Message(reason.NotFoundSocketVMNet, "\n\n")
+			profileArg := ""
+			if cn := ClusterFlagValue(); cn != constants.DefaultClusterName {
+				profileArg = fmt.Sprintf(" -p %s", cn)
+			}
+			exit.Message(reason.NotFoundSocketVMNet, "\n\n", out.V{"profile": profileArg})
 		}
 	case "":
 		if detect.SocketVMNetInstalled() {

--- a/pkg/minikube/mustload/mustload.go
+++ b/pkg/minikube/mustload/mustload.go
@@ -154,7 +154,7 @@ func running(name string, first bool, options *run.CommandOptions) []ClusterCont
 		hostname, ip, port, err := driver.ControlPlaneEndpoint(cc, &cp, hostInfo.DriverName)
 		if err != nil {
 			if last {
-				exit.Message(reason.DrvCPEndpoint, `Unable to get control-plane node {{.name}} endpoint: {{.err}}`, out.V{"name": machineName, "err": err})
+				exit.Message(reason.DrvCPEndpoint, `Unable to get control-plane node {{.name}} endpoint: {{.err}}`, out.V{"name": machineName, "err": err, "profileArg": fmt.Sprintf("--profile=%s", cc.Name)})
 			}
 			out.WarningT(`Unable to get control-plane node {{.name}} endpoint (will try others): {{.err}}`, out.V{"name": machineName, "err": err})
 			continue


### PR DESCRIPTION
`reason.Kind.Advice` is rendered as a `text/template` against the `out.V` map passed to `exit.Message`. `exit.Message` always supplies a non-empty map (it inserts `fatal_msg` and `fatal_code`), so the advice template is always executed, and any placeholder missing from the map renders as the literal `<no value>`.

Two call sites do not pass the variables their advice needs, so the suggestion printed on exit names a command the user cannot run:

```
Suggestion:
  Recreate the cluster by running:
  minikube delete <no value>
  minikube start <no value>
```

```
Suggestion:
  Option 2) Using the user network:
  minikube start<no value> --driver qemu --network user
```

- `reason.DrvCPEndpoint.Advice` uses `{{.profileArg}}` twice. The other call site for that Kind, `pkg/minikube/node/start.go`, already passes it; the one in `mustload` was missed when the advice was added in #9291.
- `reason.NotFoundSocketVMNet.Advice` uses `{{.profile}}` and its only call site passes no `out.V` at all.

Both values use the form already in tree for these two templates: `--profile=<name>` as in `node/start.go`, and the leading-space `" -p <name>"` as in the `KubernetesDowngrade` advice in `start.go`.

Verified by rendering both `reason.Kind` values through `out.Error` with the exact `out.V` each call site produces:

| | before | after |
|---|---|---|
| DrvCPEndpoint | `minikube delete <no value>` | `minikube delete --profile=minikube` |
| NotFoundSocketVMNet | `minikube start<no value> --driver qemu --network user` | `minikube start -p p1 --driver qemu --network user` |

Also ran `GOOS=darwin go build ./...`, `GOOS=windows go build ./...`, `go test ./pkg/minikube/out/... ./pkg/minikube/mustload/... ./cmd/minikube/cmd/...` and `gofmt`.

Happy to drop the `start_flags.go` hunk if the socket_vmnet path is going away with #23607; the `mustload.go` one-liner stands on its own.
