### PR TITLE
ci: restore qemu smoke test on ubuntu-24.04

### DIFF
--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -286,6 +286,12 @@ jobs:
       - name: Install kubectl
         timeout-minutes: 1
         uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
+      - name: Install qemu and socket_vmnet (macos)
+        if: contains(matrix.os, 'macos') && matrix.driver == 'qemu'
+        timeout-minutes: 1
+        run: |
+          brew install qemu socket_vmnet
+          HOMEBREW=$(which brew) && sudo ${HOMEBREW} services start socket_vmnet
       - name: Install vfkit and vmnet_helper (macos)
         if: matrix.driver == 'vfkit'
         timeout-minutes: 1

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -105,7 +105,16 @@ jobs:
         if: matrix.driver == 'qemu'
         run: |
           sudo apt-get update
-          sudo apt-get install -y qemu-system-x86 qemu-utils
+          sudo apt-get install -y qemu-system-x86 qemu-utils ovmf
+          # The qemu2 driver health check stats this exact path on amd64
+          # (pkg/minikube/registry/drvs/qemu2/qemu2.go: qemuFirmwarePath +
+          # status) and minikube start refuses with PROVIDER_QEMU2_NOT_FOUND
+          # without it — even though BIOS boot never passes it to qemu.
+          # Ubuntu 24.04's ovmf package ships only OVMF_CODE_4M.fd, so link
+          # the legacy name the driver looks up. Long-term fix: teach the
+          # driver to look up both filenames instead of this symlink.
+          sudo ln -sf /usr/share/OVMF/OVMF_CODE_4M.fd /usr/share/OVMF/OVMF_CODE.fd
+          ls -l /usr/share/OVMF/ || true
           # GitHub hosted runners expose /dev/kvm but the runner user
           # lacks rw permission (660 root:kvm). qemu -accel kvm then fails
           # with "Could not access KVM kernel module: Permission denied".

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -44,7 +44,7 @@ jobs:
           - name: qemu-containerd-ubuntu-24.04-x86
             driver: qemu
             os: ubuntu-24.04
-            start_flags: --force --container-runtime=containerd
+            start_flags: --network builtin --force --container-runtime=containerd
             sudo: ""
           - name: vfkit-containerd-macos-15-x86
             driver: vfkit
@@ -105,9 +105,15 @@ jobs:
         if: matrix.driver == 'qemu'
         run: |
           sudo apt-get update
-          sudo apt-get install -y qemu-system-x86 qemu-utils ovmf
-          # ubuntu 24.04 ships OVMF_CODE_4M.fd but the qemu driver checks /usr/share/OVMF/OVMF_CODE.fd
-          sudo ln -sf /usr/share/OVMF/OVMF_CODE_4M.fd /usr/share/OVMF/OVMF_CODE.fd
+          sudo apt-get install -y qemu-system-x86 qemu-utils
+          # GitHub hosted runners expose /dev/kvm but the runner user
+          # lacks rw permission (660 root:kvm). qemu -accel kvm then fails
+          # with "Could not access KVM kernel module: Permission denied".
+          # chmod is immediate for ephemeral CI runners; usermod -aG kvm
+          # would require re-login and does not take effect in the same job.
+          ls -l /dev/kvm || true
+          sudo chmod 666 /dev/kvm
+          ls -l /dev/kvm
       - name: Inspect host before test (macos)
         timeout-minutes: 1
         if: contains(matrix.os, 'macos')

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -105,16 +105,9 @@ jobs:
         if: matrix.driver == 'qemu'
         run: |
           sudo apt-get update
-          sudo apt-get install -y qemu-system-x86 qemu-utils ovmf
-          # The qemu2 driver health check stats this exact path on amd64
-          # (pkg/minikube/registry/drvs/qemu2/qemu2.go: qemuFirmwarePath +
-          # status) and minikube start refuses with PROVIDER_QEMU2_NOT_FOUND
-          # without it — even though BIOS boot never passes it to qemu.
-          # Ubuntu 24.04's ovmf package ships only OVMF_CODE_4M.fd, so link
-          # the legacy name the driver looks up. Long-term fix: teach the
-          # driver to look up both filenames instead of this symlink.
-          sudo ln -sf /usr/share/OVMF/OVMF_CODE_4M.fd /usr/share/OVMF/OVMF_CODE.fd
-          ls -l /usr/share/OVMF/ || true
+          sudo apt-get install -y qemu-system-x86 qemu-utils
+          # The qemu driver looks up both OVMF_CODE.fd and OVMF_CODE_4M.fd
+          # itself (see #23690), so no ovmf package or symlink is needed.
           # GitHub hosted runners expose /dev/kvm but the runner user
           # lacks rw permission (660 root:kvm). qemu -accel kvm then fails
           # with "Could not access KVM kernel module: Permission denied".

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -41,6 +41,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: qemu-containerd-ubuntu-24.04-x86
+            driver: qemu
+            os: ubuntu-24.04
+            start_flags: --force --container-runtime=containerd
+            sudo: ""
           - name: vfkit-containerd-macos-15-x86
             driver: vfkit
             os: macos-15-intel
@@ -95,6 +100,14 @@ jobs:
         run: |
           brew install vfkit
           curl -fsSL https://github.com/minikube-machine/vmnet-helper/releases/latest/download/install.sh | sudo VMNET_INTERACTIVE=0 bash
+      - name: Install qemu (ubuntu)
+        timeout-minutes: 5
+        if: matrix.driver == 'qemu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86 qemu-utils ovmf
+          # ubuntu 24.04 ships OVMF_CODE_4M.fd but the qemu driver checks /usr/share/OVMF/OVMF_CODE.fd
+          sudo ln -sf /usr/share/OVMF/OVMF_CODE_4M.fd /usr/share/OVMF/OVMF_CODE.fd
       - name: Inspect host before test (macos)
         timeout-minutes: 1
         if: contains(matrix.os, 'macos')


### PR DESCRIPTION
`brew install qemu` on `macos-15-intel` has been timing out since Sep 2026, when Brew stopped building bottles for Intel. #23657 removed the `qemu-containerd-macos-15-x86` smoke job, but that left the qemu driver with no boot coverage at all.

This brings it back on `ubuntu-24.04`, where qemu installs from apt and hosted runners expose `/dev/kvm`. socket_vmnet is macOS-only, so the job uses the builtin network. Keeps vfkit on macOS Intel until those runners go away in 2027, and drops the now-dead `Install qemu and socket_vmnet (macos)` step from `functional_test.yml` (no qemu entry exists there).

Notes:
- Ubuntu 24.04 ships `OVMF_CODE_4M.fd` instead of `OVMF_CODE.fd`, so the install step symlinks it for the driver's firmware check.
- Matrix is back to 4 jobs: 1 qemu (ubuntu), 1 vfkit (macos), 2 docker (ubuntu).

Refs #23628 (the macOS test story, including vfkit, still needs a team call - likely self-hosted runners; this PR only restores qemu driver signal)
