### PR TITLE
qemu: accept OVMF_CODE_4M.fd firmware on ubuntu 24.04

### DIFF
--- a/pkg/minikube/registry/drvs/qemu2/qemu2.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2.go
@@ -100,12 +100,29 @@ func qemuFirmwarePath(customPath string) (string, error) {
 
 	switch arch {
 	case "amd64":
-		return "/usr/share/OVMF/OVMF_CODE.fd", nil
+		// Ubuntu 24.04's ovmf package ships only OVMF_CODE_4M.fd while
+		// older releases ship OVMF_CODE.fd (see #23628).
+		return firstExistingFirmware(
+			"/usr/share/OVMF/OVMF_CODE.fd",
+			"/usr/share/OVMF/OVMF_CODE_4M.fd",
+		), nil
 	case "arm64":
 		return "/usr/share/AAVMF/AAVMF_CODE.fd", nil
 	default:
 		return "", fmt.Errorf("unknown arch: %s", arch)
 	}
+}
+
+// firstExistingFirmware returns the first firmware path that exists on
+// disk, or the preferred path when none exists so the provider status
+// check still reports a useful path.
+func firstExistingFirmware(paths ...string) string {
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return paths[0]
 }
 
 func qemuVersion() (semver.Version, error) {

--- a/pkg/minikube/registry/drvs/qemu2/qemu2_test.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package qemu2
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTempFile(t *testing.T, name string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte("firmware"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", p, err)
+	}
+	return p
+}
+
+// TestFirstExistingFirmware covers the Ubuntu 24.04 case from #23628 where
+// only OVMF_CODE_4M.fd ships and the legacy OVMF_CODE.fd name is missing.
+func TestFirstExistingFirmware(t *testing.T) {
+	preferred := writeTempFile(t, "OVMF_CODE.fd")
+	fallback := writeTempFile(t, "OVMF_CODE_4M.fd")
+
+	tests := []struct {
+		name  string
+		paths []string
+		want  string
+	}{
+		{"preferred exists", []string{preferred, fallback}, preferred},
+		{"only fallback exists", []string{filepath.Join(t.TempDir(), "missing.fd"), fallback}, fallback},
+		{"none exists returns preferred", []string{preferred + ".missing", fallback + ".missing"}, preferred + ".missing"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := firstExistingFirmware(tc.paths...); got != tc.want {
+				t.Errorf("firstExistingFirmware(%v) = %q, want %q", tc.paths, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
On Ubuntu 24.04 the ovmf package only ships OVMF_CODE_4M.fd, but the qemu2 health check stats OVMF_CODE.fd first and fails the provider with PROVIDER_QEMU2_NOT_FOUND. I have taught qemuFirmwarePath to use whichever file exists, preferring the old name. This lets #23688 drop its CI symlink once it lands, but it does not cover the macOS runner story. Tests: go test ./pkg/minikube/registry/drvs/qemu2/... passes, including a new TestFirstExistingFirmware. Related to #23628.