### PR TITLE
ci: remove dead qemu macos step from functional_test.yml

### DIFF
--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -286,12 +286,6 @@ jobs:
       - name: Install kubectl
         timeout-minutes: 1
         uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
-      - name: Install qemu and socket_vmnet (macos)
-        if: contains(matrix.os, 'macos') && matrix.driver == 'qemu'
-        timeout-minutes: 1
-        run: |
-          brew install qemu socket_vmnet
-          HOMEBREW=$(which brew) && sudo ${HOMEBREW} services start socket_vmnet
       - name: Install vfkit and vmnet_helper (macos)
         if: matrix.driver == 'vfkit'
         timeout-minutes: 1


### PR DESCRIPTION
No qemu entry exists in the functional test matrix (drivers are docker, podman, none only), so the `Install qemu and socket_vmnet (macos)` step with `if: contains(matrix.os, 'macos') && matrix.driver == 'qemu'` can never run.

Split out from #23688 per review by @nirs (https://github.com/kubernetes/minikube/pull/23688#discussion_r).

No behavior change — dead code removal only.