### PR TITLE
cluster/status: apply transient codes to nodes in place

### DIFF
--- a/pkg/minikube/cluster/status.go
+++ b/pkg/minikube/cluster/status.go
@@ -314,10 +314,7 @@ func GetState(sts []*Status, profile string, cc *config.ClusterConfig) State {
 				transientCode = exitCode
 			}
 
-			for _, n := range cs.Nodes {
-				n.StatusCode = transientCode
-				n.StatusName = codeNames[n.StatusCode]
-			}
+			applyTransientCodeToNodes(cs.Nodes, transientCode)
 
 			klog.Infof("transient code %d (%q) for step: %+v", transientCode, codeNames[transientCode], data)
 		}
@@ -350,6 +347,14 @@ func GetState(sts []*Status, profile string, cc *config.ClusterConfig) State {
 	cs.StatusDetail = codeDetails[cs.StatusCode]
 
 	return cs
+}
+
+// applyTransientCodeToNodes updates node status in place (range copies structs).
+func applyTransientCodeToNodes(nodes []NodeState, code int) {
+	for i := range nodes {
+		nodes[i].StatusCode = code
+		nodes[i].StatusName = codeNames[nodes[i].StatusCode]
+	}
 }
 
 // NodeStatus looks up the status of a node

--- a/pkg/minikube/cluster/status_test.go
+++ b/pkg/minikube/cluster/status_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import "testing"
+
+func TestApplyTransientCodeToNodes(t *testing.T) {
+	nodes := []NodeState{
+		{BaseState: BaseState{Name: "minikube", StatusCode: OK, StatusName: "OK"}},
+		{BaseState: BaseState{Name: "minikube-m02", StatusCode: OK, StatusName: "OK"}},
+	}
+
+	applyTransientCodeToNodes(nodes, InsufficientStorage)
+
+	for i, n := range nodes {
+		if n.StatusCode != InsufficientStorage {
+			t.Errorf("nodes[%d].StatusCode = %d, want %d", i, n.StatusCode, InsufficientStorage)
+		}
+		if n.StatusName != "InsufficientStorage" {
+			t.Errorf("nodes[%d].StatusName = %q, want InsufficientStorage", i, n.StatusName)
+		}
+	}
+}


### PR DESCRIPTION
`for _, n := range cs.Nodes` copies each node, so writing `n.StatusCode` never updates the slice. cluster JSON can say InsufficientStorage while every node stays OK.

index the slice instead.

Fixes #23683